### PR TITLE
chore(i18n): record catalog locations by file, not file:line

### DIFF
--- a/docs/man/po/manpages-de.po
+++ b/docs/man/po/manpages-de.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-de\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:29+0000\n"
 "Last-Translator: Balla Marcell <marcell.balla@gmx.at>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -17,74 +17,74 @@ msgstr ""
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 # type: SH
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NAME"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - der alle-Plattformen eMule p2p Client"
 
 # type: SH
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SYNTAX"
 
 # type: TP
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>PfadE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>PfadE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
@@ -92,113 +92,111 @@ msgstr "[B<-t> I<E<lt>NumE<gt>>] [I<eD2k-Verweis>]"
 
 # type: SH
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
 # type: Plain text
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>PfadE<gt>>, B<--config-dir>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Liest die Konfiguration E<lt>PfadE<gt> anstelle des Home."
 
 # type: TP
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Gibt die Größe des Programmfensters an. I<E<lt>geomE<gt>> hat das selbe Format wie Standard X11 Anwendungen:\t[B<=>][I<E<lt>BreiteE<gt>>{B<xX>}I<E<lt>HöheE<gt>>][{B<+->}I<E<lt>xOffsetE<gt>>{B<+->}I<E<lt>yOffsetE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Schreibt Log-Meldungen auf die Standardausgabe."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Setzt die Konfiguration auf die Standardwerte zurück."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Aktiviert bzw. deaktiviert den automatischen Start von aMule beim Benutzerlogin, beendet danach.  Der betriebssystemspezifische Speicherort wird automatisch ausgewählt: Windows Registrierung run Schlüssel, macOS LaunchAgent, Linux XDG I<.desktop> Autostart Eintrag."
 
 # type: Plain text
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>PfadE<gt>>, B<--use-amuleweb>=I<E<lt>PfadE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Setzt den Ort der ausführbaren Datei von amuleweb auf I<E<lt>PfadE<gt>>."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "Fatale Ausnahmen nicht abfangen und das Beenden bei Assertions nicht blockieren.  Nützlich für Headless- / überwachte Setups (systemd, Watchdog-Skripte), bei denen der sonst modale Assertion-Dialog den automatischen Neustart verhindert."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Schaltet die Standardeingabe nicht ab."
 
 # type: TP
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>NumE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Setzt die Kategorie für den übergebenen eD2k Verweis I<E<lt>NumE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Zeigt die derzeitige Versionsnummer an."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Gibt eine kurze Nutzungsbeschreibung aus."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
@@ -206,7 +204,7 @@ msgstr "B<[ eD2k-Verweis ]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
@@ -214,503 +212,496 @@ msgstr "Fügt einen eD2k- oder Magnetverweis dem Kern hinzu."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Der eD2k-Verweis darf enthalten:"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "ein Link zu einer Datei (ed2k://|file|...), dieser wird Downloadliste hinzugefügt;"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "ein Link zu einem Server (ed2k://|server|...), dieser wird der Serverliste hinzugefügt;"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "ein Serverlisten-Verweis, in diesem Fall werden alle Server dieser Liste der Serverliste hinzugefügt;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "ein Magnet Verweis."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 # type: SH
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "ANMERKUNGEN"
 
 # type: SS
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Pfade"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Für alle Optionen die ein I<E<lt>PfadE<gt>> Argument erwarten, wenn der I<Pfad> kein Verzeichnis enthält(z.B. nur einen Dateinamen), dann wird angenommen, diese Datei liegt um aMule-Konfigurationsverzeichnis, I<~/.aMule>."
 
 # type: SH
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "DATEIEN"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 # type: SH
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "FEHLER MELDEN"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Bitte meldet Fehler entweder in unserem Forum (I<https://github.com/amule-org/amule/discussions>), oder in unseren Bugtracker (I<https://github.com/amule-org/amule/issues>). Bitte meldet uns weder Fehler per E-Mail, noch auf unsere Mailingliste oder direkt an unsere Teammitglieder."
 
 # type: SH
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule und alle seine zugehörigen Anwendungen werden unter der GNU General Public License verteilt."
 
 # type: SH
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "SIEHE AUCH"
 
 # type: SH
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "VERFASSER"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Diese manpage wurde geschrieben von Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "aMule Hilfsprogramme"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Konsolenbasiertes Programm um aMule zu steuern"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>HostE<gt>>] [B<-p> I<E<lt>PortE<gt>>] [B<-P> I<E<lt>PasswortE<gt>>] [B<-f> I<E<lt>PfadE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>SpracheE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>BefehlE<gt>>]B< >}"
 
 # type: TP
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>PfadE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> ist ein Konsolenprogramm zur Steuerung von aMule."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>HostE<gt>>, B<--host>=I<E<lt>HostE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Der Rechner auf dem aMule läuft (Standard: I<127.0.0.1>).  I<E<lt>HostE<gt>> kann eine IP-Adresse oder ein DNS-Name sein."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>PortE<gt>>, B<--port>=I<E<lt>PortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule's Port für Externe Verbindungen, wie in den Optionen unter-E<gt>Fernsteuerung (Standard: I<4712>) eingestellt."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>PasswortE<gt>>, B<--password>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Passwort für Externe Verbindungen."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>PfadE<gt>>, B<--config-file>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Benutzt die angegebene Konfigurationsdatei. Die Standardkonfigurationsdatei ist I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Keine Ausgabe auf stdout ausgeben."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Sei gesprächig - Gebe auch Debuggingausgaben aus"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>SpracheE<gt>>, B<--locale>=I<E<lt>SpracheE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Setzt die Lokale (Sprache) des Programms.  Siehe Abschnitt B<ANMERKUNGEN> für die Beschreibung des I<E<lt>SpracheE<gt>> Parameters."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Schreibe die Kommandozeilenoptionen in die Konfigurationsdatei und kehre zur Shell zurück."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>BefehlE<gt>>, B<--command>=I<E<lt>BefehlE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Führe I<E<lt>BefehlE<gt>> aus, als wäre es auf amulecmd's Eingabeaufforderung eingegeben worden, und beende dich."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Konfigurationsdatei basierend auf I<E<lt>PfadE<gt>>, welche auf eine gültige aMule Konfigurationsdatei verweisen muss, erstellen und danach beenden."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Erzwingt ZLIB Kompression der externen Verbindung, unabhängig von der Lokalität der gewählten IP. Nützlich, wenn der Server über einen VPN Tunnel erreichbar ist, der eine LAN IP ist, und die Heuristik sonst Kompression deaktivieren würde."
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "BEFEHLE"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Alle Befehle können groß oder klein geschrieben werden."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Fügt einen eD2k- oder Magnetverweis dem Kern hinzu."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "eine Serverlisten-Verweis, in diesem Fall werden alle Server dieser Liste der Serverliste hinzugefügt."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Der Magnet Verweis muss die eD2k Prüfsumme und die Dateigröße enthalten."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Bricht den Download, der mit I<E<lt>PrüfsummeE<gt>> oder I<E<lt>NummerE<gt>> angegeben wurde, ab. Benutze B<show> um den Wert zu erfahren."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Verbindung zu einem Netzwerk aufbauen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Die Verbindung wird zu allen Netzwerken aufgebaut, die in den Einstellungen aktiviert wurden."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Mit dem optionalen Parameter kannst du das Netzwerk angeben, zu welchem eine Verbindung aufgebaut werden soll. Wenn du eine Server-Adresse als IP:Port angibst (wobei IP entweder eine durch punktierte dezimale IPv4 Adresse oder ein auflösbarer DNS Name ist), so wird aMule sich nur zu diesem Server verbinden."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Trennt die Verbindung zu allen Netzwerken mit denen du verbunden bist, oder nur zu dem, welches angegeben wurde."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Startet den Download einer Datei."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Die I<E<lt>NummerE<gt>> einer Datei aus der letzten Suche muss angegeben werden.  Beispiel: 'download 12' startet den Download der Datei, die in der letzten Suche die Nummer 12 hatte."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Verbindung zu amule/amuled trennen und amulecmd beenden."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Liest eine Option und zeigt sie an."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Verfügbare Werte für I<E<lt>WasE<gt>>:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Bandbreitenbeschränkungen abfragen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "IPFilter Einstellungen abfragen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Gibt eine kurze Nutzungsübersicht aus.  Wenn ohne Parameter aufgerufen, zeigt es eine Liste der verfügbaren Befehle an.  Wenn mit I<E<lt>BefehlE<gt>>aufgerufen, zeigt es eine Kurzbeschreibung diese Befehls an."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Pausiert den Download der mit I<E<lt>PrüfsummeE<gt>> oder I<E<lt>NumnerE<gt>> angegeben wurde. Benutze B<show> um den Wert zu erfahren."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Setzt die Priorität für den Download der mit I<E<lt>PrüfsummeE<gt>> oder I<E<lt>NummerE<gt>> angegeben wurde."
 
 # type: TP
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Verfügbare Werte für I<E<lt>PrioritätE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Automatische Priorität."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Hohe Priorität."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Niedrige Priorität."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Normale Priorität."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "Synonym für den B<exit> Befehl."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Aktualisiert das angegebene Objekt."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Liste der freigegebenen Dateien neu laden."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "IP Filter Tabellen neu laden."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Setzt das Log zurück."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Setzt den Download der mit I<E<lt>PrüfsummeE<gt>> oder I<E<lt>NummerE<gt>> angegeben wurde fort. Nutze B<show>, um den Wert zu erfahren."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
@@ -718,863 +709,863 @@ msgstr "Startet eine Suche nach dem angegebenenI I<E<lt>SchlüsselwortE<gt>>. Ei
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Verfügbare Suchtypen:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Führt eine globale Suche durch."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Führt eine Suche im Kad-Netzwerk durch."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Führt eine lokale Suche durch."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "Optionale Filter können vor, nach oder zwischen den Suchbegriffen eingefügt werden:"
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Beschränkt die Ergebnisse auf den angegebenen Dateityp."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Beschränkt die Ergebnisse auf eine bestimmte Dateierweiterung (z. B.\\ I<iso>, I<mp3>)."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Mindestanzahl an Quellen, die ein Ergebnis melden muss."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Kleinste zurückzugebende Dateigröße. Suffixe verwenden binäre Multiplikatoren (K = 1024, M = K\\(mu1024, G = M\\(mu1024); kein Suffix bedeutet Bytes."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Größte zurückzugebende Dateigröße. Gleiche Suffixe wie B<--min-size>."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Beispiel: `search global linux iso --type Iso --min-size 100M' liefert Ergebnisse für \\(lqlinux iso\\(rq vom Dateityp Iso mit mindestens 100 MiB."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Setzt die angegebene Option."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Setzt die Bandbreitenbeschränkungen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "IPFilter Einstellungen setzen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Zeigt upload/download Warteschlange, Serverliste oder die Liste der freigegebenen Dateien an."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Downloadwarteschlange anzeigen."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Log anzeigen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Serverliste anzeigen."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Liste der freigegebenen Dateien anzeigen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Uploadwarteschlange anzeigen."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Beendet das Programm (amule/amuled) zu dem du verbunden bist. Dies beendet auch den Textclient, da er ohne Verbindung nicht zu gebrauchen ist."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Zeigt die Statistiken an."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Die optionale I<E<lt>NummerE<gt>> im Bereich von 0-255 kann als Argument diesem Befehel übergeben werden. Sie gibt an, wie viele Einträge der Clientversionsliste angezeigt werden sollen. Der Wert 0, oder keine Angabe bedeutet 'unbegrenzt'."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Beispiel: 'statistics 5' zeigt nur die oberen 5 Versionen der einzelnen Clienttypen an."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Zeigt den Verbindungsstatus, aktuelle Up/Downloadgeschindigkeiten, etc. an."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Sprachen"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Der I<E<lt>SpracheE<gt>> Parameter der B<-l> Option hat folgende Form: I<sprache>[B<_>I<SPRACHE>][B<.>I<kodierung>][B<@>I<modifikation>] wobei I<sprache> die eigentliche Sprache, I<SPRACHE> das Gebiet, I<kodierung> den zu nutzenden Zeichensatz und I<modifikation> eine bestimmte Untergruppe in diesem darstellt."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Zum Besispiel sind die folgenden Zeichenketten gültig:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Alle oben genannten Zeicheketten werden als gültige Sprachdefinitionen akzeptiert, I<KODIERUNG> und I<zusatz> werden zur Zeit nicht genutzt."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Zusätzlich zu den obigen Formaten, kann man komplette englische Sprachbezeichnungen angeben - B<-l german> ist ebenfalls gültig und entspricht B<-l de_DE>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Wenn keine Sprache definiert wurde, weder in der Kommandozeile noch in der Konfigurationsdatei, wird die Standardsprache des Systems verwendet."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "BEISPIEL"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Typischerweise startet man amulecmd als erstes mit:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<EC-Port> B<-P> I<EC-Passwort> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "oder"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/Benutzer/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Dies speichert die Einstellungen in I<$HOME/.aMule/remote.conf>, und später tippst du nur noch:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Natürlich brauchst du dich nicht unbedingt an dieses Beispiel halten."
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Dämon v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Dämon"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - Der alle-Plattformen eMule p2p Client - dämonisierte Version"
 
 # type: TP
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>PfadE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>PfadE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Im Hintergrund ausführen."
 
 # type: Plain text
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>PfadE<gt>>, B<--pid-file>=I<E<lt>PfadE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Erstelle eine Pid-Datei in I<E<lt>PfadE<gt>>.  I<E<lt>PfadE<gt>> muss einen Dateinamen enthalten."
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Konfiguration für EC (Externe Verbindungen)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Aktiviert bzw. deaktiviert den automatischen Start von amuled beim Benutzerlogin, beendet danach.  Der betriebssystemspezifische Speicherort wird automatisch ausgewählt: Windows Registrierung run Schlüssel, macOS LaunchAgent, Linux XDG I<.desktop> Autostart Eintrag."
 
 # type: TP
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>NumE<gt>>, B<--category>=I<E<lt>NumE<gt>> B<]>"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - aMule Steuerungsprogramm mit GUI"
 
 # type: TP
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>NumE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> ist ein Clientprogramm, das mit aMule oder amuled über EC verbunden werden kann. Du kannst aMule mit diesem Programm steuernt. Es besitzt annähernd die selbe Funktionalität wie aMule, auch wenn der Kern auf einem anderen Computer läuft."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Überspringe den Verbindungsdialog."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Aktiviert bzw. deaktiviert den automatischen Start von amulegui beim Benutzerlogin, beendet danach.  Der betriebssystemspezifische Speicherort wird automatisch ausgewählt: Windows Registrierung run Schlüssel, macOS LaunchAgent, Linux XDG I<.desktop> Autostart Eintrag."
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Diese manpage wurde geschrieben von Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Diese manpage wurde überarbeitet von Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 # type: TH
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 # type: TH
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule Webserver v@PACKAGE_VERSION@"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule Webserver"
 
 # type: TP
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>SpracheE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>NameE<gt>>] [B<-s> I<E<lt>PortE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>PortE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>PasswortE<gt>>] [B<-G> I<E<lt>PasswortE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>PfadE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> ermöglicht dir den Zugriff auf amule(d) per Webbrowser. Man kann amuleweb zusammen mit B<amule>(1) starten lassen, oder ihn separat später starten. Optionen können auf der Kommandozeile oder in der Konfigurationsdatei angegeben werden. Kommandozeilenoptionen überschreiben die Werte aus der Konfigurationsdatei."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>NameE<gt>>, B<--template>=I<E<lt>NameE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Lädt die mit I<E<lt>NameE<gt>> spezifizierte Vorlage. Siehe auch Abschnitt B<SKIN UNTERSTÜTZUNG> für Details."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>PortE<gt>>, B<--server-port>=I<E<lt>PortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "HTTP Port des Webservers. Der Port der im Browser angegeben werden muss (Standard: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Aktiviere UPnP."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>PortE<gt>>, B<--upnp-port>=I<E<lt>PortE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "UPnP Port."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Benutzt gzip Kompression für den HTTP Verkehr um Bandbreite zu sparen."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Schalten die gzip Kompression ab (Standard)"
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>PasswortE<gt>>, B<--admin-pass>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Passwort für vollen Zugriff auf den Webserver"
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>PasswortE<gt>>, B<--guest-pass>=I<E<lt>PasswortE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Gäste Passwort für den Webserver"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Erlaubt den Zugriff als Gast."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Verbietet den Zugriff als Gast (Standard)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Lade/Speichere Einstellungen vom/zum entfernen aMule. Dies bringt amuleweb dazu, die Kommandozeilen- und Konfigurationsdateieinstellungen zu ignorieren, und von aMule zu beziehen. Beim Speichern werden keine Einstellungen in die Konfigurationsdatei geschrieben, sondern zu aMule gesendet. (das funktioniert nur für Einstellungen in aMule's Einstellungen-E<gt>Fernsteuerung Dialog)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deaktiviert den PHP Interpreter (veraltet)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Erstellt die PHP-Seiten bei jedem Aufruf neu."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>PfadE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Pfad zur aMule Konfigurationsdatei. B<NICHT DIREKT BENUTZEN!> aMule benutzt dies zum starten von amuleweb wenn aMule startet. Diese Option sorgt dafür, das alle anderen Parameter ignoriert werden, und nur aus der angegeben Datei gelesen werden, und impliziert auch die B<-q -L> Optionen."
 
 # type: SH
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SKIN UNTERSTÜTZUNG"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> ist in der Lage Informationen mit unterschiedlichen Skins anzuzeigen.  Diese Skins werden Templates genannt, und due kannst über die Kommandozeilenoption B<-t> angeben welches geladen werden soll.  Templates werden in 2 verschiedenen Orten gesucht: zuerst in I<~/.aMule/webserver/> und dann in I</usr/share/amule/webserver/> wenn du mit --prefix=/usr installiert hast."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Jedes Template muss in einem Unterverzeichnis des Templatenamens liegen, welches alle Dateien enthält, die das Template benötigt."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Typischerweise wird amuleweb als erstes folgendermaßen gestartet:"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<EC-Port> B<-P> I<EC-Passwort> B<-s> I<HTTP-Port> B<-A> I<Admin-Passwort> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Natürlich kann man zusätzliche Optionen angeben und einzelne auch beim ersten Start weglassen, oder es komplett anders machen."
 
 # type: TH
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 # type: TH
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule eD2k Verweis parser v1.5.1"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - aMule ED2k Verweis-Parser"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>PfadE<gt>>] [B<-t> I<E<lt>NumE<gt>>]"
 
 # type: TP
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-VerweisE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Sendet den übergebenen I<E<lt>eD2k-VerweisE<gt>> an aMule, d.h. schreibt ihn in die Datei ~/.aMule/ED2KLinks, welche von aMule jede Sekunde auf neue Verweise geprüft wird."
 
 # type: TP
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>NumE<gt>>, B<--category>=I<E<lt>NumE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Setzt Kategorie für übergebene ed2K Links zu I<E<lt>NumE<gt>>.  Im Unterschied zu B<--config-dir> liest der Parser den Wert als das nächste Argument und akzeptiert das B<--category>=I<E<lt>numE<gt>> Syntax nicht."
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Lädt alle Verweise aus der als I<E<lt>eD2k_VerweisE<gt>> übergebenen emulecollection."
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Listet alle Verweise in der emulecollection, die als I<E<lt>eD2k_VerweisE<gt>> übergeben wurde, auf."
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-Verweis ]>"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Fügt einen eD2k-Verweis zur Downloadliste hinzu."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "ein Magnetverweis;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "eine emulecollection Datei."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<Die Reihenfolge in der du die Parameter angibst, ist entscheidend.> Du kannst mehr als einen Verweis übergeben und jeder Verweis kann seine eigenen Parameter haben.  Zum Beispiel B<ed2k E<lt>Verweis1E<gt> -t2 E<lt>Verweis2E<gt>> lädt I<E<lt>Verweis1E<gt>> in der Standardkategorie und I<E<lt>Verweis2E<gt>> in Kategorie 2 herunter."
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "ed2k - aMule eD2k Verweis parser"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> ist ein graphisches Werkzeug zum erstellen von eD2k Links für Dateien auf deinem Computer."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Dieses Programm hat keine Parameter."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule eD2k Verweis Ersteller"
 
 # type: TH
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - textbasierter eD2k Verweis Ersteller für aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>eingabedatei_listeE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Berechne die eD2k Verweise aller Eingabedateien aus I<E<lt>dateilisteE<gt>> (eine oder mehrere Dateien)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Berechne Teilprüfsummen und füge sie dem berechneten eD2k Verweis hinzu."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Sei gesprächig - Zeige auch die Rechenschritte an."
 
 # type: TH
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c aMule statistics"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> ist ein Program zum Anzeigen des Inhaltes deiner aMule Online Signaturdatei in der Konsole (in von Menschen lesbarem Format). Damit dies funktioniert, musst du die \"Online-Signatur\" Option in den aMule Einstellungen aktivieren."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Schreibt das online Signatur Bild.  Die lange Form B<--picture> akzeptiert ein optionales I<=E<lt>PATHE<gt>> um den Ausgabeort zu bestimmen; die Kurzform B<-o> / B<-P> tut es nicht (B<-P> benötigt ein unmittelbar folgendes I<E<lt>PATHE<gt>> Argument, und B<-o> ist eine Option ohne Parameter).  Dafür muss Unterstützung für GD einkompiliert sein (I<__GD__>); ansonsten wird diese Option ohne Nachricht ignoriert."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "HTML Seite with Status und Bild.  Die Langform B<--html> akzeptiert ein optionales I<=E<lt>PATHE<gt>> um den Ausgabeort zu bestimmen; die Kurzform B<-p> / B<-H> tut es nicht (B<-H> benötigt ein unmittelbar folgendes I<E<lt>PATHE<gt>> Argument, und B<-p> ist eine Option ohne Parameter)."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Ohne Optionen schreibt es die Online Signatur auf die Standardausgabe."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> wurde geschrieben von Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (oder .jpg, wenn B<-o> / B<--picture> verwendet wird und GD verfügbar ist)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (wenn B<-p> / B<--html> verwendet wird)"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c aMule statistics"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> ist ein Programm zum Anzeigen des Inhaltes deiner Online Signaturdatei in einem hübschen wx Fenster auf deinem Desktop.  Damit dies funktioniert, musst du die \"Online-Signatur\" Option in den aMule Einstellungen aktivieren."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Basierend auf Pedro de Oliveira's B<cas>(1).  B<wxcas> wurde geschrieben von ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-es.po
+++ b/docs/man/po/manpages-es.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:29+0000\n"
 "Last-Translator: Mad-Soft <mad.soft@gmail.com>\n"
 "Language-Team: Spanish <es_ES@li.org>\n"
@@ -20,1369 +20,1360 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NOMBRE"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - cliente p2p multiplataforma basado en eMule"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SINOPSIS"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-Link>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Leer configuración desde I<E<lt>pathE<gt>> en lugar de home"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Fija la geometría de la aplicación. I<E<lt>geomE<gt>> usa el mismo formato estándar de las aplicaciones X11:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Imprime mensajes de registro en la salida estándar."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Reiniciar configuración a valores por defecto."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activa o desactiva el arranque automático de aMule al iniciar sesión el usuario, y luego termina. Se seleccionará automáticamente el almacenamiento específico de cada SO: clave del registro en Windows, LaunchAgent en macOS, entrada en Linux XDG I<.desktop> autostart."
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Especifica la ubicación del binario amuleweb en I<E<lt>pathE<gt>>."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "No captura las excepciones fatales y no bloquea la salida en los diálogos modales.  Útil para configuraciones sin interfaz / supervisadas (systemd, scripts watchdog) donde el cuadro de diálogo modal impide el reinicio automático."
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "No deshabilitar entrada estándar."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Fijar categoría para enlace eD2k pasado a I<E<lt>numE<gt>>"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Mostrar el número de la versión actual."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Imprime una breve descripción de uso."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k-Link ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Añadir un enlace eD2k o un enlace magnet al núcleo."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "El enlace eD2k para ser añadido puede ser:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "un enlace de archivo (ed2k://|archivo|...), será añadido a la cola de descarga;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "un enlace de servidor (ed2k://|servidor|...), será añadido a la cola de servidores;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "un enlace de lista de servidores, en cuyo caso todos los servidores de la lista serán añadidos a la lista de servidores;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "un enlace magnet."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTAS"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Rutas"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Todas las opciones que tengan I<E<lt>pathE<gt>> como valor, si I<path> no contiene una ruta de directorios (p.e. sólo un archivo normal), entones se usará el directorio de la configuración, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "ARCHIVOS"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "INFORMANDO ERRORES"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Por favor informe de fallos ya sea en nuestro foro (I<https://github.com/amule-org/amule/discussions>), o en nuestro bugtracker (I<https://github.com/amule-org/amule/issues>). Por favor no informe de fallos por correo, ni en nuestras listas, ni directamente al correo de algun miembro del equipo."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule y todas las demás utilidades relacionadas son distribuidas bajo la GNU General Public License."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "VÉASE TAMBIÉN"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Esta página de manual fue escrita por Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "aMule utilidades"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Programa basado en consola para controlar aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> es un cliente basado en consola para controlar aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Host donde se está ejecutando aMule (por defecto: I<127.0.0.1>).  I<E<lt>hostE<gt>> debe ser o una dirección IP o un nombre DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Puerto de conexión externa de aMule, puesto en Opciones-E<gt>Controles Remotos (por defecto: 4712)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Contraseña de conexiones externas."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Usar la configuración dada por el archivo. El archivo de configuración por defecto es I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "No mostrar ninguna salida en stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Modo detallado - muestra también los mensajes de depuración."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Selecciona el idioma del programa. Ver la sección B<NOTAS> para la descripción del parámetro del I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Escribe opciones de la línea de comando al archivo de configuración y termina"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Ejecuta I<E<lt>commandE<gt>> como si se hubiera introducido en el prompt en amulecmd, y termina."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Crear archivo de configuración basado en I<E<lt>pathE<gt>>, el cual debe apuntar a un archivo de configuración válido, y entonces termina."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forzar la compresión ZLIB en el protocolo de Conexiones Externas aunque se esté conectando a una IP local/LAN. Esto es útil cuando la conexión al servidor se realiza a través de un túnel VPN que se resuelve a una IP de LAN, lo que por defecto desactivaría la compresión."
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "COMANDOS"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Todos los comandos ignoran las mayúsculas."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Añadir un enlace eD2k o un enlace magnet al núcleo."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "un enlace con una lista de servidores, se añadirán todos los servidores a la lista."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "El enlace magnet debe contener un hash eD2k y la longitud del archivo."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Cancela la descarga especificada por I<E<lt>hashE<gt>> o I<E<lt>numberE<gt>>. Para obtener el valor use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Conectar a la red."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Esto conectará a todas las redes que estén habilitadas en las preferencias."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Con el parámetro opcional, puede especificar a qué red conectarse. Al dar una dirección en formato IP:puerto (siendo IP una dirección IPv4 numérica o un nombre DNS resoluble) aMule se conectará sólo a ese servidor."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Desconectar de todas las redes a las que está conectado, o desconectar solo de la red especificada."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Comenzar a descargar un archivo."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Debe proporcionarse el I<E<lt>numberE<gt>> de un fichero de la última búsqueda.  Ejemplo: `download 12' empezará a descargar el archivo con el número 12 de la búsqueda previa."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Desconectar de amule/amuled y salir de amulecmd."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Obtener y mostrar un valor de preferencias."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Valores disponibles para I<E<lt>whatE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Obtener los límites de ancho de banda."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Obtener opciones del filtro IP."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Muestra una breve descripción de uso. Si se llama sin parámetros, muestra una lista de comando disponibles.  Si se llama con I<E<lt>commandE<gt>>, mostrará una breve descripción de dicho comando."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Pausa la descarga especificada por I<E<lt>hashE<gt>> o I<E<lt>numberE<gt>>. Para obtener el valor use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Fijar la prioridad de una descarga especificada por I<E<lt>hashE<gt>> o I<E<lt>numberE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Valores disponibles para I<E<lt>priorityE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Prioridad automática."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Prioridad alta."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Prioridad baja."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Prioridad normal."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr "Muestra el progreso de una búsqueda en curso. Opcionalmente, toma un I<E<lt>idE<gt>> de búsqueda (como obtenido de B<search>); sin id, muestra la última búsqueda iniciada."
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "Un sinónimo del comando B<exit>."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Recargar un objeto dado."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Recargar la lista de archivos compartidos."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Recargar tablas de filtros IP."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Reiniciar el registro."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr "Muestra los resultados de una búsqueda. Opcionalmente, toma un I<E<lt>idE<gt>> de búsqueda (como obtenido de B<search>); sin id, muestra la última búsqueda iniciada.  Se pueden mantener varias búsquedas a la vez en el núcleo y acceder a ellas por el id."
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Reanuda la descarga especificada por I<E<lt>hashE<gt>> o I<E<lt>numberE<gt>>. Para obtener el valor use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Hace una búsqueda para la I<E<lt>keywordE<gt>> especificada. El tipo de búsqueda y una palabra a buscar son obligatorios.  Ejemplo: `search kad amule' realiza una búsqueda kad de la palabra `amule'.  Muestra un id de búsqueda; páselo a B<results> o B<progress> para identificar esta búsqueda. Varias búsquedas se pueden ejecutar a la vez, cada una con su propio id."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Tipos de búsquedas disponibles:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Realiza una búsqueda global."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Realiza una búsqueda en la red Kademlia."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Realiza una búsqueda local."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "Pueden colocarse filtros opcionales antes, después o intercalados con la(s) palabra(s) clave de búsqueda:"
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Restringe los resultados al tipo de archivo indicado."
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Restringe los resultados a una extensión de archivo específica (ej.\\ I<iso>, I<mp3>)."
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Número mínimo de fuentes que un resultado debe informar."
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Tamaño mínimo de archivo a devolver. Los sufijos usan multiplicadores binarios (K = 1024, M = K\\(mu1024, G = M\\(mu1024); sin sufijo significa bytes."
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Tamaño máximo de archivo a devolver. Mismos sufijos que B<--min-size>."
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Ejemplo: `search global linux iso --type Iso --min-size 100M' devuelve resultados para \\(lqlinux iso\\(rq de tipo de archivo Iso de al menos 100 MiB."
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Asigna un valor dado de opción."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Establecer los límites de ancho de banda."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Ajusta las opciones del FiltroIP."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Muestra la cola de subida/descarga, la lista de servidores, o la lista de archivos compartidos."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Mostrar la cola de descarga."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Mostrar el registro."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Mostrar lista de servidores."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Mostrar la lista de archivos compartidos."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Mostrar la cola de subida."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Apaga el núcleo remoto en ejecución (amule/amuled).  Esto también terminará el cliente de texto, ya que es inútil sin un núcleo remoto activo."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Mostrar árbol de estadísticas."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Un I<E<lt>numberE<gt>> opcional en el rango 0-255 puede pasarse como parámetro de este comando, que indica cuántos valores de versiones de clientes debe mostrar el árbol. Pasar 0, u omitirlo significa `ilimitado'."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Ejemplo: `statistics 5' mostrará sólo las primeras 5 versiones de cada tipo de cliente."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Muestra el estado de la conexión, la velocidad de subida/descarga actual, etc."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Lenguajes"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "El parámetro I<E<lt>langE<gt>> para la opción B<-l> tiene esta forma: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] donde I<lang> es el lenguaje primario, I<LANG> es un sublenguaje/territorio, I<encoding> es el conjunto de caracteres a usar y I<modifier> permite al usuario elegir una instancia específica de localización dentro de una única categoría."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Por ejemplo, las siguientes cadenas son válidas:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Aunque todas las cadenas previas son aceptadas como definiciones de lenguaje válidas, I<encoding> y I<modifier> aún no se usan."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Además del formato previo, también se pueden especificar el nombre completo del idioma en inglés, por lo que B<-l german> es válido y equivale a B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Cuando no se define ninguna localización, ni por línea de comandos ni en fichero de configuración, se usará el lenguaje por defecto del sistema."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EJEMPLO"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Normalmente amulecmd se ejecutará primero como:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "o"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/usuario/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Esto guardará las opciones en I<$HOME/.aMule/remote.conf>, y después sólo tiene que escribir:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Por supuesto, no tiene por qué seguir este ejemplo."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "Demonio aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "Demonio aMule"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - el cliente p2p eMule multi-plataforma - versión en segundo plano"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Enviar a segundo plano."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Tras el fork, crear un archivo PID en I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> debe contener el nombre del archivo."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Configurar EC (Conexiones Externas)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activa o desactiva el arranque automático del servicio de aMule (amuled) al iniciar sesión el usuario, y luego termina. Se seleccionará automáticamente el almacenamiento específico de cada SO: clave del registro en Windows, LaunchAgent en macOS, entrada en Linux XDG I<.desktop> autostart."
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - Programa para controlar aMule con Interfaz Gráfica"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> es un programa cliente, y puede conectarse a amule o amuled usando EC. Permite gestionar remotamente la sesión amule(d). Proporciona casi la misma funcionalidad que amule, incluso cuando el núcleo funciona en un ordenador remoto."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Saltar diálogo de conexión."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activa o desactiva el arranque automático de amulegui al iniciar sesión el usuario, y luego termina. Se seleccionará automáticamente el almacenamiento específico de cada SO: clave del registro en Windows, LaunchAgent en macOS, entrada en Linux XDG I<.desktop> autostart."
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Esta página de manual fue escrita por Julien Delange para Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Esta página de manual fue reescrita por Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "Servidor web aMule v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - servidor web de aMule"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>langE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr "B<DEPRECATED:> amuleweb está obsoleto y podría ser eliminado en aMule 3.2 o posterior.  No se está eliminando todavía; considere migrar a amuleapi, el API REST/SSE."
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gestiona una sesión de amule a través del navegador web.  Puede iniciar amuleweb junto a B<amule>(1), o por separado en cualquier momento posterior.  Las opciones se pueden especificar en la línea de comando o en un fichero de configuración.  Las opciones de línea de comandos tienen prioridad sobre las del fichero de configuración."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carga la plantilla llamada I<E<lt>nameE<gt>>. Consulte la sección B<SKIN SUPPORT> para más detalles."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Puerto HTTP del servidor web. Éste es el puerto al que debe apuntar su navegador (por defecto: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Habilitar UPnP."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Puerto UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activar compresión gzip para ahorrar tráfico HTTP."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Deshabilitar la compresión gzip (esto es por defecto)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Contraseña de acceso completo al servidor web."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Contraseña de invitado al servidor web."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Permitir acceso invitado."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Deniega el acceso invitado (por defecto)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Cargar/Guardar del aMule remoto la configuración del servidor web.  Esto hace que amuleweb ignore la configuración de la línea de comandos o del fichero de config, y que la cargue directamente de aMule.  Al guardarla, no se escribirá nada en el fichero de configuración, sino en aMule.  (Por supuesto, esto sólo funciona para los parámetros que pueden configurarse en las Preferencias de aMule-E<gt>Controles Remotos.)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deshabilitar el intérprete PHP (obsoleto)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompilar páginas PHP en cada solicitud."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Ruta al fichero de configuración de aMule.  B<¡NO USAR DIRECTAMENTE!> aMule usa esta opción al arrancar amuleweb durante el arranque de aMule.  Esta opción hace que cualquier otra configuración de la línea de comandos o del fichero de configuración sea ignorada, y que las preferencias se lean del fichero especificado. También implica las opciones B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SOPORTE TEMAS"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> es capaz de usar diferentes skins para mostrar información.  Estos skins se llaman plantillas, y puede cargarse una plantilla específica usando la opción B<-t> de la línea de comandos.  Las plantillas se buscan en dos ubicaciones: primero en I<~/.aMule/webserver/> y luego en I</usr/share/amule/webserver/> si se instaló con la opción --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Cada plantilla debe estar en un subdirectorio con el nombre de la plantilla, y este directorio debe contener todo los ficheros que la plantilla necesita."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Normalmente amuleweb se ejecutará primero como:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/usuario/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Por supuesto, puede especificar las opciones en el ejemplo de la primera línea, y también puede omitirlo."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "Analizador aMule de enlaces eD2k v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - analizador aMule de enlaces eD2k"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-LinkE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Envía el I<E<lt>enlace eD2kE<gt>> a aMule, para ello, lo escribe en el fichero ~/.aMule/ED2KLinks, que aMule lee una vez por segundo."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Establece la categoría I<E<lt>numE<gt>> para los enlaces eD2k introducidos.  Al contrario que B<--config-dir>, el parseador lee el valor como el siguiente argumento y no acepta  B<--category>=I<E<lt>numE<gt>> como sintaxis."
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Carga todos los enlaces encontrados en la emulecollection especificada como I<E<lt>ed2k-linkE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Lista todos los enlaces encontrados en la emulecollection especificada como I<E<lt>ed2k-linkE<gt>>"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-Link ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Añadir un enlace eD2k al núcleo."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "Un enlace magnet;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "Un archivo emulecollection."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<El orden de los parámetros es importante.> Se pueden proporcionar varios enlaces, y cada enlace puede tener sus propios parámetros.  Por ejemplo B<ed2k E<lt>enlace1E<gt> -t2 E<lt>enlace2E<gt>> descargará I<E<lt>enlace1E<gt>> en la categoría estándar y I<E<lt>enlace2E<gt>> en la categoría 2."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - el creador de enlaces eD2k de aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> es una herramienta gráfica para crear enlaces eD2k de los archivos de su ordenador."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Esta aplicación no recibe ningún argumento."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "Calculador de enlaces eD2k de aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - calculador de enlaces eD2k basado en texto para aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>inputfiles_listE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Calcula los enlaces eD2k de todos los archivos especificados en I<E<lt>inputfiles_listE<gt>> (Puede haber uno o varios archivos)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Calcula y añade los hashes de partes a los enlaces eD2k calculados."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Modo Extendido - muestra también los pasos de cálculo."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c estadísticas de aMule"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> es un programa para mostrar el contenido de la firma online de aMule por consola (en un formato legible para personas). Para funcionar, debe activarse la opción \"Online Signature\" en las preferencias de aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Escribe la imagen de la firma online.  La forma larga B<--picture> acepta un I<=E<lt>PATHE<gt>> opcional para especificar la ubicación de salida; las formas cortas B<-o> / B<-P> no lo aceptan (B<-P> requiere un argumento I<E<lt>PATHE<gt>> inmediatamente a continuación, y B<-o> es un switch sin argumentos).  Requiere soporte GD en la compilación (I<__GD__>); de lo contrario esta opción se ignora silenciosamente."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "Página HTML con estadísticas e imagen.  La forma larga B<--picture> acepta un I<=E<lt>PATHE<gt>> opcional para especificar la ubicación de salida; las formas cortas B<-p> / B<-H> no lo aceptan (B<-H> requiere un argumento I<E<lt>PATHE<gt>> inmediatamente a continuación, y B<-p> es un switch sin argumentos)."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Si no se especifica ninguna opción, imprime los datos de la firma online en stdout."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> fue escrita por Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (o .jpg, cuando se usa B<-o> / B<--picture> y GD está disponible)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (cuando se usa B<-p> / B<--html>)"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c estadísticas de aMule"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> es un programa para mostrar el contenido de la firma online en una ventana wx Window de su Escritorio.  Para funcionar, debe activarse la opción \"Online Signature\" en las preferencias de aMule."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Basado en B<cas>(1) de Pedro de Oliveira.  B<wxcas> fue escrito por ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-fr.po
+++ b/docs/man/po/manpages-fr.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:29+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -21,1369 +21,1360 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NOM"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - le client P2P eMule multiplateforme"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SYNOPSIS"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>cheminE<gt>>] [B<-geometry> I<E<lt>géomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>] [I<lien eD2k>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>cheminE<gt>>, B<--config-dir>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Utiliser le fichier de config I<E<lt>cheminE<gt>> à la place de celui par défaut"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>géomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Fixe la géométrie de l'application. I<E<lt>géomE<gt>> utilise le même format que les applications X11 standards :\t[B<=>][I<E<lt>largeurE<gt>>{B<xX>}I<E<lt>hauteurE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Affiche les messages du journal sur stdout."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Réinitialise à la configuration par défaut."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activer ou désactiver le lancement d'aMule à l'ouverture d'une session de l'utilisateur, puis quitter.  Le dépôt spécifique au système d'exploitation est sélectionné automatiquement : clef d'exécution (Run) du registre pour Windows, LaunchAgent pour macOS et élément de lancement automatique XDG I<.desktop> pour GNU/Linux."
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>cheminE<gt>>, B<--use-amuleweb>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Préciser l'emplacement du binaire d'amuleweb I<E<lt>cheminE<gt>>."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "Ne pas intercepter les exceptions fatales et ne pas bloquer la sortie sur les assertions.  Utile pour les configurations sans interface / supervisées (systemd, scripts watchdog) où la boîte de dialogue d'assertion, autrement modale, empêche le redémarrage automatique."
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Ne désactive pas stdin."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Définir la catégorie pour les liens eD2k passé à I<E<lt>numE<gt>>"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Affiche le numéro de la version actuelle."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Affiche une courte description d'utilisation."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ lien eD2k ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Ajoute un lien eD2k ou magnet au noyau."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Le lien eD2k à ajouter peut être :"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "un lien fichier (ed2k://|fichier|…), il sera ajouté à la file des téléchargements ;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "un lien serveur (ed2k://|serveur|…), il sera ajouté à la liste des serveurs ;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "un lien de liste de serveurs, dans ce cas tous les serveurs dans la liste seront ajoutés à la liste des serveurs ;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "un lien magnet."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTES"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Chemins"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Pour toutes les options prenant en paramètre un I<E<lt>cheminE<gt>>, si le I<chemin> ne contient pas de répertoire (c'est-à-dire juste un nom de fichier), alors il sera considéré comme étant dans le répertoire de configuration d'aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "FICHIERS"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "RAPPORTER DES BOGUES"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Veuillez rapporter les bogues sur notre forum (I<https://github.com/amule-org/amule/discussions>), ou sur notre traqueur de bogues (I<https://github.com/amule-org/amule/issues>).  Veuillez ne pas rapporter les bogues par e-mail, sur notre liste de diffusion ou directement aux membres de l'équipe."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule et tous ses outils sont distribués sous la Licence publique générale GNU."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "VOIR ÉGALEMENT"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTEUR"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Cette page de manuel a été écrite par Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "Outils d'aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Programme de contrôle d'aMule en mode texte"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>hôteE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>motdepasseE<gt>>] [B<-f> I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandeE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> est un client en mode texte pour contrôler aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hôteE<gt>>, B<--host>=I<E<lt>hôteE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Hôte où aMule fonctionne (par défaut : I<127.0.0.1>).  I<E<lt>hôteE<gt>> peut être une adresse IP ou un nom DNS."
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Port d'aMule pour les Connexions Externes, tel que défini dans Préférences-E<gt>Contrôles à Distance (par défaut: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>motdepasseE<gt>>, B<--password>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Mot de passe des connexions externes."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>cheminE<gt>>, B<--config-file>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Utiliser le fichier de configuration désigné.  Le fichier de configuration par défaut est I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Ne pas afficher de sortie sur stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Mode bavard - afficher aussi les messages de débogage."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Définit les paramètres régionaux (langue). Voir la section B<NOTES> pour la description du paramètre I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Écrire les options de la ligne de commande sur le fichier de configuration et quitter"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>commandeE<gt>>, B<--command>=I<E<lt>commandeE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Exécuter la I<E<lt>commandeE<gt>> comme si elle avait été entrée dans l'invite de commande d'amulecmd et quitter."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Créer un fichier de configuration basé sur I<E<lt>cheminE<gt>>, qui doit pointer sur un fichier de configuration d'aMule valide, et quitter ensuite."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forcer la compression ZLIB sur le lien Connexion Externe quelle que soit l'adresse IP de destination.  Utile lorsque le serveur est accessible via un tunnel VPN qui se résout en une adresse IP du réseau local et que l'heuristique ignorerait autrement la compression."
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "COMMANDES"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Toutes les commandes sont insensibles à la casse."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Ajoute un lien eD2k ou magnet au noyau."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "un lien de liste de serveurs, dans ce cas tous les serveurs dans la liste seront ajoutés à la liste des serveurs."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Le lien magnet doit contenir le hachage eD2k et la longueur du fichier."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Annule le téléchargement spécifié par le I<E<lt>hachageE<gt>> ou le I<E<lt>numéroE<gt>>. Pour obtenir la valeur utiliser B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Se connecter au réseau."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Cela connectera à tous les réseaux qui sont activés dans les préférences."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Avec le paramètre optionnel, vous pouvez spécifier le réseau pour se connecter. Donner une adresse de serveur sous la forme IP:Port (où IP est soit une adresse décimale IPv4 ou un nom DNS résolvable) aMule se connectera à ce serveur uniquement."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Déconnecter de tous les réseaux dont vous êtes connecté, ou juste déconnecter d'un réseau spécifié."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Commencer à télécharger un fichier."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Le I<E<lt>numéroE<gt>> d'un fichier à partir de la dernière recherche doit être donné.  Exemple : `download 12' va commencer à télécharger le fichier avec le numéro 12 de la recherche précédente."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Déconnecter d'amule/amuled et quitter amulecmd."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Obtenir et afficher une valeur de préférence."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Valeurs disponibles pour I<E<lt>quoiE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Obtenir les limites de bande passante."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Obtenir les préférences de filtrage IP."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Affiche une courte description d'utilisation.  S'il est appelé sans paramètre, il affiche une liste des commandes disponibles.  Lorsqu'il est appelé avec la I<E<lt>commandeE<gt>>, il affiche une courte description de la commande donnée."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Interrompt le téléchargement spécifié par le I<E<lt>hachageE<gt>> ou le I<E<lt>numéroE<gt>>. Pour obtenir la valeur utiliser B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Définir la priorité d'un téléchargement spécifié par le I<E<lt>hachageE<gt>> ou le I<E<lt>numéroE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Valeurs disponibles pour la I<E<lt>prioritéE<gt>> :"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Priorité automatique."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Priorité haute."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Priorité basse."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Priorité normale."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr "Affiche la progression d'un recherche en cours. Prend éventuellement un I<E<lt>idE<gt>> de recherche (tel qu'affiché par B<search>) ; sans identifiant, affiche la recherche démarrée le plus récemment."
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "Un synonyme de la commande B<exit>."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Recharge un objet donné."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Recharger la liste des fichiers partagés."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Recharger les tables de filtre d'IP."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Réinitialiser le journal."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr "Vous affiche les résultats d'une recherche. Prend éventuellement un  I<E<lt>idE<gt>> de recherche (tel qu'affiché par B<search>) ; sans identifiant, affiche la recherche démarrée le plus récemment.  Plusieurs recherches peuvent être conservées sur le démon en même temps et gérées par identifiant."
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Reprend le téléchargement spécifié par le I<E<lt>hachageE<gt>> ou le I<E<lt>numéroE<gt>>. Pour obtenir la valeur utiliser B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Fait une recherche du I<E<lt>mot-clefE<gt>> donné. Un type de recherche et d'un mot-clef de recherche sont obligatoires pour le faire. Exemple : `search kad amule' effectue une recherche kad pour `amule'.  Affiche un identifiant de recherche ; passez-le à B<results> ou B<progress> pour cibler cette recherche. Plusieurs recherches peuvent être exécutées simultanément, chacune ayant son identifiant."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Types de recherche disponibles :"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Effectue une recherche globale."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Effectue une recherche sur le réseau Kademlia."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Effectue une recherche locale."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "Des filtres facultatifs peuvent être placés avant, après ou intercalés avec le(s) mot(s)-clé(s) de recherche :"
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Restreindre les résultats au type de fichier indiqué."
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Restreindre les résultats à une extension de fichier spécifique (par ex.\\ I<iso>, I<mp3>)."
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Nombre minimum de sources qu'un résultat doit indiquer."
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Taille minimale du fichier à renvoyer. Les suffixes utilisent des multiplicateurs binaires (K = 1024, M = K\\(mu1024, G = M\\(mu1024) ; l'absence de suffixe signifie octets."
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Taille maximale du fichier à renvoyer. Mêmes suffixes que B<--min-size>."
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Exemple : `search global linux iso --type Iso --min-size 100M' renvoie des résultats pour \\(lqlinux iso\\(rq de type de fichier Iso d'au moins 100 MiB."
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Définit une valeur compte tenu des préférences."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Définir les limites de bande passante."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Définir les préférences de filtrage d'IP."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Montre la file d'attente des envois/réceptions, la liste des serveurs ou la liste des fichiers partagés."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Montrer la file d'attente des réceptions."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Afficher le journal."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Afficher la liste des serveurs."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Afficher la liste des fichiers partagés."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Montrer la file d'attente des envois."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Arrêt du noyau distant exécutant (amule/amuled). Cela arrêtera aussi le client en mode texte, car il est inutilisable sans un noyau en cours d'exécution."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Afficher l'arbre des statistiques."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Le I<E<lt>chiffreE<gt>> optionnel dans l'intervalle 0-255 peut être passé comme argument à cette commande, ce qui indique le nombre d'entrées de la sous-arborescence de la version du client qui doit être affiché. Indiquer 0 ou bien l'omettre signifie 'illimité'."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Exemple: `statistics 5' affichera seulement le top 5 des versions pour chaque type de client."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Afficher l'état de la connexion, et la vitesse actuelle d'émission/réception, etc."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Langues"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Le paramètre I<E<lt>langE<gt>> pour B<-l> l'option a la forme suivante : I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] où I<lang> est la langue principale, I<LANG> est le dialecte, I<encoding> est le jeu de caractères défini à utiliser et I<modifier> permet à l'utilisateur de sélectionner une instance spécifique des données de localisation dans une seule catégorie."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Par exemple, les chaînes de caractères suivantes sont valables :"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Bien que toutes les chaînes ci-dessus soient acceptées comme des définitions de langue valide,  I<encoding> et I<modifier> ne sont pas encore utilisés."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "En plus du format ci-dessus, vous pouvez également spécifier des noms entiers de langue en anglais - ainsi B<-l german> est également valide et équivaut à B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "En l'absence de paramètres linguistiques définis, soit sur ​​la ligne de commande ou sur le fichier de configuration, la langue utilisée par défaut sera celle du système d'exploitation."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLE"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Typiquement amulecmd sera lancée la première fois ainsi :"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<nom de l'hôte> B<-p> I<port EC> B<-P> I<mot de passe EC> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "ou"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Cela sauvegardera les options dans I<$HOME/.aMule/remote.conf>, et il suffira de taper plus tard :"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Bien sûr, vous n'avez pas à suivre cet exemple."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - le client P2P eMule multiplateforme - version daemonisée"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Passe en arrière plan."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>cheminE<gt>>, B<--pid-file>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Après l'embranchement, créer un fichier pid dans le I<E<lt>répertoireE<gt>>.  I<E<lt>répertoireE<gt>> doit contenir le fichier."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Configurer les EC (Connexions Externes)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activer ou désactiver le lancement d'amuled à l'ouverture d'une session de l'utilisateur, puis quitter.  Le dépôt spécifique au système d'exploitation est sélectionné automatiquement : clef d'exécution (Run) du registre pour Windows, LaunchAgent pour macOS et élément de lancement automatique XDG I<.desktop> pour GNU/Linux."
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - programme de contrôle d'aMule avec Interface Graphique"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> est un programme client, et peut être connecté à amule ou amuled via EC. Vous pouvez gérer votre programme amule avec lui. Il fournit presque les mêmes fonctionnalités qu'amule, même si le noyau fonctionne sur un autre ordinateur."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Sauter la boîte de dialogue de connexion."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Activer ou désactiver le lancement d'amulegui à l'ouverture d'une session de l'utilisateur, puis quitter.  Le dépôt spécifique au système d'exploitation est sélectionné automatiquement : clef d'exécution (Run) du registre pour Windows, LaunchAgent pour macOS et élément de lancement automatique XDG I<.desktop> pour GNU/Linux."
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Cette page de manuel a été rédigée par Julien Delange pour Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Cette page de manuel a été réécrite par Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - serveur web d'aMule"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>langE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>nomE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>motdepasseE<gt>>] [B<-G> I<E<lt>motdepasseE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>cheminE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr "B<OBSOLÈTE :> amuleweb est obsolète est peut être enlevé dans aMule 3.2 ou une version ultérieure.  Il n'est pas enlevé pour l'instant ; envisagez de migrer vers amuleapi, l'API REST/SSE."
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gère votre accès à amule via un navigateur Web.  Vous pouvez démarrer ensemble amuleweb et B<amule>(1), ou séparément, à un moment ultérieur.  Les options peuvent être spécifiées par ligne de commande ou via fichier de configuration. Les options passées en ligne de commande prévalent sur les options de fichier de configuration."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomE<gt>>, B<--template>=I<E<lt>nomE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Charge le modèle nommé I<E<lt>nomE<gt>>. Voir la section B<SKIN SUPPORT> pour plus de détails."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Port HTTP du serveur Web. Il s'agit du port vers lequel votre navigateur doit pointer (par défaut : I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Activer UPnP."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Port UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activer la compression gzip pour le trafic HTTP pour économiser la bande passante."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Désactive la compression gzip (c'est le réglage par défaut)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>motdepasseE<gt>>, B<--admin-pass>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Mot de passe d'accès total pour le serveur web."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>motdepasseE<gt>>, B<--guest-pass>=I<E<lt>motdepasseE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Mot de passe invité pour le serveur web."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Autoriser l'accès invité."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Interdit l'accès invité (par défaut)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Charger/enregistrer les paramètres de serveur web à partir de/vers l'aMule distant.  amuleweb ignorera la ligne de commande et les paramètres de fichier de configuration, et les chargera à partir aMule. Lors de la sauvegarde, aucune préférence ne sera écrite sur le fichier de configuration, mais sur aMule.  (Bien sûr, cela ne fonctionne que pour les paramètres qui peuvent être définis dans les préférences de -E<gt>Contrôle à distance d'aMule.)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Désactiver l'interpréteur PHP (obsolète)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompile les pages PHP à chaque requête."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>cheminE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Chemin du fichier de configuration d'aMule.  B<NE PAS UTILISER DIRECTEMENT !> aMule utilise cette option lors du démarrage d'amuleweb au démarrage d'aMule.  Cette option permet d'ignorer toutes les autres options de ligne de commande et les paramètres de fichier de configuration, et lit les préférences depuis le fichier de configuration précisé, et implique également les options B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "PRISE EN CHARGE DES THÈMES"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> est capable d'afficher des informations dans différents thèmes.  Ces thèmes sont appelés modèles, et vous pouvez faire de charger à amuleweb un modèle spécifique via l'option en ligne de commande B<-t>.  Les modèles sont recherchés dans deux endroits : d'abord dans : I<~/.aMule/webserver/> puis dans I</usr/share/amule/webserver/> si vous l'avez installé avec --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Chaque modèle doit être dans un sous répertoire du nom du modèle, et ce répertoire doit contenir tous les fichiers dont le modèle a besoin."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Typiquement amuleweb sera lancée la première fois ainsi :"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nom de l'hôte> B<-p> I<port EC> B<-P> I<mot de passe EC> B<-s> I<port HTTP> B<-A> I<mot de passe Admin> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Bien sûr, vous pouvez spécifier plus ou moins d'options sur la première ligne d'exemple, et vous pouvez également totalement le supprimer."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule eD2k link parser v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - analyseur de liens eD2k pour aMule"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>cheminE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>lien eD2kE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Envoie le I<E<lt>lien-eD2kE<gt>> à aMule, c'est-à-dire qu'il l'écrit sur le fichier ~/.aMule/ED2KLinks, qui sera vérifié par aMule chaque seconde pour les liens."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Définir la catégorie pour les liens eD2k transmis à I<E<lt>numE<gt>>.  Contrairement à B<--config-dir>, l'analyseur lit la valeur en tant que prochain argument et n'accepte pas la syntaxe B<--category>=I<E<lt>numE<gt>>."
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Charge tous les liens trouvés dans l'emulecollection transmise en tant que I<E<lt>lien-eD2kE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Liste tous les liens trouvés dans l'emulecollection transmise en tant que I<E<lt>lien-eD2kE<gt>>"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ lien eD2k ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Ajoute un lien eD2k au noyau."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "un lien magnet ;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "un fichier de collection emule."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<Le ordre dans lequel vous donnez les paramètres est important.> Vous pouvez donner plus d'un lien, et chaque lien peut avoir ses propres paramètres.  Par exemple, B<ed2k E<lt>lien1E<gt> -t2 E<lt>lien2E<gt>> téléchargera I<E<lt>lien1E<gt>> dans la catégorie standard et I<E<lt>lien2E<gt>> dans la catégorie 2."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - le créateur de liens eD2k d'aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> est un utilitaire graphique pour créer un lien eD2k pour n'importe quel fichier sur votre ordinateur."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Cette application ne prend pas d'arguments."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule eD2k links calculator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - calculateur de lien eD2k pour aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>liste de fichiers d'entréeE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Calcule les liens eD2k de tous les fichiers d'entrée précisé dans la I<E<lt>liste des fichiers d'entréeE<gt>> (Il peut y un seul fichier ou plusieurs)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Calcule et ajoute les parties de hachages aux liens eD2k calculés."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Mode bavard - afficher aussi les étapes de calculs."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c aMule statistics"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> est un programme pour afficher le contenu de votre fichier de signature aMule en ligne sur la console (sous une forme lisible par l'homme). Pour que cela fonctionne, vous devez activer l'option \"Online Signature\" dans les préférences d'aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Écrit l'image de la signature en ligne.  La forme longue B<--picture> accepte un argument facultatif I<=E<lt>CHEMINE<gt>> pour spécifier l'emplacement de sortie ; la forme courte B<-o> / B<-P> ne nécessite pas (B<-P> un argument I<E<lt>CHEMINE<gt>> qui suivrait immédiatement et B<-o> est un commutateur sans argument.  Nécessite que le support de GD soit compilée dans (I<__GD__>) ; cette option est silencieusement ignorée sinon."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "Page HTML avec les statistiques et l'image.  La forme longue B<--html> accepte un argument facultatif I<=E<lt>CHEMINE<gt>> afin de spécifier l'emplacement de sortie ; la forme courte B<-p> / B<-H> ne nécessite pas (B<-H> un argument I<E<lt>PATHE<gt>> qui suivrait immédiatement et B<-o> est un commutateur sans argument."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Sans aucune option, elle affiche des données de signature en ligne sur la sortie standard."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> a été écrit par Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (ou bien .jpg, lorsque B<-o> / B<--picture> est utilisé et que GD est disponible)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (lorsque B<-p> / B<--html> est utilisé)"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c aMule statistics"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> est un programme permettant d'afficher le contenu de votre fichier de signature en ligne dans une belle fenêtre wx sur votre bureau.  Pour que cela fonctionne, vous devez activer l'option \"Online Signature\" dans les préférences d'aMule."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Basé sur B<cas>(1) de Pedro de Oliveira. B<wxcas> a été écrit par ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-hu.po
+++ b/docs/man/po/manpages-hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: po 4a\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:29+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: none\n"
@@ -17,1382 +17,1373 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NÉV"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - a \"minden-platform\" eMule p2p kliens"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "ÁTTEKINTÉS"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>útvonalE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>számE<gt>>] [I<eD2k-hivatkozás>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "LEÍRÁS"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>útvonalE<gt>>, B<--config-dir>=I<E<lt>útvonalE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "A beállításokat az I<E<lt>útvonalE<gt>>-ból olvassa az alapértelmezett helyett."
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Beállítja az alkalmazás geometriáját. A I<E<lt>geomE<gt>> paraméter ugyanazt a formátumot használja, mint a többi X11 alkalmazás:\t[B<=>][I<E<lt>szélességE<gt>>{B<xX>}I<E<lt>magasságE<gt>>][{B<+->}I<E<lt>xpozícióE<gt>>{B<+->}I<E<lt>ypozícióE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "A napló bejegyzéseket a szabvány kimenetre írja."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Beállítások visszaállítása az alapértelmezett értékekre."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>fájlE<gt>>, B<--use-amuleweb>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Az amuleweb programnak I<E<lt>fájlE<gt>>-t fogja használni."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Nem zárja le a szabvány bemenetet."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>számE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "A megadott eD2k hivatkozást a I<E<lt>számE<gt>>-adik kategóriába tölti."
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Megjeleníti a verziószámot."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Egy rövid használati leírást jelenít meg."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k-hivatkozás ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Egy eD2k vagy magnet hivatkozást ad a letöltéshez."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Az eD2k hivatkozás a következő lehet:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "egy fájl hivatkozás (ed2k://|file|...), ez a letöltési sorhoz lesz hozzáadva;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "egy kiszolgáló hivatkozás (ed2k://|server|...), ez a kiszolgáló-listához lesz hozzáadva;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "egy kiszolgáló-lista hivatkozás, mely esetben a listában szereplő összes kiszolgáló a kiszolgáló-listához adódik;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "egy magnet hivatkozás."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "MEGJEGYZÉSEK"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Elérési utak"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Minden olyan opciónál amely I<E<lt>fájlE<gt>> paramétert kér, ha a megadott I<fájl> nem tartalmaz könyvtár komponenst (vagyis tisztán csak egy fájlnév), akkor azt az aMule konfigurációs könyvtárában (I<~/.aMule>) fogja keresni."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "FÁJLOK"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "HIBÁK JELENTÉSE"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "A hibákat kérjük vagy a fórumon (I<https://github.com/amule-org/amule/discussions>), vagy a hibakövetőben (I<https://github.com/amule-org/amule/issues>) jelentsék. Hibákról kérjük ne írjanak levelet (e-mail-t) se a levelezési listára, se közvetlenül valamelyik fejlesztőnek."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "Az aMule és az összes hozzá tartozó segédprogram a GNU General Public License védelme alatt áll."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "LÁSD MÉG"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "SZERZŐ"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Ezt a kézikönyv lapot Vollstrecker E<lt>amule@vollstreckernet.deE<gt> írta."
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "aMule segédprogramok"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Szöveges program az aMule \"távvezérléséhez\""
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>gépE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>jelszóE<gt>>] [B<-f> I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>nyelvE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>parancsE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "Az amulecmd egy szöveges program az aMule vezérlésére."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>gépE<gt>>, B<--host>=I<E<lt>gépE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "A gép, amelyen az aMule fut (alapértelmezés: I<127.0.0.1>). A I<E<lt>gépE<gt>> lehet egy IP cím vagy egy DNS név."
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Az aMule távoli elérés portja, amint az a Beállítások-E<gt>Távoli Elérés panelen beállítható (alapértelemzés: I<4712>)."
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>jelszóE<gt>>, B<--password>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "A távoli elérés jelszava."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>fájlE<gt>>, B<--config-file>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "A megadott konfigurációs fájl használata. Az alapértelmezett konfigurációs fájl: I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Ne írjon semmit a szabvány kimenetre."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Bőbeszédű mód - a hibakeresési üzenetek megjelenítése."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>nyelvE<gt>>, B<--locale>=I<E<lt>nyelvE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Beállítja a program nyelvét. Lásd a B<MEGJEGYZÉSEK> fejezetet a I<E<lt>nyelvE<gt>> paraméter bővebb leírásához."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "A parancssori paramétereket beírja a konfigurációs fájlba és kilép."
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>parancsE<gt>>, B<--command>=I<E<lt>parancsE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Végrehajtja a megadott parancsot, mintha azt a saját parancssorába írtuk volna be, majd kilép."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Konfigurációs fájl készítése a I<E<lt>fájlE<gt>> alapján, amely az aMule érvényes konfigurációs fájlja kell legyen, majd utána kilép."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "PARANCSOK"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Minden parancs érzéketlen a kis/nagy betűkre."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Egy eD2k vagy magnet hivatkozást ad a letöltéshez."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "egy kiszolgáló-lista hivatkozás, mely esetben a listában szereplő összes kiszolgáló a kiszolgáló-listához adódik."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "A magnet hivatkozásnak tartalmaznia kell az eD2k hash-t és a fájl hosszát."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Megszakítja a I<E<lt>hashE<gt>> vagy I<E<lt>számE<gt>> által azonosított letöltést. Az értékek megszerzéséhez használd a B<show> parancsot."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Kapcsolódik a hálózathoz."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "A Beállításokban engedélyezett összes hálózathoz kapcsolódik."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Az opcionális paraméterrel megadható, melyik hálózathoz csatlakozzon. Egy kiszolgáló címének IP:Port formában történő megadásával (ahol az IP vagy egy pontozott decimális cím, vagy egy feloldható DNS név) az aMule a megadott kiszolgálóhoz fog csatlakozni."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Leválasztás minden csatlakoztatott hálózatról, vagy csak a megadott hálózatról."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Letölt egy fájlt."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Meg kell adni egy fájl számát a legutóbbi keresésből. Például: a \\(Bqdownload 12\\(rq parancs az előző keresés eredményei közül a 12-es sorszámú fájlt fogja letölteni."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Leválasztás az amule(d)-ről és kilépés az amulecmd-ből."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Megmutat egy beállítás értéket."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "A I<E<lt>mitE<gt>> lehetséges értékei:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Sávszélesség határok."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "IP-szűrő beállítások."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Egy rövid használati leírást jelenít meg. Ha paraméter nélkül hívjuk meg, kilistázza az elérhető parancsokat. Ha egy I<E<lt>parancsE<gt>>-ot is megadunk, rövid leírást ad az adott parancsról."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Megállítja a I<E<lt>hashE<gt>> vagy I<E<lt>számE<gt>> által azonosított letöltést. Az értékek megszerzéséhez használd a B<show> parancsot."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Beállítja a I<E<lt>hashE<gt>> vagy I<E<lt>számE<gt>> által azonosított letöltés prioritását."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "A I<E<lt>prioritásE<gt>> lehetséges értékei:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Automatikus prioritás."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Magas prioritás."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Alacsony prioritás."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Normál prioritás."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "Az B<exit> parancs szinonímája."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "A megadott objektum újratöltése."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "A megosztott fájlok listájt tölti újra."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Az IP szűrő újratöltése."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Napló újrakezdése."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Folytatja a I<E<lt>hashE<gt>> vagy I<E<lt>számE<gt>> által azonosított letöltést. Az értékek megszerzéséhez használd a B<show> parancsot."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Elindít egy keresést a megadott I<E<lt>kulcsszóE<gt>>-ra. Kötelező megadni a keresés típusát és a kulcsszót. Példa: a \\(Bqsearch kad amule\\(rq parancs egy Kademlia keresést indít az \\(Bqamule\\(rq kulcsszóra."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Elérhető keresés típusok:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Globális keresést hajt végre."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "A Kademlia hálózaton keres."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Lokális keresés."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Egy beállítás érték megváltoztatása."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Sávszélesség határok beállítása."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "IP-szűrő beállításainak módosítása."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Megmutatja a fel- és letöltési sort, a kiszolgáló- és megosztott fájlok listáját."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Letöltési lista megjelenítése."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Napló megjelenítése."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Kiszolgálók listájának megjelenítése."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Reload shared files list."
 msgid "Show shared files list."
 msgstr "A megosztott fájlok listájt tölti újra."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Feltöltési lista megjelenítése."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Leállítja a távoli magot (amule/amuled). Ez egyszersmind a szöveges klienst is leállítja, mivel az nemigen használható futó mag nélkül."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "A statisztika fa megjelenítése."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Lehetséges megadni egy számot a 0-255 tartományban, amely megadja az ügyfél-verziók al-fák maximális nagyságát. Nulla megadása vagy a szám teljes elhagyása nem korlátoz."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Példa: a \\(Bqstatistics 5\\(rq parancs csak az 5 leggyakoribb ügyfél változatot mutatja minden ügyfél típusra."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Megjeleníti a kapcsolat állapotát, pillanatnyi fel-/letöltési sebességet, stb."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Nyelvek"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "A B<-l> opció I<E<lt>nyelvE<gt>> paramétere a következőképpen adható meg: I<nyelv>[B<_>I<TERÜLET>][B<.>I<kódolás>][B<@>I<módosító>], ahol I<nyelv> az elsődleges nyelv, I<TERÜLET> egy nyelvváltozat/terület kódja, I<kódolás> a karakterkészlet kódja és a I<módosító> \\(Bqlehetővé teszi, hogy a felhasználó kiválasszon egy meghatározott esetet a helyi jellemzők adataiból egyetlen kategórián belül\\(rq."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Például a következő értékek mind érvényesek:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Habár a fentieket mind elfogadja a program, mint érvényes nyelvmeghatározást, a I<kódolás> és I<módosító> még nem használt."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Ráadásként a fenti formátumhoz, megadható akár egy nyelv teljes angol megnevezése is, így például a B<-l german> szintén érvényes és egyenértékű a B<-l de_DE> megadással."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Ha sem a konfigurációs fájlban, sem a parancssorban nincs megadva a nyelv, akkor a rendszer alapértelmezett nyelvét fogja használni."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "PÉLDA"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Tipikusan az amulecmd-t először a következőképpen indítjuk:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<gépnév> B<-p> I<EC-port> B<-P> I<EC-jelszó> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "vagy"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/felhasználónév/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Ez elmenti a beállításokat a I<$HOME/.aMule/remote.conf> fájlba, hogy később már csak ezt kelljen írni:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Természetesen nem kötelező ezt a példát követni."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amule - a \"minden-platform\" eMule p2p kliens - démon változat"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>útvonalE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Háttérbe vonul."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>fájlE<gt>>, B<--pid-file>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "A háttérbe vonulás után hozzon létre egy pid-fájlt."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "A távoli elérés beállítása."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>sablonE<gt>>, B<--template>=I<E<lt>sablonE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - aMule vezérlő program grafikus felülettel"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>számE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "Az B<amulegui> egy ügyfél program, távoli elérés segítségével kapcsolódik az amule(d)-hez. Majdnem a teljes funkcionalitást biztosítja, még ha a mag egy távoli gépen fut is."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "A kapcsolódási párbeszéd átugrása."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Ezt a kézikönyv oldalt Julien Delange E<lt>julien AT gunnm DOT orgE<gt> írta a Debian számára."
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Ezt a kézikönyv oldalt Vollstrecker E<lt>amule@vollstreckernet.deE<gt> újraírta."
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule web kiszolgáló v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule web kiszolgáló"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>nyelvE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>sablonE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>jelszóE<gt>>] [B<-G> I<E<lt>jelszóE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>fájlE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "Az B<amuleweb> programmal egy web-böngésző segítségével vezérelhetjük az amule(d)-t. Az amuleweb-et az B<amule>(1)-vel együtt is lehet indítani, vagy külön, kézzel. A beállításait konfigurációs fájlban vagy parancssorban is megadhatjuk. A parancssori opciók elsőbbséget élveznek a konfigurácós fájlban találtakkal szemben."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>sablonE<gt>>, B<--template>=I<E<lt>sablonE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Betölti a I<E<lt>névE<gt>> nevű sablont. Bővebb részletekért lásd a B<SABLONOK> fejezetet."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Web kiszolgáló HTTP port. Erre a portra kell irányítanod a böngésződet (alapértelmezés: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "UPnP engedélyezése."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "UPnP port."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Engedélyezi a gzip tömörítést a HTTP adatátvitelnél a sávszélesség jobb kihasználása érdekében."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "gzip tömörítés tiltása (alapértelmezett)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>jelszóE<gt>>, B<--admin-pass>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Teljes hozzáférésű jelszó a web kiszolgálóhoz."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>jelszóE<gt>>, B<--guest-pass>=I<E<lt>jelszóE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Web kiszolgáló vendég felhasználó jelszava."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Vendég felhasználó engedélyezése."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Vendég felhasználó tiltása (alapértelmezett)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Beállítások töltése/mentése a távoli aMule-ról/ra. Ebben az esetben az amuleweb figyelmen kívül hagyja azokat a parancssori és konfigurációs fájlbeli beállításokat, amelyeket az aMule-tól is be tud szerezni (ezek beállíthatók a Beállítások-E<gt>Távoli Elérés pontban). A beállítások mentésekor sem írja azokat fájlba (mint egyébként), hanem az aMule-t értesíti a beállítások megváltozásáról. Azon beállítások, melyek az aMule Beállítások párbeszédpaneljén nem szerepelnek, nem kerülnek mentésre."
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP értelmező letiltása (elavult, ne használd)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "PHP oldalak újrafordítása minden kérésnél."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>fájlE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule konfigurációs fájl. B<NE HASZNÁLD!> Az aMule használja ezt a paramétert amikor automatikusan indítja az amuleweb-et. Ezen paraméter hatására minden más parancssori és konfigurációs fájl-béli beállítást figyelmen kívül hagy, a beállításait a megadott I<E<lt>fájlE<gt>>-ból olvassa, illetve bekapcsolja a B<-q -L> opciókat."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SABLONOK"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "Az B<amuleweb> képes az információ különböző felületekkel történő megjelenítésére. Ezeket hívjuk sablonoknak, és az amuleweb a B<-t> parancssori opcióval vehető rá egy adott sablon használatára. A sablonokat a következő helyeken keresi: először a I<~/.aMule/webserver/> könyvtárban, majd utána a I</usr/share/amule/webserver/> könyvtárban."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Minden sablonnak a sablon nevével megegyező alkönyvtárban kell lennie, és ez a könyvtár kell tartalmazzon minden fájlt, amelyre a sablonnak szüksége van."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipikusan az amuleweb-et először a következőképpen indítjuk:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<gépnév> B<-p> I<EC-port> B<-P> I<EC-jelszó> B<-s> I<HTTP-port> B<-A> I<admin-jelszó> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/felhasználónév/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Természetesen más paraméterek is megadhatók az első példában, illetve teljesen el is hagyhatóak."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule eD2k hivatkozás kezelő v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - Az aMule eD2k hivatkozás kezelő."
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>útvonalE<gt>>] [B<-t> I<E<lt>számE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-hivatkozásE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Elküldi a megadott I<E<lt>eD2k hivatkozásE<gt>>-t az aMule-nek, azaz beírja a ~/.aMule/ED2KLinks fájlba, amit az aMule másodpercenként megnéz, hivatkozásokat keresve."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>sablonE<gt>>, B<--template>=I<E<lt>sablonE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Loads all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "A megadott gyűjtemény összes fájlját letölti."
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Lists all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Kilistázza a megadott gyűjtmény összes fájlját."
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-hivatkozás ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "eD2k hivatkozás letöltése."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "egy magnet hivatkozás;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "egy emulecollection (gyűjtemény) fájl."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<A paraméterek sorrendje számít.> Megadhatsz egynél több hivatkozást, mindegyiket a saját paramétereivel. Például az B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> parancs a I<E<lt>link1E<gt>>-et az alapértelmezett, míg a I<E<lt>link2E<gt>>-t a 2. kategóriába tölti."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - az aMule eD2k hivatkozás készítő"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "Az B<alc> egy grafikus segédprogram eD2k hivatkozások létrehozásához"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "A program nem vár semmilyen paramétert."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule eD2k hivatkozás készítő"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - szöveges eD2k hivatkozás készítő az aMule-hez"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>fájl(ok)...E<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "A parancssorban megadott fájl(ok)hoz számítja ki az eD2k hivatkozás(oka)t. Egyszerre több fájl is megadható."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Rész-hash-ek számítása és hozzáadása a készített eD2k hivatkozáshoz."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Bőbeszédű mód - a számítási lépéseket is megjeleníti."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c aMule statisztikák"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "A B<cas> program az aMule online-aláírás fájljának tartalmát jeleníti meg a képernyőn. Ahhoz, hogy ez működjön, engedélyezni kell az \\(BqOnline aláírás\\(rq opciót az aMule beállításaiban."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Paraméterek nélkül az online-aláírás adatokat a szabvány kimenetre írja."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "A B<cas>-t Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt> írta."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c aMule statisztikák"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "A B<wxcas> az aMule online-aláírás fájljának tartalmát jeleníti meg grafikusan. Ahhoz, hogy ez működjön, engedélyezni kell az \\(BqOnline aláírás\\(rq opciót az aMule beállításaiban."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Készült a Pedro de Oliveira írta B<cas>(1) alapján.  A B<wxcas>-t ThePolish E<lt>thepolish@vipmail.ruE<gt> írta."
 

--- a/docs/man/po/manpages-it.po
+++ b/docs/man/po/manpages-it.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule SVN\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: none\n"
@@ -20,1599 +20,1590 @@ msgstr ""
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 # type: SH
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NOME"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - il client p2p multipiattaforma basato su eMule"
 
 # type: SH
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SINTASSI"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>percorsoE<gt>>] [B<-geometry> I<E<lt>geometriaE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>percorsoE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>numeroE<gt>>] [I<collegamento-eD2k>|I<file-collezione>]"
 
 # type: SH
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
 # type: TP
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>percorsoE<gt>>, B<--config-dir>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Legge la configurazione dal I<E<lt>percorsoE<gt>> invece che dalla directory dell'utente"
 
 # type: TP
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geometriaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Imposta la geometria della applicazione. I<E<lt>geometriaE<gt>> usa lo stesso formato delle applicazioni X11 standard: \t[B<=>][I<E<lt>larghezzaE<gt>>{B<xX>}I<E<lt>altezzaE<gt>>][{B<+->}I<E<lt>spostamentoxE<gt>>{B<+->}I<E<lt>spostamentoyE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Scrive i messaggi di log nello stdout."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Reimposta la configurazione ai valori di default."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Abilita o disabilita l'avvio di aMule all'accesso dell'utente, poi esce.  L'archivio specifico del sistema operativo viene selezionato automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS, voce di avvio automatico XDG I<.desktop> su Linux."
 
 # type: TP
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>percorsoE<gt>>, B<--use-amuleweb>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Specifica la posizione dell'eseguibile di amuleweb in I<E<lt>percorsoE<gt>>."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "Non intercettare le eccezioni fatali e non bloccare l'uscita sulle assertion.  Utile per installazioni headless / supervisionate (systemd, script watchdog)  dove la finestra di assertion altrimenti modale impedisce il riavvio automatico."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Non disabilita lo stdin."
 
 # type: TP
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>numeroE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Imposta la categoria per i collegamenti eD2k ricevuti a I<E<lt>numeroE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Visualizza il numero di versione corrente."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Visualizza una breve descrizione dell'utilizzo."
 
 # type: TP
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ collegamento-eD2k | file-collezione ]>"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Aggiunge al core un collegamento eD2k, o ogni collegamento contenuto in un file collezione eMule."
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Il collegamento eD2k da aggiungere può essere:"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "un collegamento a un file (ed2k://|file|...), sarà aggiunto alla coda di download;"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "un collegamento a un server (ed2k://|server|...), sarà aggiunto alla lista dei server;"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "un collegamento a una lista di server, nel cui caso tutti i server inclusi nella lista verranno aggiunti alla lista dei server;"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "un collegamento magnet."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr "In alternativa l'argomento può essere il percorso di un file .emulecollection, o un URL file:// che lo indica, nel qual caso ogni collegamento in esso contenuto viene aggiunto alla coda di download. È questo che permette a un file manager di aprire una collezione con aMule."
 
 # type: SH
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTE"
 
 # type: SS
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Percorsi"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Per tutte le opzioni che accettano un I<E<lt>percorsoE<gt>>, se il I<percorso> non contiene una directory (ossia è solo un nome di file), allora si assume che esso sia presente nella directory di configurazione di aMule, I<~/.aMule>."
 
 # type: SH
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "FILE"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 # type: SH
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "SEGNALARE I BUG"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Per favore segnalare i bug nel nostro forum (I<https://github.com/amule-org/amule/discussions>) o nel nostro bugtracker (I<https://github.com/amule-org/amule/issues>). Per favore non segnalare i bug via posta elettronica, né nella nostra mailing list né direttamente a qualunque membro del gruppo."
 
 # type: SH
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule e tutti i programmi di utilità correlati sono distribuiti in accordo alla GNU General Public License."
 
 # type: SH
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "VEDI ANCHE"
 
 # type: SH
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTORE"
 
 # type: Plain text
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Questa pagina del manuale è stata scritta da Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "utilità di aMule"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - programma in console per controllare aMule"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portaE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>percorsoE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>linguaggioE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>comandoE<gt>>]B< >}"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>percorsoE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> è un client in console per controllare aMule."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Computer dove è in esecuzione aMule (default: I<127.0.0.1>). I<E<lt>hostE<gt>> può essere un indirizzo IP o un nome DNS"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portaE<gt>>, B<--port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "porta di aMule per le connessioni esterne, come impostata nelle preferenze-E<gt>controllo remoto (default: I<4712>)"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Password delle connessioni esterne."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>percorsoE<gt>>, B<--config-file>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Usa il file di configurazione fornito. Il file di configurazione di default è I<~/.aMule/remote.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Non scrivere nulla nello stdout."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Mostra anche i messaggi di debug."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>linguaggioE<gt>>, B<--locale>=I<E<lt>linguaggioE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Imposta il linguaggio del programma. Vedi anche la sezione delle B<NOTE> per la descrizione del parametro I<E<lt>linguaggioE<gt>> ."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Scrive le opzioni della riga di comando nel file di configurazione ed esce"
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>comandoE<gt>>, B<--command>=I<E<lt>comandoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Esegue il I<E<lt>comandoE<gt>> come se fosse stato immesso nel prompt di amulecmd ed esce."
 
 # type: TP
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Crea un file di configurazione basandosi sul I<E<lt>percorsoE<gt>>, che deve puntare ad un file di configurazione di aMule valido, e quindi esce."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forza la compressione ZLIB sulla connessione esterna indipendentemente dalla località dell'IP contattato.  Utile quando il server è raggiungibile attraverso un tunnel VPN che risolve a un IP di LAN e l'euristica salterebbe altrimenti la compressione."
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "COMANDI"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Tutti i comandi non distinguono tra maiuscolo e minuscolo."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Aggiunge un collegamento eD2k o un collegamento magnet."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "un collegamento ad una lista di server, nel cui caso tutti i server contenuti nella lista saranno aggiunti alla lista dei server correnti."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Il collegamento magnet deve contenere l'hash eD2k e la lunghezza del file."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Cancella il download specificato da I<E<lt>hashE<gt>> o I<E<lt>numeroE<gt>>. Per ottenere il valore utilizzare B<show>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Connessione alla rete."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Questo avvierà la connessione a tutte le reti abilitate nelle preferenze."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Con il parametro opzionale si può specificare a che rete connettersi. Fornendo un indirizzo di server nella forma IP:Porta (dove IP è un indirizzo IPv4 in forma decimale puntata o un nome DNS risolvibile) aMule si connetterà solo a quel server."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Disconnette da tutte le reti attualmente connesse, o disconnette solo dalla rete specificata."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Inizia il download di un file."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Deve essere fornito il I<E<lt>numeroE<gt>> di un file dall'ultima ricerca.Esempio: `download 12' inizierà il download del file numero 12 della ricerca precedente."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Disconnette da amule/amuled ed esce da amulecmd."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Legge e visualizza un valore delle preferenze."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "I valori disponibili per l'I<E<lt>oggettoE<gt>> sono:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Legge i limiti di banda."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Legge le preferenze del filtro IP."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Visualizza una breve descrizione dell'uso. Se chiamato senza parametro, mostra una lista dei comandi disponibili. Se chiamato con il parametro I<E<lt>commandE<gt>>, mostra una breve descrizione del comando dato."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Mette in pausa il download specificato da I<E<lt>hashE<gt>> o I<E<lt>numeroE<gt>>. Per ottenere il valore utilizzare B<show>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Imposta la priorità di un download specificato da I<E<lt>hashE<gt>> o I<E<lt>numeroE<gt>>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "I valori disponibili per I<E<lt>prioritàE<gt>> sono:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Priorità automatica."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Priorità alta."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Priorità bassa."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Priorità normale."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr "Mostra i progressi di una ricerca in corso. Accetta facoltativamente un I<E<lt>idE<gt>> di ricerca (come stampato da B<search>); senza id, mostra la ricerca avviata più di recente."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "Un sinonimo del comando B<exit>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Ricarica un dato oggetto."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Ricarica la lista dei file condivisi."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Ricarica la tabella dei filtri IP."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Cancella il log."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr "Mostra i risultati di una ricerca. Accetta facoltativamente un I<E<lt>idE<gt>> di ricerca (come stampato da B<search>); senza id, mostra la ricerca avviata più di recente.  È possibile mantenere più ricerche contemporaneamente sul demone, indirizzandole tramite id."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Riprende il download specificato da I<E<lt>hashE<gt>> o I<E<lt>numeroE<gt>>. Per ottenere il valore utilizzare B<show>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Esegue una ricerca per la data I<E<lt>parola-chiaveE<gt>>. Il tipo della ricerca e una parola chiave da cercare sono obbligatori. Esempio: ' search kad amule' esegue una ricerca sulla rete kad per ' amule'. Stampa un id di ricerca, da passare a B<results> o B<progress> per indirizzare questa ricerca. È possibile eseguire più ricerche contemporaneamente, ciascuna con il proprio id."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Tipi di ricerca disponibili:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Esegue una ricerca globale."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Esegue una ricerca sulla rete Kademlia."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Esegue una ricerca locale."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "È possibile inserire filtri opzionali prima, dopo o intervallati alla/e parola/e chiave di ricerca:"
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Limita i risultati al tipo di file indicato."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Limita i risultati a un'estensione di file specifica (ad es.\\ I<iso>, I<mp3>)."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Numero minimo di fonti che un risultato deve dichiarare."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Dimensione minima del file da restituire. I suffissi usano moltiplicatori binari (K = 1024, M = K\\(mu1024, G = M\\(mu1024); senza suffisso indica byte."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Dimensione massima del file da restituire. Stessi suffissi di B<--min-size>."
 
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Esempio: `search global linux iso --type Iso --min-size 100M' restituisce risultati per \\(lqlinux iso\\(rq di tipo file Iso di almeno 100 MiB."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Imposta un dato valore di preferenza."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Imposta i limiti di banda."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Imposta le preferenze del filtro IP."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Mostra la coda di upload/download, la lista dei server o la lista dei file condivisi."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Mostra la coda di download."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Mostra il log."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Mostra la lista dei server."
 
 # type: Plain text
 # AI-GENERATED — please review.
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Mostra la lista dei file condivisi."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Mostra la coda di upload."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Chiude il motore remoto in esecuzione (amule/amuled). Questo chiuderà anche il cliente in formato testo, siccome è inutile senza un motore in esecuzione."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Mostra l'albero delle statistiche."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Il I<E<lt>numeroE<gt>> opzionale, nell'intervallo 0-255, può essere passato come argomento a questo comando per indicare quante righe del ramo delle versioni dei client devono essere mostrate. Indicando 0, o omettendo il parametro significa `illimitato'."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Esempio: `statistics 5' mostrerà solo le prime 5 versioni per ogni tipo di client."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Mostra lo stato della connessione, le velocità correnti di up/download, ecc."
 
 # type: SS
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Linguaggi"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Il parametro I<E<lt>linguaggioE<gt>> per l'opzione B<-l> ha la forma seguente: I<linguaggio>[B<_>I<LINGUAGGIO>][B<.>I<codifica>][B<@>I<modificatore>] dove I<linguaggio> è il linguaggio primario, I<LINGUAGGIO> è il sottotipo/territorio, I<codifica> è l'insieme di caratteri usato e I<modificatore> consente all'utente di selezionare una specifica istanza dei dati di localizzazione all'interno di una singola categoria."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Per esempio, le stringhe seguenti sono valide:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Sebbene tutte le stringhe sopra elencate sono accettate come definizioni di linguaggio valide, I<codifica> e I<modificatore> sono ancora inutilizzati."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "In aggiunta al formato di cui sopra, si può anche specificare il nome completo del linguaggio in inglese, e quindi B<-l german> è valido ed equivalente a B<-l de_DE>."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Quando nessun linguaggio è definito in riga di comando o nel file di configurazione, verrà usato il linguaggio di default del sistema."
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 # type: SH
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ESEMPIO"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Di norma amulecmd sarà inizialmente eseguito come:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<nomehost> B<-p> I<portaEC> B<-P> I<passwordEC> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "o"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "In questo modo la configurazione verrà salvata in I<$HOME/.aMule/remote.conf>, e le volte successive si dovrà solo digitare:"
 
 # type: Plain text
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Ma non è necessario seguire questo esempio."
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - il client p2p multipiattaforma basato su eMule - versione demone"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>percorsoE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>percorsoE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Continua l'esecuzione in background."
 
 # type: TP
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>percorsoE<gt>>, B<--pid-file>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Dopo il passaggio in background, crea un file di pid in I<E<lt>percorsoE<gt>>. I<E<lt>percorsoE<gt>> deve includere il nome del file."
 
 # type: Plain text
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Configura le connessioni esterne (EC)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Abilita o disabilita l'avvio di amuled all'accesso dell'utente, poi esce.  L'archivio specifico del sistema operativo viene selezionato automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS, voce di avvio automatico XDG I<.desktop> su Linux."
 
 # type: TP
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 # type: TH
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - programma in interfaccia grafica per controllare aMule"
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>numeroE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> è un programma client, e può connettersi tramite EC ad amule o amuled. Con esso si può gestire amule. Fornisce circa le stesse funzionalità di amule, anche se il motore lavora su un'altro computer."
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Salta la finestra di connessione."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Abilita o disabilita l'avvio di amulegui all'accesso dell'utente, poi esce.  L'archivio specifico del sistema operativo viene selezionato automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS, voce di avvio automatico XDG I<.desktop> su Linux."
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Questa pagina di manuale è stata scritta da Julien Delange per Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 # type: Plain text
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Questa pagina di manuale è stata riscritta da Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 # type: TH
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 # type: TH
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule web server"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>linguaggioE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "B<-t> I<E<lt>nomeE<gt>>] [B<-s> I<E<lt>portaE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portaE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>percorsoE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr "B<DEPRECATED:> amuleweb è deprecato e potrebbe essere rimosso in aMule 3.2 o versioni successive.  Per ora non viene rimosso; valuta la migrazione ad amuleapi, l'API REST/SSE."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gestisce l'accesso ad amule attraverso un browser web.  Si può eseguire amuleweb insieme ad B<amule>(1), o separatamente in qualunque momento successivo. Le opzioni possono essere specificate in riga di comando o nel file di configurazione. Le opzioni in riga di comando hanno la precedenza su quelle nel file di configurazione."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carica il modello chiamato I<E<lt>nomeE<gt>>. Vedi la sezione B<SUPPORTO AGLI SKIN> per i dettagli."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portaE<gt>>, B<--server-port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Porta HTTP del server web. Questa è la porta da indicare nel browser (default: I<4711>)."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Abilita il supporto UPnP."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portaE<gt>>, B<--upnp-port>=I<E<lt>portaE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Porta per l'UPnP."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Abilita la compressione gzip nel traffico HTTP per risparmiare banda."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Disabilita la compressione gzip (questo è il default)."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwordE<gt>>, B<--admin-pass>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Password per l'accesso completo al web server."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwordE<gt>>, B<--guest-pass>=I<E<lt>passwordE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Password for l'accesso ospite al web server."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Permette l'accesso ospite."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Nega l'accesso ospite (default)."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Carica/salva le configurazioni del webserver da/verso aMule remoto. amuleweb ignorerà le opzioni in linea di comando e nel file di configurazione, e le caricherà invece da aMule. Quando si salveranno le preferenze, niente verrà scritto nel file di configurazione, ma in aMule. (Ovviamente, questo funzionerà solo per quelle impostazioni che possono essere scritte nelle preferenze di aMule-E<gt>controllo remoto.)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Disabilita l'interprete PHP (deprecato)"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Ricompila le pagine PHP ad ogni richiesta."
 
 # type: TP
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>percorsoE<gt>> B<]>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "percorso del file di configurazione di aMule. B<NON USARE DIRETTAMENTE!> aMule usa questa opzione quando lancia amuleweb all'avvio di aMule. Questa opzione fa sì che tutte le altre impostazioni in riga di comando e nel file di configurazione vengano ignorate, le preferenze vengano lette dal file di configurazione dato, e anche implica le opzioni B<-q -L> ."
 
 # type: SH
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPPORTO AGLI SKIN"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> può visualizzare l'informazione utilizzando diversi 'skin'. Questi 'skin' sono contenuti in dei modelli, e si può far caricare da amuleweb un dato modello tramite l'opzione B<-t> in riga di comando. I modelli sono cercati in due posti: prima in I<~/.aMule/webserver/> e quindi in I</usr/share/amule/webserver/> se aMule è stato installato con --prefix=/usr."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Ogni modello deve essere in una sottodirectory del nome di modello, e questa directory deve contenere tutti i file necessari al modello."
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Di norma amuleweb sarà inizialmente eseguito con:"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nomehost> B<-p> I<ECporta> B<-P> I<passwordEC> B<-s> I<portaHTTP> B<-A> I<PasswordAmministrazione> B<-w>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 # type: Plain text
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Ovviamente, si possono specificare più o meno opzioni della prima riga di esempio, e si si possono anche omettere completamente."
 
 # type: TH
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 # type: TH
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "analizzatore di collegamenti eD2k per aMule v1.5.1"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - Analizzatore di collegamenti eD2k per aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>percorsoE<gt>>] [B<-t> I<E<lt>numeroE<gt>>]"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>collegamento-eD2kE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Invia il I<E<lt>collegamento-eD2kE<gt>> ad aMule, cioè lo scrive nel file ~/.aMule/ED2KLinks, che sarà controllato da aMule ogni secondo per nuovi collegamenti."
 
 # type: TP
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Imposta a I<E<lt>numE<gt>> la categoria per i collegamenti eD2k passati.  A differenza di B<--config-dir>, il parser legge il valore come argomento successivo e non accetta la sintassi B<--category>=I<E<lt>numE<gt>>."
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Carica tutti i collegamenti trovati nel file emulecollection fornito come I<E<lt>collegamento-ed2kE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Elenca tutti i collegamenti trovati nel file emulecollection fornito come I<E<lt>collegamento-ed2kE<gt>>"
 
 # type: TP
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ collegamento-eD2k ]>"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Aggiunge un collegamento eD2k."
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "un collegamento magnet;"
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "un file emulecollection."
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<L'ordine con cui fornisci i parametri è importante.> Si può fornire più di un collegamento, e ogni collegamento può avere propri parametri. Per esempio B<ed2k E<lt>collegamento1E<gt> -t2 E<lt>collegamento2E<gt>> eseguirà il download di I<E<lt>collegamento1E<gt>> in categoria standard e I<E<lt>collegamento2E<gt>> in categoria 2."
 
 # type: Plain text
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - generatore di collegamenti eD2k di aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> è una utilità grafica per creare un collegamento eD2k da ogni file sul vostro computer."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Questa applicazione non accetta parametri."
 
 # type: TH
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "calcolatore di collegamenti eD2k di aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - Generatore di collegamenti eD2k in formato testo per aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>elenco_di_fileE<gt>>"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Genera i collegamenti eD2k di tutti i file in ingresso forniti in I<E<lt>elenco_di_fileE<gt>> (Ci possono essere uno o più file)."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Genera e include gli hash delle singole parti al collegamento eD2k."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Dettagliato - mostra anche i passaggi di calcolo."
 
 # type: TH
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - statistiche c di aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> è un programma per visualizzare i contenuti del file di firma generato da aMule in console (in forma leggibile dalle persone). Per il funzionamento, devi abilitare l'opzione \"firma online\" nelle preferenze di aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Scrive l'immagine della firma online.  La forma estesa B<--picture> accetta un facoltativo I<=E<lt>PERCORSOE<gt>> per specificare la posizione di output; le forme corte B<-o> / B<-P> no (B<-P> richiede un argomento I<E<lt>PERCORSOE<gt>> immediatamente di seguito, e B<-o> è uno switch senza argomenti).  Richiede il supporto GD compilato (I<__GD__>); in caso contrario l'opzione viene ignorata silenziosamente."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "Pagina HTML con statistiche e immagine.  La forma estesa B<--html> accetta un facoltativo I<=E<lt>PERCORSOE<gt>> per specificare la posizione di output; le forme corte B<-p> / B<-H> no (B<-H> richiede un argomento I<E<lt>PERCORSOE<gt>> immediatamente di seguito, e B<-p> è uno switch senza argomenti)."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Senza opzioni, scrive i dati della firma nello stdout."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> è stato scritto da Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (o .jpg, quando si usa B<-o> / B<--picture> e GD è disponibile)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (quando si usa B<-p> / B<--html>)"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 # type: TH
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - statistiche wx c di aMule"
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> è un programma per visualizzare i contenuti del file di firma online in una bella finestra wx sul tuo schermo. Per il funzionamento, devi abilitare l'opzione \"firma online\" nelle preferenze di aMule."
 
 # type: Plain text
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Basato su B<cas>(1) di Pedro de Oliveira.  B<wxcas> è stato scritto da ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-pt_BR.po
+++ b/docs/man/po/manpages-pt_BR.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule man pages\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: Marcelo Roberto Jimenez <mroberto@users.sourceforge.net>\n"
@@ -18,1371 +18,1362 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NOME"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "aMule - o cliente p2p eMule multi-plataforma"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SINOPSE"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>caminhoE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>] [I<link eD2k>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "DESCRIÇÃO"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>caminhoE<gt>>, B<--config-dir>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Ler configuração de I<E<lt>pathE<gt>> ao invés de home"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Ajusta a geometria do aplicativo. I<E<lt>geomE<gt>> usa o mesmo formato que aplicativos X11 padrão:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Imprime mensagens de log para stdout."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Reseta configuração para os valores padrão."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Habilita ou desabilita iniciar o aMule quando o usuário fizer login, então sair. O armazenamento específico do Sistema Operacional é selecionado automaticamente: chave Run do Registry do Windows, LaunchAgent do MacOS, XDG I<.desktop> autostart entry no Linux."
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>caminhoE<gt>>, B<--use-amuleweb>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Especifica o local do binário amuleweb para I<E<lt>pathE<gt>>."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "Não captura exceções fatais e não bloqueia saída em assertivas. Útil para configurações \"headless / supervisionadas\" (systemd, scripts de watchdog) onde caso contrário, diálogos de assertivas modais previnem o recomeço automático."
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Não desabilita stdin."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>numeroE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Seta categoria para links eD2k para I<E<lt>numE<gt>>"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Mostra o número de versão atual."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Imprime uma descrição de uso curta."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ link eD2k ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Adiciona um link eD2k ou link magnético ao núcleo."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "O link eD2k a ser adicionado pode ser:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "um link de arquivo (ed2k://|file|...), ele será adicionado à fila de download;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "um link de servidor (ed2k://|server|...), ele será adicionado à lista de servidores;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "um link de lista de servidores, neste caso, todos os servidores na lista serão adicionados à lista de servidores;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "um link magnético."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTAS"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Caminhos"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Para todas as opções que recebem um valor I<E<lt>pathE<gt>>, se o I<path> não contém uma parte de diretório (i.e. apenas o nome de arquivo), então é considerado estar debaixo do diretório de configuração do aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "ARQUIVOS"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "RELATANDO BUGS"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Por favor, relate bugs ou em nosso forum (I<https://github.com/amule-org/amule/discussions>), ou em nosso bugtracker (I<https://github.com/amule-org/amule/issues>). Por favor, não relate bugs por e-mail, nem para nossa lista de e-mail, nem diretamente para qualquer membro do time."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "DIREITOS DE CÓPIA"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule e todos os seus utilitários relacionados são distribuídos sob a licença geral pública GNU."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "VEJA TAMBÉM"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Esta manpage foi escrita por Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "utilitários aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Programa baseado em console para controlar o aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>anfitriãoE<gt>>] [B<-p> I<E<lt>portaE<gt>>] [B<-P> I<E<lt>senhaE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>línguaE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>comandoE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> é um cliente de console para controlar o aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>anfitriãoE<gt>>, B<--host>=I<E<lt>anfitriãoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Anfitrião onde o aMule está rodando (padrão: I<127.0.0.1>).  I<E<lt>anfitriãoE<gt>> pode ser um endereço IP ou um nome de DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portaE<gt>>, B<--port>=I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Porta do aMule para conexões externas, conforme configurado em Preferências-E<gt>Controles Remotos (padrão: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>senhaE<gt>>, B<--password>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Senha das Conexões Externas."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>caminhoE<gt>>, B<--config-file>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Use o arquivo de configuração dado. O arquivo de configuração padrão é I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Não imprima mensagens em stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Seja verborrágico - mostre até as mensagens de debug."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>línguaE<gt>>, B<--locale>=I<E<lt>línguaE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Configura o local do programa (linguagem). Veja a seção B<NOTAS> para a descrição do parâmetro I<E<lt>langE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Escrever as opções da linha de comando para o arquivo de configuração e sair"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>commandoE<gt>>, B<--command>=I<E<lt>commandoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Executar I<E<lt>commandE<gt>> como se fosse digitado no prompt do amulecmd e sair."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Criar arquivo de configuração baseado em I<E<lt>pathE<gt>>, que precisa apontar para um arquivo válido de configuração do aMule, e então sair."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Força compressão ZLIB no link de Conexões Externas independente da localidade IP-discada. Útil quando o lado do servidor for alcançável com um túnel VPN que resolve para um IP de LAN e a heurística iria pular a compressão."
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "COMANDOS"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Todos os comandos são insensíveis a maiúsculas e minúsculas."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Adiciona um link eD2k ou link magnético ao núcleo."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "um link de lista de servidores, no qual todos os servidores na lista serão adicionados à lista de servidores."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "O link magnético precisa conter o hash eD2k e o tamanho do arquivo."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Cancela o download especificado por I<E<lt>hashE<gt>> ou I<E<lt>numberE<gt>>. Para pegar o valor, use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Conectar à rede."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Isto vai conectar à todas as redes que estiverem habilitadas nas preferências."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Com o parâmetro opcional você pode especificar a que rede conectar. Ao dar um endereço de servidor na forma IP:Porta (onde IP é um endereço IPv4 ou um nome de DNS resolvível) o aMule vai conectar apenas a este servidor."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Desconectar de todas as redes que estiver conectado ou apenas desconectar da rede especificada."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Começar a baixar um arquivo."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "O I<E<lt>numeroE<gt>> de um arquivo da última busca tem que ser dado.  Exemplo: `download 12' começará a baixar o arquivo com o número 12 da última busca."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Desconecta do amule/amuled e sai de amulecmd."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Obter e mostrar o valor da preferência selecionada."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Valores disponíveis para I<E<lt>qualE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Obter limites de largura de banda."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Pegar preferências de IPFilter."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Imprime uma descrição de uso curta. Se chamado sem parâmetros, mostra a lista dos comandos disponíveis. Se chamado com I<E<lt>commandE<gt>>, mostra uma descrição curta do comando dado."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Pausa o download especificado por I<E<lt>hashE<gt>> ou I<E<lt>numeroE<gt>>. Para pegar o número use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Configura a prioridade de um download especificado por I<E<lt>hashE<gt>> ou I<E<lt>numeroE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Valores disponíveis para I<E<lt>prioridadeE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Prioridade automática."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Alta prioridade."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Baixa prioridade."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Prioridade normal."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "Um sinônimo para o comando B<exit>."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Recarrega um objeto dado."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Recarregar a lista de arquivos compartilhados."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Recarrega as tabelas de filtragem de IP."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Apaga o log."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Retoma o download especificado por I<E<lt>hashE<gt>> ou I<E<lt>numeroE<gt>>. Para pegar o valor, use B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Faz uma busca pela I<E<lt>palavra chaveE<gt>> dada. Um tipo de busca e uma palavra chave são mandatórias para fazer isso. Exemplo: `search kad amule' executa uma busca kad por `amule'."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Tipos de busca disponíveis:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Executa uma busca global."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Executa uma busca na rede Kademlia."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Executa uma busca local."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "Filtros opcionais podem ser colocado antes, depois ou intercalados com as palavras chaves de busca:"
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Restringir os resultados ao tipo de arquivo dado."
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Restringir os resultados ao tipo específico de extensão. (e.g. \\ I<iso>, I<mp3>)."
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Número mínimo de fontes que um resultado tem que reportar."
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Menor tamanho de arquivo a ser retornado. Os sufixos usam multiplicadores binários (K = 1024, M = K\\(mu1024, G = M\\(mu1024); sem sufixos significa bytes."
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Maior tamanho de arquivo a ser retornado. Mesmos sufixos que B<--min-size>."
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Exemplo: `earch global linux iso --type Iso --min-size 100M' retorna resultados para \\(lqlinux iso\\(rq do tipo de arquivo Iso com no mínimo 100 MiB."
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Configura um dado valor de preferência."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Ajusta a limitação de largura de banda."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Configura preferências de IPFilter."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Mostra a fila de upload/download, lista de servidores or lista de arquivos compartilhados."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Mostrar fila de download."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Mostrar o log."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Mostrar a lista de servidores."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Mostrar a lista de arquivos compartilhados."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Mostrar fila de upload."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Desliga o núcleo rodando remotamente (amule/amuled). Isto também desligará o cliente modo texto, já que este é inútil sem um núcleo rodando."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Mostra a árvore de estatísticas."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "O I<E<lt>numeroE<gt>> opcional na faixa de 0-255 pode ser passado como argumento para este comando, que diz quantas entradas da sub-árvore de versão do cliente deve ser mostrada. Passar 0 ou omitir significa `ilimitado'."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Exemplo: `statistics 5' vai mostrar apenas as 5 versões mais altas para cada tipo de cliente."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Mostrar o estado das conexões, velocidades atuais de upload/download, etc."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Línguas"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "O parâmetro I<E<lt>langE<gt>> da opção B<-l> tem a seguinte forma: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] onde I<lang> é a linguagem principal, I<LANG> é a sub-lingua/território, I<encoding> é o conjunto de caracteres a ser utilizado e I<modifier> permite ao usuário selecionar uma instância específica dos dados de localização dentro de uma única categoria."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Por exemplo, as seguintes strings são válidas:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Apesar de todas as strings acima serem aceitas como definições de línguas válidas, I<encoding> e I<modifier> não são utilizados ainda."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Além do formato acima, você pode também especificar nomes completos de linguagens em Inglês - deste modo B<-l german> também é válido e é igual a B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Quando nenhum local está definido, seja na linha de comando ou no arquivo de configuração, a linguagem padrão do sistema será utilizada."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLO"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Tipicamente, amulecmd será inicialmente rodado assim:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<nome do anfitrião> B<-p> I<porta EC> B<-P> I<senha EC> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "ou"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Estes savarão as configurações em I<$HOME/.aMule/remote.conf>, e posteriormente você só precisa digitar:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Claro, você não precisa seguir este exemplo."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - o cliente p2p eMule multi-platforma - versão daemonizada"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Bifurca para execução em pano de fundo."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>caminhoE<gt>>, B<--pid-file>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Após bifurcar, cria um arquivo pid no caminho I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> precisa conter o nome do arquivo."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Configura EC (Conexões Externas)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Habilida ou desabilita iniciar o amuled quando o usuário fizer login e então sair. O armazenamento específico do Sistema Operacional é selecionado automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a entrada XDG I<.desktop> autostart no Linux."
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - Programa de controle do aMule com IGU"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> é um programa cliente, e pode ser conectado ao aMule via EC. Você pode gerenciar seu programa aMule com ele. Ele provê quase as mesmas funcionalidades que o aMule, mesmo que o núcleo trabalhe em outro computador."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Pular o diálogo de conexão."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Habilita ou desabilita iniciar o amulegui quando o usuário fizer login e sair. O armazenamento específico do Sistema Operacional é selecionado automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a entrada XDG I<.desktop> autostart no Linux."
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Esta página man foi escrita por Julien Delange para o Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Esta página man foi reescrita por Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - servidor web de aMule"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>línguaE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>nomeE<gt>>] [B<-s> I<E<lt>portaE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portaE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>senhaE<gt>>] [B<-G> I<E<lt>senhaE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>caminhoE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr "B<DEPRECATED:> amuleweb está deprecado e pode ser removido no aMule 3.2 ou posterior. Não está removido ainda; considere migrar para amuleapi, que é a  API REST/SSE."
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> gerencia seu acesso ao aMule através de um navegador web. Você pode iniciar o amuleweb junto com o B<amule>(1), ou separadamente, a qualquer momento depois. As opções podem ser especificadas via linha de comando ou via arquivo de configuração. Opções de linha de comando têm precedência sobre opções de arquivo de configuração."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Carrega o template chamado I<E<lt>nomeE<gt>>. Veja a seção B<SKIN SUPPORT> para detalhes."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portaE<gt>>, B<--server-port>=I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Porta HTTP do servidor web. Esta é a porta para a qual você precisa apontar seu navegador web (padrão: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Habilita UPnP."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portaE<gt>>, B<--upnp-port> I<E<lt>portaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Porta UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Habilita o uso de compressão gzip em tráfego HTTP para poupar largura de banda."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Desabilita o uso de compressão gzip (este é o padrão)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>senhaE<gt>>, B<--admin-pass>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Senha de acesso total para o servidor web."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>senhaE<gt>>, B<--guest-pass>=I<E<lt>senhaE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Senha do convidado para o servidor web."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Permite acesso do convidado."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Nega acesso ao convidado (padrão)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Carrega/salva a configuração do servidor web de/para o aMule remoto. Isto faz com que o amuleweb ignore configurações de linha de comando e de arquivo de configuração, e as carrega do aMule. Quando estiver salvando as preferências, nenhuma será escrita no arquivo de configuração, e sim para o aMule. (Claro que isto funciona apenas para as configurações que podem ser configuradas nas Preferências-E<gt>Controles Remotos do aMule.)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Desabilitar o interpretador PHP (obsoleto)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompila as páginas PHP a cada pedido."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>caminhoE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Caminho do arquivo de configuração do aMule.  B<NÃO USE DIRETAMENTE!> aMule usa esta opção quando inicia o amuleweb na inicialização. Esta opção faz com que todas as outras opções de linha de comando e de arquivo de configuração sejam ignoradas, preferências sejam lidas do arquivo de configuração dado, e também impica na escolha das opções B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPORTE À PELES"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> é capaz de mostrar informação em peles diferentes. Estas peles são chamadas \"templates\", e você pode fazer o amuleweb carregar um template específico através da opção de linha de comando B<-t>. Templates são procurados em dois locais: primeiro em I<~/.aMule/webserver/> e depois em I</usr/share/amule/webserver/> se você instalou com --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Cada template precisa estar em um subdiretório do nome do template, e este diretório precisa conter todos os arquivos que o template necessita."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipicamente o amuleweb será rodado primeiro assim:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Claro que você pode especificar quaisquer opções a mais ou a menos na primeira linha de exemplo, e você pode também omiti-las totalmente."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule eD2k link parser v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - aMule eD2k link parser"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>caminhoE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-linkE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Manda o I<E<lt>link eD2kE<gt>> dado para o aMule, i.e. escreve ele no arquivo ~/.aMule/ED2KLinks, o qual será conferido pelo aMule a cada segundo para links novos."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Categoria de conjunto para links eD2k passados para I<E<lt>numE<gt>>. Ao contrário de B<--config-dir>, o parser lê os valores como o próximo argumento e não aceita a sintaxe B<--category>=I<E<lt>numE<gt>>."
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Carrega todos os links encontrados na emulecollection dada como I<E<lt>link ed2kE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Lista todos os links encontrados na emulecollection dada como I<E<lt>link ed2kE<gt>>"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ link eD2k ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Adiciona um link eD2k ao núcleo."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "um link magnético;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "um arquivo de emulecollection."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<A ordem na qual você dá os parâmetros é importante.> Você pode dar mais de um link, e todo link pode ter seus próprios parâmetros. Por exemplo B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> vai baixar I<E<lt>link1E<gt>> na categoria padrão e I<E<lt>link2E<gt>> na categoria 2."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - o criador de links eD2k do aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> é um utilitário gráfico para criar um link eD2k para qualquer arquivo em seu computador."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Esta aplicação não recebe argumentos."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "Calculador de links eD2k do aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - calculador de links eD2k do aMule modo texto (console)"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>lista_de_arquivos_de_entradaE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Calcula os links eD2k de todos os arquivos de entrada dados na I<E<lt>inputfiles_listE<gt>> (pode haver mais de um arquivo)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Calcula e soma hashes de parte aos links eD2k calculados."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Seja verboso - mostre também os passos de cálculo."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - estatísticas do aMule em C"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> é um programa para mostrar o conteúdo de seu arquivo de assinaturas online do aMule no console (em um formato legível para humanos). Para funcionar, você precisa habilitar a opção \"Assinatura Online\" nas preferências de aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Escreve a imagem da assinatura on-line. A forma longa B<--picture> aceita um parâmetro opcional I<=E<lt>PATHE<gt>> para especificar o local de saída; as formas curtas B<-o> / B<-P> não (B<-P> requer que imediatamente siga um argumento I<E<lt>PATHE<gt>>, e B<-o> é uma chave sem argumento). Requer suporte GD compilado em (I<__GD__>); esta opção é silenciosamente ignorada, caso contrário."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "Página HTML com estatísticas e imagem. A forma longa B<--html> aceita uma chave opcional I<=E<lt>PATHE<gt>> para especificar o local de saída; as formas curtas B<-p> / B<-H> não (B<-H> requer um argumento I<E<lt>PATHE<gt>> imediatamente seguinte, e B<-p> é uma chave sem argumentos)."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Sem opção alguma, ele imprime os dados da assinatura online em stdout."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> foi escrito por Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (or .jpg, quando B<-o> / B<--picture> for usado e GD estiver disponível)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (quando B<-p> / B<--html> for usado)"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - estatísticas do aMule em wx + C"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> é um programa para mostrar o conteúdo de seu arquivo de assinaturas online em uma bonita janela em seu Desktop.  Para funcionar, você precisa habilitar a opção \"Assinatura Online\" na preferências de aMule."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Baseado em B<cas>(1) de Pedro de Oliveira. B<wxcas> foi escrito por ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-ro.po
+++ b/docs/man/po/manpages-ro.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Romanian <kde-i18n-doc@kde.org>\n"
@@ -17,1382 +17,1373 @@ msgstr ""
 "X-Generator: Poedit 2.0.2\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "NUME"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - client eMule p2p pentru toate platformele"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "REZUMAT"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "DESCRIERE"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Citește configurarea din I<E<lt>pathE<gt>> în schimb de acasă"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Configurează geometria aplicației. I<E<lt>geomE<gt>> utilizează același format ca standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Tipărește jurnalul de mesaje la stdout."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Resetare configurări la valorile implicite."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Specificați locația fișierului binar amuleweb la I<E<lt>pathE<gt>>."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Nu dezactiva stdin."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Configurați categoria pentru link-urile eD2k trecute la I<E<lt>numE<gt>>"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Afișează numărul versiunii curente."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Tipărește o scurtă descriere de utilizare."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k-link ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Adaugă la nucleu o legătură eD2k sau o legătură magnet."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Link-ul eD2k de adăugat poate fi:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "un link fișier (ed2k://|file|...), va fi adăugat la coada descărcărilor;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "o legătură server (ed2k://|server|...), care va fi adăugată la lista serverelor;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "o legătură listă server, în care caz toate serverele din listă vor fi adăugate la lista serverelor;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "o legătură magnet."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTE"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Căi"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Pentru toate opțiunile care iau o I<E<lt>pathE<gt>> valoare, dacă I<path> nu conține nici o parte a unui director (ex. doar un nume de fișier simplu), atunci se consideră a fi sub directorul de configurare aMule, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "FIȘIERE"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "RAPORTAREA ERORILOR"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Vă rugăm să raportați erorile fie pe forumul  nostru(I<https://github.com/amule-org/amule/discussions>), sau în bugtracker-ul nostru (I<https://github.com/amule-org/amule/issues>). Nu raportați erorile pe email, nici la lista noastră de adrese nici direct la nici un membru al echipei."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "DREPT DE AUTOR"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule și toate utilitarele conexe sunt distribuite sub GNU General Public License."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "VEDEȚI ȘI"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTOR"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Această pagină manual a fost scrisă de Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "utilitare aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - Program bazat pe terminal pentru controlat aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> este un client bazat pe terminal pentru a controla aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Gazda unde rulează aMule (implicit: I<127.0.0.1>).  I<E<lt>hostE<gt>> ar putea fi o adresă IP sau un nume DNS"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Portul aMule pentru conexiuni externe, cum este configurat în Preferințe-E<gt>Control la distanță (implicit: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Parolă conexiuni externe."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Utilizează fișierul de configurare dat. Fișierul de configurare implicit este I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Nu tipării nici o ieșire la stdout."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Fi detaliat - arată și mesajele de depanare."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Configurați localizarea aplicației (limba). Vedeți secțiunea B<NOTES> pentru descrierea parametrului I<E<lt>langE<gt>> ."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Scrie opțiunile liniei de comandă în fișierul de configurare și ieși"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Execută I<E<lt>commandE<gt>> ca și cum ar fi fost introdusă în terminalul amulecmd și ieși."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Creează fișierul de configurare bazat pe I<E<lt>pathE<gt>>, care trebuie să indice la un fișier de configurare aMule valid, iar apoi ieși."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "COMENZI"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "toate comenzile nu sunt sensibile la majuscule."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Adaugă la nucleu o legătură eD2k sau o legătură magnet."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "un link listă server, în care caz toate serverele din listă vor fi adăugate la lista serverelor."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Legătura magnet trebuie să conțină indexul eD2k și lungimea fișierului."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Anulează descărcarea specificată de I<E<lt>hashE<gt>> sau I<E<lt>numberE<gt>>. Pentru a obține valoarea utilizați  B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Conectare la rețea."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Aceasta va conecta la toate rețelele care sunt activate în preferințe."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Cu parametrii facultativi puteți specifica la care rețea să se conecteze. Dând o adresă pentru server în forma IP:Port (unde IP este fie o adresă zecimală IPv4 sau un nume DNS rezolvabil) aMule se va conecta numai la acel server."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Deconectați de la toate rețelele la care sunteți conectat, sau doar deconectați de la rețeaua specificată."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Pornește descărcarea unui fișier."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Un I<E<lt>numberE<gt>> a unui fișier de la ultima căutare trebuie dat. Exemplu: `descărcarea 12' va porni descărcarea fișierului cu numărul 12 al căutării anterioare."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Deconectează de la amule/amuled și termină amulecmd."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Ia și afișează o valoare preferată."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Valori disponibile pentru I<E<lt>whatE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Ia limitele lățimii de bandă."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Ia preferințele filtrului IP."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Tipărește o scurtă descriere a utilizării. Dacă este adresată fără nici un parametru, va arăta o listă a comenzilor disponibile. Dacă este adresată cu I<E<lt>commandE<gt>>, va arăta o scurtă descriere a comenzii date."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Pauzează descărcarea specificată de I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. Pentru a obține valoarea utilizați B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Configurați prioritatea unei descărcări cu I<E<lt>hashE<gt>> sau I<E<lt>numberE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Valori disponibile pentru I<E<lt>priorityE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Prioritate automată."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Prioritate înaltă."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Prioritate scăzută."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Prioritate normală."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "Un sinonim a comenzii B<exit> ."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Reâncarcă un obiect dat."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Reâncarcă lista fișierelor partajate."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Reâncarcă tabelele filtrului IP."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Resetează jurnalul."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Reia descărcarea specificată de I<E<lt>hashE<gt>> sau I<E<lt>numberE<gt>>. Pentru a obține valoarea utilizați B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Face o căutare a cuvântului cheie dat I<E<lt>keywordE<gt>>. Un tip de căutare și un un cuvânt cheie sunt obligatorii pentru a face asta. Exemplu: `caută kad amule' efectuează o căutare kad pentru `amule'."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Tipuri de căutări disponibile:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Efectuează o căutare globală."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Efectuează o căutare în rețeaua Kademlia."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Efectuează o căutare locală."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Configurați o valoare a preferințelor date."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Configurare limite lățime de bandă."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Configurare preferințe filtru IP."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Arată coada încărcărilor/descărcărilor, lista serverelor sau lista fișierelor partajate."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Arată coada descărcărilor."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Arată jurnalul."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Arată lista serverelor."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Reload shared files list."
 msgid "Show shared files list."
 msgstr "Reâncarcă lista fișierelor partajate."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Arată coada încărcărilor."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Închide nucleul distant care rulează (amule/amuled). Aceasta va închide de asemenea clientul text, deoarece este inutilizabil fără un nucleu care rulează."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Arată arborele statisticilor."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Numărul facultativ I<E<lt>numberE<gt>> în domeniul 0-255 poate fi trecut ca argument la această comandă, care spune cât de multe intrări de subdiviziuni a versiunii clientului vor fi afișate. Trecând 0, sau lăsând gol va însemna `nelimitat'."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Exemplu: `statistici 5' va afișa numai primele 5 versiuni pentru fiecare tip de client."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Arată starea conexiunii, vitezele actuale de încărcare/descărcare, etc."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Limbi"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Parametrul I<E<lt>langE<gt>> pentru opțiunea B<-l> are următoarea formă: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] unde I<lang> este limba primară, I<LANG> este dialectul/teritoriul, I<encoding> este setul de caractere de utilizat iar I<modifier> permite utilizatorului de a specifica o instanță specifică a datelor localizării în cadrul unei singure categorii."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "De exemplu, următoarele șiruri sunt valide:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Deși toate șirurile de mai sus sunt acceptate ca definiții de limbă valide, I<encoding> și I<modifier> sunt momentan neutilizate."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "În completare la formatul de mai sus, puteți specifica și numele întreg al limbii în engleză - so B<-l german> este valid și  similar cu B<-l de_DE>."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Când nu este definită nici o limbă, în linia de comandă sau în fișierul de configurare, va fi utilizată limba implicită a sistemului de operare."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "EXEMPLU"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "De obicei amulecmd va rula întâi ca:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "sau"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Aceasta va salva configurările la I<$HOME/.aMule/remote.conf>, iar mai târziu trebuie doar să tastați:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Desigur, nu trebuie să urmați acest exemplu."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - clientul eMule p2p pentru toate platformele - versiunea demonizată"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Bifurcă spre fundal."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "După bifurcare, crează un fișier-pid în I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> trebuie să conțină numele fișierului."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Configurează EC (conexiuni externe)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - Controlul programului aMule prin GUI"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> este un program client și poate fi conectat la amule sau amuled prin EC. Puteți administra programul amule cu el. Asigură aproape aceleași funcțiuni ca amule, chiar dacă nucleul funcționează pe un alt computer."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Omite dialogul de conectare."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Această pagină manual a fost scrisă de către Julien Delange pentru Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Această pagină manual a fost revizuită de Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule server web"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>langE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>parolăE<gt>>] [B<-G> I<E<lt>parolăE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> vă administrează accesul la amule printr-un navigator web. Puteți porni amuleweb împreună cu B<amule>(1), sau separat, oricând mai târziu. Pot fi specificate opțiuni prin linia de comandă sau prin fișierul de configurare. Opțiunile din linia de comandă au prioritate față de opțiunile din fișierul de configurare."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Încarcă modelul denumit I<E<lt>nameE<gt>>. Vedeți secțiunea B<SKIN SUPPORT> pentru detalii."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Portul HTTP al serverului web. Acesta este portul pe care trebuie să-l indicați navigatorului (implicit: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Activare UPnP."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Port UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Activează utilizând compresia gzip în traficul HTTP pentru a salva lățimea de bandă."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Dezactivează utilizând compresia gzip (aceasta este implicita)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Parola pentru accesul nerestricționat pentru serverul web."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Parolă oaspete pentru webserver."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Permite accesul oaspeților."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Interzice accesul oaspeților (implicit)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Încarcă/Salvează configurările serverului web din/la aMule distant. Aceasta determină amuleweb să ignore configurările din linia de comandă sau fișierul de configurare și să le încarece din aMule. Când se salvează preferințele nu se va scrie nimic în fișierul de configurare, doar la aMule. (Desigur, aceasta funcționează doar pentru acele configurări care pot fi configurate în aMule la Preferințe-E<gt>Control la distanță.)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Dezactivează interpretorul PHP (învechit)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Recompilează paginile PHP la fiecare cerere."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Calea fișierului de configurare aMule. B<NU UTILIZAȚI DIRECT!> aMule utilizează această opțiune când pornește amuleweb la pornirea aMule. Această opțiune cauzează tuturor celorlalte configurări din linia de comandă și fișiere de configurare să fie ignorate, preferințele vor fi citite din fișierul de configurare dat, de asemenea implică și opțiunile B<-q -L> ."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "SUPORT ASPECT"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> este capabil să afișeze informația în diferite aspecte. Aceste aspecte se numesc modele, și puteți face ca amuleweb să încarce un model anumit prin B<-t> opțiune linie de comandă. Modelele sunt căutate în două locuri: întâi în I<~/.aMule/webserver/> apoi în I</usr/share/amule/webserver/> dacă a fost instalat cu --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Fiecare șablon trebuie să fie într-un subdirector al numelui șablonului, iar acest director trebuie să conțină toate fișierele de care șablonul are nevoie."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "De obicei amuleweb va rula la început ca:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<nume gazdă> B<-p> I<ECport> B<-P> I<ECprolă> B<-s> I<HTTPport> B<-A> I<Parolă administrator> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Desigur, puteți specifica cât de multe sau cât de puține opțiuni în linia primului exemplu, și de asemenea le puteți omite integral."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "Analizor aMule de link-uri eD2k v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - analizor aMule de linkuri eD2k"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-linkE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Trimite link-ul dat I<E<lt>eD2k-linkE<gt>> la aMule, ex. îl scrie în fișierul ~/.aMule/ED2KLinks, care va fi verificat de aMule în fiecare secundă pentru link-uri."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Loads all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Încarcă toate link-urile găsite în colecția emule date ca I<E<lt>ed2k-linkE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Lists all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Listează toate link-urile găsite în colecția emule date ca I<E<lt>ed2k-linkE<gt>>"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-link ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Adaugă o legătură eD2k la nucleu."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "o legătură magnet;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "un fișier colecție emule."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B< Ordinea în care dați parametrii este importantă.> Puteți da mai mult decât un link, iar fiecare link poate avea proprii parametri. De exemplu B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> va descărca I<E<lt>link1E<gt>> în categoria standard și I<E<lt>link2E<gt>> în categoria 2."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - creatorul aMule eD2k de legături"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> este un utilitar grafic care crează o legătură eD2k la orice fișier de pe computerul dumneavoastră."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Această aplicație nu ia nici un argument."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "Calculator de legături aMule eD2k"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - calculator link-uri eD2k bazat pe text pentru aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>inputfiles_listE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Calculează link_urile eD2k pentru toate fișierele de intrare date în I<E<lt>inputfiles_listE<gt>> (Poate fi unul sau mai multe fișiere)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Calculează și adaugă indexurile părților la legătura eD2k calculată."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Fi detaliat - arată, de asemenea, pașii de calcul."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c aMule statistici"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> este un program pentru afișarea conținutului fișierului semnătură online al aMule în terminal (într-o formă de citire umană). Pentru ca aceasta să lucreze, trebuie să activați opțiunea \"Semnătură online\" în preferințele aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Fără nici o opțiune, va tipării data semnăturii online la stdout."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> a fost scris de  Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c aMule statistici"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> este un program pentru afișarea conținutul fișierului de semnătură online într-o fereastră drăguță wx pe Desktop. Pentru ca aceasta să funcționeze, trebuie să activați opțiunea \"Semnătură online\" în preferințele aMule."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Bazat pe B<cas>(1) a lui Pedro de Oliveira. B<wxcas> a fost scris de ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-ru.po
+++ b/docs/man/po/manpages-ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-ru\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Russian <LL@li.org>\n"
@@ -19,1382 +19,1373 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "ИМЯ"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - мультиплатформенный p2p клиент eMule"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "ОБЗОР"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>путьE<gt>>] [B<-geometry> I<E<lt>геометрияE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>номерE<gt>>] [I<eD2k-ссылка>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "ОПИСАНИЕ"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>путьE<gt>>, B<--config-dir>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Прочитать конфигурацию из места, указанного в I<E<lt>путиE<gt>>, вместо домашнего каталога"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>геометрияE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Указать геометрию окна. I<E<lt>ГеометрияE<gt>> использует стандартный формат X11:\t[B<=>][I<E<lt>ширинаE<gt>>{B<xX>}I<E<lt>высотаE<gt>>][{B<+->}I<E<lt>смещениеXE<gt>>{B<+->}I<E<lt>смещениеYE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Печатает сообщения лога в стандартный вывод."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Сбрасывает конфигурацию в изначальную."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>путьE<gt>>, B<--use-amuleweb>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Указать I<E<lt>путьE<gt>> к исполняемому файлу amuleweb."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Не отключать стандартный ввод."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>номерE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "Указать I<E<lt>номерE<gt>> категории для eD2k ссылок"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Выводит информацию о версии."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Выводит короткую помощь по использованию."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k-ссылка ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Добавляет eD2k-ссылку или magnet-ссылку в ядро."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Добавляемая eD2k-ссылка может быть:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "файловая ссылка (ed2k://|file|...), она будет добавлена в очередь закачки;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "серверная ссылка (ed2k://|server|...), она будет добавлена в список серверов;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "ссылка на список серверов, тогда все сервера из списка будут добавлены в список серверов;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "magnet-ссылка."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "ЗАМЕЧАНИЯ"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Пути"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "Для всех опций, в которых указывается I<E<lt>путьE<gt>>, если I<путь> не содержит каталога (т.е. только имя самого файла), то предполагается, что файл находится в каталоге конфигурации, I<~/.aMule>."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "ФАЙЛЫ"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "СООБЩЕНИЕ ОБ ОШИБКАХ"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Пожалуйста, сообщайте об ошибках либо на нашем форуме (I<https://github.com/amule-org/amule/discussions>), либо в багтрекере (I<https://github.com/amule-org/amule/issues>). Пожалуйста, не сообщайте об ошбках по электронной почте, по нашим спискам рассылки, или напрямую участникам."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "АВТОРСКИЕ ПРАВА"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule и все прилагающиеся инструменты распространаются под Открытым Лицензионным Соглашением GNU (GNU GPL)."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "СМ. ТАКЖЕ"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "АВТОРЫ"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Автор страницы помощи: Vollstrecker E<lt>amule@vollstreckernet.deE<gt>, перевод: Radist Morse E<lt>radist.morse@gmail.comE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "утилиты aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - консольная программа для управления aMule"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>хостE<gt>>] [B<-p> I<E<lt>портE<gt>>] [B<-P> I<E<lt>парольE<gt>>] [B<-f> I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>языкE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>командаE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> консольный клиент для управления программой aMule."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>хостE<gt>>, B<--host>=I<E<lt>хостE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "Адрес компьютера на котором работает aMule (по умолчанию: I<127.0.0.1>). I<E<lt>ХостE<gt>> может быть IP-адресом или DNS-именем"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>портE<gt>>, B<--port>=I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "Порт, который использует aMule для внешних соединений. Указывается в Настройках-E<gt>Удаленное управление (по умолчанию: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>парольE<gt>>, B<--password>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Пароль для внешних соединений."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>путьE<gt>>, B<--config-file>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Использовать указанный файл конфигурации. По умолчанию используется I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Не печетать ничего в стандартный вывод."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Выводить также отладочную информацию."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>языкE<gt>>, B<--locale>=I<E<lt>языкE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Задать локаль (язык). См. секцию B<ЗАМЕЧАНИЯ> для дополнительной информации по параметру I<E<lt>языкE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Записать параметр командной строки в файл конфигурации и выйти"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>командаE<gt>>, B<--command>=I<E<lt>командаE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "Выполнить I<E<lt>командуE<gt>> как если бы она была введена в консоль amulecmd и выйти."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "Создать файл конфигурации на основе файла указанного в I<E<lt>путиE<gt>> и выйти. Указанный файл должен быть валидным файлом конфигурации aMule."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "КОМАНДЫ"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Все команды чувствительны к регистру."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Добавляет eD2k-ссылку или magnet-ссылку в ядро."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "ссылка на список серверов, в этом случае все серверы из списка будут добавлены в список серверов."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Magnet-ссылка должна содержать eD2k-хэш и размер файла."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Отменяет закачку указанную по I<E<lt>хэшуE<gt>> или I<E<lt>номеруE<gt>>. Чтобы определить значения, воспользуйтесь командой B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Подключиться к сети."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Это подсоединит ко всем сетям, включенным в настройках."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "С помощью дополнительного параметра можно указать сеть к которой будет произведено подключение. При указании адреса сервера в виде IP:Порт (где IP может быть либо цифровым представлением IPv4 либо DNS-именем) aMule подключится только к этому серверу."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Отсоединяет от всех сетей, или только от указанной сети."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Начать закачку файла."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Должен быть указан I<E<lt>номерE<gt>> файла в последнем поиске.  Пример: `download 12' поставит на закачку файл, который был под номером 12 в последнем поиске."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "Отключится от amule/amuled и выйти из amulecmd."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Вывести параметр настроек."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "Возможные значения поля I<E<lt>параметрE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Вывести ограничения канала."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "Вывести настройки IPFilter."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Вывести короткую справку. Если вызвана без параметров, выводит список возможных команд. Если вызвана с параметром I<E<lt>командаE<gt>>, показывает справку по данной команде."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Ставит на паузу закачку указанную по I<E<lt>хэшуE<gt>> или I<E<lt>номеруE<gt>>. Чтобы определить значения, воспользуйтесь командой B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "Указывает приоритет закачки указанной по I<E<lt>хэшуE<gt>> или I<E<lt>номеруE<gt>>."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "Возможные значения I<E<lt>приоритетаE<gt>>:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Автоматический приоритет."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Высокий приоритет."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Низкий приоритет."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Нормальный приоритет."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "То же что и B<exit>."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Обновляет указанный объект."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Обновляет список публикуемых файлов."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "Обновляет таблицы IP фильтра."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Обнуляет лог."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "Возобновляет закачку указанную по I<E<lt>хэшуE<gt>> или I<E<lt>номеруE<gt>>. Чтобы определить значения, воспользуйтесь командой B<show>."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Производит поиск по указанному I<E<lt>словуE<gt>>. Указание типа и слова обязательны. Пример: `search kad amule' производит поиск по kad по слову `amule'."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Возможные типы поиска:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Глобальный поиск."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Поиск по сети kademlia."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Локальный поиск."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Задает указанный параметр."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Задает ограничения канала."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "Задает параметры IPFilter."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "Выводит очередь закачки/отдачи, список серверов или опубликованные файлы."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "Выводит очередь закачки."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Выводит лог."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Выводит список серверов."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Reload shared files list."
 msgid "Show shared files list."
 msgstr "Обновляет список публикуемых файлов."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Выводит список отдачи."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Завершает работу ядра (amule/amuled). Так же завершает работу amulecmd, т.к. он бесполезен без работающего ядра."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "Выводит дерево статистики."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "Параметр I<E<lt>числоE<gt>> может быть в промежутке 0-255, и будет показывать сколько элементов показывать в под-дереве `версия клиента'. Указание 0 или пропуск означает `неограниченно'."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Пример: `statistics 5' покажет только 5 наиболее популярных версий для каждого типа клиента."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Вывести статус соединения, скорости, итд."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Языки"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "Параметр I<E<lt>языкE<gt>> для опции B<-l> имеет следующую форму: I<язык>[B<_>I<ЯЗЫК>][B<.>I<кодировка>][B<@>I<модификатор>], где I<язык> является основным языком, I<ЯЗЫК> - диалект/территория, I<кодировка> - используемая кодировка символов и I<модификатор> позволяет пользователю использовать определенный вариант локализации в данной категории."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "К примеру, все следующие строчки являются приемлемыми:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Хотя все приведенный строки будут приняты, поля I<кодировка> и I<модификатор> пока не используются."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "К дополнению к приведенному формату, можно просто указать английское имя языка. Так, B<-l russian> тоже приемлемо и равносильно B<-l ru_RU>."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Когда язык не указан ни в качестве опции ни в файле конфигурации, используется системный."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ПРИМЕРЫ"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Как правило, в первый раз amulecmd запускается так:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<имя_хоста> B<-p> I<EC_порт> B<-P> I<EC_пароль> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "или"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Это сохранит параметры в I<$HOME/.aMule/remote.conf>, и в дальнейшем надо будет только набрать:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Конечно, вы не обязаны следовать этим рекомендациям."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "Демон aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "Демон aMule"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - мультиплатформенный p2p клиент eMule - демонизированная версия"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Уйти в фоновый режим."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>путьE<gt>>, B<--pid-file>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "После запуска создать pid-файл по указанному I<E<lt>путиE<gt>>. I<E<lt>ПутьE<gt>> должен указывать на файл."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "Сконфигурировать EC (внешние соединения)."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>имяE<gt>>, B<--template>=I<E<lt>имяE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - программа управления aMule с GUI"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>номерE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "Программа B<amulegui> позволяет управлять ядром (amule/amuled) по протоколу EC. Программа предоставляет функциональность почти идентичную amule, несмотря на то что ядро может работать на другом компьютере."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Пропустить диалог соединения."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Автор страницы помощи (для Debian): Julien Delange E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Переработка страницы помощи: Vollstrecker E<lt>amule@vollstreckernet.deE<gt>, перевод: Radist Morse E<lt>radist.morse@gmail.comE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "Вебсервер aMule v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - вебсервер aMule"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>языкE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>имяE<gt>>] [B<-s> I<E<lt>портE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>портE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>парольE<gt>>] [B<-G> I<E<lt>парольE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>путьE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> организует доступ к amule через веб браузер. Вы можете запустить amuleweb вместе с B<amule>(1), или отдельно позже. Настройки могут быть определены с помощью командной строки или файла конфигурации. Опции командной строки являются приоритетными по отношению к файлу конфигурации."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>имяE<gt>>, B<--template>=I<E<lt>имяE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Устанавливает шаблон с указанным I<E<lt>именемE<gt>>. Подробности в секции B<ПОДДЕРЖКА СКИНОВ>."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>портE<gt>>, B<--server-port>=I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "HTTP порт вебсервера. Этот порт должен быть указан в строке адреса браузера (по умолчанию: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "Включить UPnP."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>портE<gt>>, B<--upnp-port> I<E<lt>портE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "Порт UPnP."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Включает использование gzip-сжатия HTTP данных для уменьшения трафика."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Отключает использование gzip-сжатия (вариант по умолчанию)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>парольE<gt>>, B<--admin-pass>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Пароль для полного доступа к вебсерверу."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>парольE<gt>>, B<--guest-pass>=I<E<lt>парольE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Пароль для гостевого доступа к вебсерверу."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Разрешить гостевой доступ."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Запретить гостевой доступ (вариант по умолчанию)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Загрузить/сохранить настройки вебсервера из/в удаленный aMule. Это приводит к игнорированию параметров командной строки и конфигурационного файла, и загрузки их из aMule. При сохранении настроек они будут писаться не в файл конфигурации, а в aMule. (Конечно, работает только для настроек которые могут быть заданы через меню Настройки-E<gt>Удаленный контроль)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Отключить интерпретатор PHP (устарело)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "Перекомпилирует страницы PHP при каждом обращении."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>путьE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "Путь к файлу конфигурации aMule. B<НЕ ИСПОЛЬЗУЙТЕ НАПРЯМУЮ!> aMule использует данную опцию для запуска amuleweb вместе с amule. Эта опция приводит к игнорированию параметров командной строки и конфигурационного файла, настройки читаются из заданного файла. Также подразумеваются опции B<-q -L>."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "ПОДДЕРЖКА СКИНОВ"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> имеет возможность отображать информацию с разными скинами. Эти скины называются шаблонами, и вы можете переключить amuleweb на определенный шаблон использую опцию B<-t> командной строки. Шаблоны ищутся в двух местах: первое I<~/.aMule/webserver/>, затем I</usr/share/amule/webserver/>, если инсталяция была проведена с --prefix=/usr."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Каждый шаблон должен являться каталогом с именем шаблона, и все необходимые файлы должны находится внутри этого каталога."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Как правило, в первый раз amuleweb запускается так:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<имя_хоста> B<-p> I<EC_порт> B<-P> I<EC_пароль> B<-s> I<HTTP_порт> B<-A> I<пароль_полного_доступа> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Конечно, вы можете указать иное количество аргументов в первой строке примера, или не использовать ее вообще."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule парсер ссылок eD2k v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - aMule парсер ссылок eD2k"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>путьE<gt>>] [B<-t> I<E<lt>числоE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-ссылкаE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Пысылает указанную I<E<lt>eD2k-ссылкуE<gt>> в aMule, т.е. пишет ее в файл ~/.aMule/ED2KLinks, который проверяется каждую секунду."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>имяE<gt>>, B<--template>=I<E<lt>имяE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Loads all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Загружает все ссылки из emulecollection как I<E<lt>ed2k-ссылкиE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Lists all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "Перечисляет все ссылки из emulecollection как I<E<lt>ed2k-ссылкиE<gt>>"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-ссылка ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Передает eD2k-ссылку в ядро."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "magnet-ссылка;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "файл emulecollection."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<Порядок параметров важен.> Вы можете указать более одной ссылки, и каждая ссылка может иметь свои собственные параметры. Например B<ed2k E<lt>ссылка1E<gt> -t2 E<lt>ссылка2E<gt>> загрузит I<E<lt>ссылку1E<gt>> в стандартную категорию и I<E<lt>ссылку2E<gt>> в категорию 2."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - создатель eD2k-ссылок aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> - графическая утилита, которая создает eD2k-ссылку для любого файла на вашем компьютере."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Утилита не принимает параметров."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule калькулятор eD2k-ссылок"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - текстовый калькулятор eD2k-ссылок для aMule"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>список_файловE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "Вычисляет eD2k-ссылки для всех файлов указанных в I<E<lt>списке_файловE<gt>> (Может быть один или более файлов)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Вычисляет и добавляет частичные хэши к вычисленным eD2k-ссылкам."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Показать подробности - показывает также шаги вычислений."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c-статистика aMule"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> - программа для отображения содержимого файла вашей онлайн-подписи aMule на консоль (в читаемой форме). Чтобы это работало, вы должны включить опцию \"Онлайн подпись\" в настройках aMule."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Без опций программа выведет данные о подписи в стандартный вывод."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> был написан Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c-статистика aMule"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> - программа для отображения содержимого файла вашей онлайн-подписи aMule в приятном wx Window окне на вашем рабочем столе. Чтобы это работало, вы должны включить опцию \"Онлайн подпись\" в настройках aMule."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Основана на программе B<cas>(1) написанной Pedro de Oliveira. B<wxcas> была написана ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages-tr.po
+++ b/docs/man/po/manpages-tr.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: \n"
@@ -16,1369 +16,1360 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "İSİM"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - her platformda çalışan eMule p2p istemcisi"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "KULLANIM"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>yolE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>sayıE<gt>>] [I<eD2k-bağlantısı>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "AÇIKLAMA"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>yolE<gt>>, B<--config-dir>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "Yapılandırmayı home yerine I<E<lt>yolE<gt>>dan oku"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "Uygulamanın geometrisini düzenler. I<E<lt>geomE<gt>> standart X11 uygulamaları ile aynı biçimi kullanır:\t[B<=>][I<E<lt>genişlikE<gt>>{B<xX>}I<E<lt>yükseklikE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "Günlük mesajlarını standart çıktıya gönderir."
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "Yapılandırmayı varsayılan değerlere sıfırlar."
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Kullanıcı oturum açtığında aMule'ün başlatılmasını etkinleştirir veya devre dışı bırakır.  İşletim sistemine has depo otomatik olarak seçilir: Windows için kayıt defteri (registry) Çalıştırma anahtarı, macOS için LaunchAgent, GNU/Linux için XDG I<.desktop> otomatik başlatma unsuru."
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>yolE<gt>>, B<--use-amuleweb>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "amuleweb çalıştırılabilir dosyasının konumunu I<E<lt>yolE<gt>> olarak belirler."
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr "Ölümcül istisnaları yakalama ve doğrulamalarda çıkmayı engellemez.  Otomatik yeniden başlatmayı engelleyen, normalde modal olan onay diyalog kutusunun bulunmadığı, başsız/denetimli kurulumlar (systemd, watchdog betikleri) için kullanışlıdır."
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "Standart girdiyi (stdin) devre dışı bırakmaz."
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>sayıE<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "I<E<lt>sayıE<gt>>ya gönderilen eD2k bağlantılarının kategorilerini belirler"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "Geçerli sürüm numarasını görüntüler."
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "Kısa bir kullanım açıklaması görüntüler."
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k-bağlantısı ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "Çekirdeğe bir eD2k ya da magnet bağlantısı ekler."
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "Eklenecek eD2k bağlantısı şunlardan biri olabilir:"
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "bir dosya bağlantısı (ed2k://|file|...) ki indirmeler kuyruğuna eklenir;"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "bir sunucu bağlantısı (ed2k://|server|...) ki sunucu listesine eklenir;"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "bir sunucu listesi bağlantısı, bu durumda listedeki tüm sunucular sunucu listesine eklenir;"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "bir magnet bağlantısı."
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "NOTLAR"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "Yollar"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "I<E<lt>yolE<gt>> değeri alan  tüm seçenekler için eğer I<yol> hiçbir dizin içermiyorsa (yani sadece bir dosya ismiyse) aMule yapılandırma dizini (I<~/.aMule>) varsayılır."
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "DOSYALAR"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "GERİBİLDİRİM"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "Hataları bildirmek için forumumuzu (I<https://github.com/amule-org/amule/discussions>) ya da hata takipçimizi (I<https://github.com/amule-org/amule/issues>) kullanınız. Hataları bildirmek için e-mail ve e-mail listemizi kullanmamanızı ve geliştiricilerden birine doğrudan bildirmemenizi rica ederiz."
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "TELİF HAKKI"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule ve ilgili tüm yardımcı araçları GNU Genel Kamu Lisansı çerçevesinde dağıtılmaktadır."
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "İLGİLİ BELGELER"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "YAZAN"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Bu kılavuz sayfası Vollstrecker E<lt>amule@vollstreckernet.deE<gt> tarafından yazılmıştır"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "aMule yardımcı araçları"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - aMule'ü yönetmek için konsol temelli bir program"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>sunucuE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>şifreE<gt>>] [B<-f> I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>dilE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>komutE<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> aMule'ü yönetmek için konsol temelli bir programdır."
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>sunucuE<gt>>, B<--host>=I<E<lt>sunucuE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "aMule'ün çalıştığı sunucu ya da bilgisayar (varsayılan: I<127.0.0.1>). I<E<lt>sunucuE<gt>> bir IP adresi ya da DNS ismi olabilir"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule'ün dışarıya bağlandığında kullandığı port, Ayarlar-E<gt>Uzak Denetimler seçeneğinde belirlenir (varsayılan: I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>şifreE<gt>>, B<--password>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "Dışarıdan kurulan bağlantılar için şifre."
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>yolE<gt>>, B<--config-file>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "Belirtilen yapılandırma dosyasını kullanır. Varsayılan yapılandırma dosyası şudur: I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "Standart çıktıya hiçbir veri yazdırmaz."
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "Geveze olur - debug mesajlarını da gösterir."
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>dilE<gt>>, B<--locale>=I<E<lt>dilE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "Programın kullandığı dili belirler. I<E<lt>dilE<gt>> parametresinin tanımlaması için B<NOTLAR> bölümüne bakınız."
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "Komut satırı seçeneklerini yapılandırma dosyasına yazıp çıkar"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>komutE<gt>>, B<--command>=I<E<lt>komutE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "I<E<lt>komutE<gt>>u amulecmd'ın komut istemine girilmiş gibi çalıştırır ve çıkar."
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "I<E<lt>yolE<gt>>a dayalı yapılandırma dosyası yaratır ve çıkar. Yolun geçerli bir aMule dosyasına işaret etmesi gerekir."
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Seçilen IP adresinin konumuna bakılmaksızın Harici Bağlantı için ZLIB sıkıştırmasını zorlar.  Sunucuya, bir LAN IP adresine çözümlenen VPN tüneli üzerinden erişilebildiğinde ve aksi takdirde sezgisel algoritmanın sıkıştırmayı atlayacağı durumlarda kullanışlıdır."
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "KOMUTLAR"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "Tüm komutlar harf büyüklüğüne duyarsızdır."
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "Çekirdeğe bir eD2k ya da magnet bağlantısı ekler."
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "bir sunucu listesi bağlantısı, bu durumda listedeki tüm sunucular sunucu listesine eklenir."
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "Magnet bağlantısı eD2k hash değerini ve dosya boyutunu içermelidir."
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "I<E<lt>hashE<gt>> ya da I<E<lt>sayıE<gt>> tarafından belirtilen indirmeyi iptal eder. Değerleri öğrenmek için B<show> komutunu kullanınız."
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "Ağa bağlanır."
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "Ayarlarda ekinleştirilmiş tüm ağlara bağlanır."
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "Ek bir parametreyle hangi ağa bağlanmak istediğinizi belirtebilirsiniz. IP:port şeklinde (IP ya noktalarla ayrılmış ondalık bir IPv4 adresi ya da çözümlenebilen bir DNS ismi olmalıdır) bir sunucu adresi verirseniz aMule sadece bu sunucuya bağlanacaktır."
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "Ya çevrimiçi olan tüm ağlarla bağlantıyı keser, ya da sadece belirtilen ağ ile."
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "Bir dosyayı indirmeye başlar."
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "Bir dosyanın son aramadan I<E<lt>sayıE<gt>> değeri girilmesi gerekir. Örneğin `download 12' son aramadaki 12 numaralı dosyayı indirmeye başlar."
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "amule/amuled ile bağlantıyı keser ve amulecmd kapanır."
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "Bir ayar değerini görüntüler."
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "I<E<lt>değerE<gt>> ile kullanılabilecek değerler:"
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "Bant genişliği değerlerini görüntüler."
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "IPFilter ayarlarını görüntüler."
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "Kısa bir kullanım açıklaması görüntüler. Bir parametre ile kullanılırsa mevcut komutların listesini verir. I<E<lt>komutE<gt>> ile kullanılırsa belirtilen komutun kısa bir açıklamasını görüntüler."
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "I<E<lt>hashE<gt>> ya da I<E<lt>sayıE<gt>> değerleri ile belirtilen indirmeyi duraklatır. Bu değerleri elde etmek için B<show> komutunu kullanabilirsiniz."
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "I<E<lt>hashE<gt>> ya da I<E<lt>sayıE<gt>> ile belirtilen bir indirmenin önceliğini ayarlar."
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "I<E<lt>öncelikE<gt>> için kullanılabilecek değerler:"
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "Otomatik öncelik."
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "Yüksek öncelik."
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "Düşük öncelik."
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "Normal öncelik."
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr "Devam etmekte olan bir aramanın ilerleyişini gösterir. Seçime dayalı olarak bir arama  I<E<lt>idE<gt>> yani kimliği alır (B<search> tarafından gösterileceği üzere); kimlik yoksa en son başlatılan aramayı gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr "B<exit> komutu ile eş anlamlıdır."
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "Belirtilen değeri yeniden yükler."
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "Paylaşılan dosyalar listesini yeniden yükler."
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "IP filtre tablolarını yeniden yükler."
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "Günlüğü sıfırlar."
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr "Size bir aramanın sonuçlarını gösterir. Seçime dayalı olarak bir arama  I<E<lt>idE<gt>> yani kimliği alır (B<search> tarafından gösterileceği üzere); kimlik yoksa en son başlatılan aramayı gösterir.  Aynı anda birden fazla arama çekirdekte muhafaza edilebilir ve kimlikleriyle hedef alınabilir."
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "I<E<lt>hashE<gt>> ya da I<E<lt>sayıE<gt>> ile belirtilen indirmeye kaldığı yerden devam eder. Değeri öğrenmek için B<show> komutunu kullanabilirsiniz."
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "Girilen I<E<lt>anahtarkelimeE<gt>> için bir arama yapar. Bir arama türü ve bir anahtar kelime kullanmanız mecburidir. Örneğin `search kad amule' kad ağında `amule' sözcüğü ile arama yapar.  Bir arama kimliği görüntüler; bu aramayı hedef almak için onu B<results> veya B<progress> ile kullanın. Birden fazla arama aynı anda çalışabilir, her biri kendi kimliğine sahip olur."
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "Kullanılabilecek arama türleri:"
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "Genel arama yapar."
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "Kad ağında arama yapar."
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "Sunucuda arama yapar."
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr "Seçime dayalı filtreler arama kelimelerinden evvel, sonra veya onların arasında konumlandırılabilir:"
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr "Sonuçları belirtilen dosya türüyle snırla."
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr "Sonuçları belli bir dosya uzantısı ile sınırla (mesela \\ I<iso>, I<mp3>)."
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr "Bir sonucun bildirmesi gereken asgari kaynak sayısı."
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr "Geri gönderilecek asgari dosya boyutu. Uzantılar ikili çarpanlar kullanır  (K = 1024, M = K\\(mu1024, G = M\\(mu1024); uzantı yoksa bayt anlamına gelir."
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr "Geri gönderilecek azami dosya boyutu. B<--min-size> ile aynı uzantılar geçerlidir."
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr "Örnek: `search global linux iso --type Iso --min-size 100M', \\(lqlinux iso\\(rq için asgari 100 MiB boyutunda ve Iso dosya türünde sonuçlar geri gönderir."
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "Belirtilen değeri ayarlara girer."
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "Bant genişliği değerlerini ayarlar."
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "IPFilter tercihlerini ayarlar."
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "İndirme/aktarma kuyruğunu, sunucu listesini ya da paylaşılan dosya listesini gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "İndirme kuyruğunu gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "Günlüğü (log) gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "Sunucu listesini gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr "Paylaşılan dosyalar listesini göster."
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "Aktarma (gönderilen dosyalar) kuyruğunu gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "Uzakta çalışmakta olan çekirdeği (amule/amuled) kapatır. Bu metin temelli istemciyi de kapatacaktır çünkü çekirdek olmadan işleyemez."
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "İstatistikler ağacını gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "0-255 arası I<E<lt>sayıE<gt>> isteğe bağlı argüman olarak komuta aktarılabilir, bu kaç tane istemci sürümü alt ağacının gösterileceğini belirtir. 0 kullanımı ya da hiçbir argüman kullanılmaması `sınırsız' anlamına gelir."
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "Örneğin `statistics 5' her istemcinin en çok kullanılan 5 sürümünü gösterir."
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "Bağlantı durumunu, sürmekte olan indirmeleri ve aktarmaları vs. gösterir."
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "Diller"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "B<-l> seçeneği için I<E<lt>dilE<gt>> parametresi şu biçimde kullanılmalıdır: I<dil>[B<_>I<DİL>][B<.>I<kodlama>][B<@>I<niteleyici>] ki burada I<dil> birinci dil, I<DİL> lehçe/bölge, I<kodlama> karakter setidir ve I<niteleyici> kullanıcıya belli bir kategori içinde belli yerelleştirme verileri kullanma olanağı sağlar."
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "Örnek olarak, aşağıdaki dizeler geçerlidir:"
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "Yukarıdaki tüm dizeler geçerlidir ancak I<kodlama> ve I<niteleyici> henüz kullanılmamaktadır."
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "Yukarıdakilere ek olarak dil isimlerini İngilizce olarak belirtebilirsiniz - yani B<-l german> ile B<-l de_DE> eşdeğerdir ve ikisi de geçerlidir."
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "Ne komut satırında ne de yapılandırma dosyasında hiçbir dil belirtilmediği zaman sistemin varsayılan dili kullanılacaktır."
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "ÖRNEK"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "Tipik olarak amulecmd ilk defada şu şekilde başlayacaktır:"
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<bilgisayaradı> B<-p> I<DBport> B<-P> I<DBşifre> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "ya da"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/kullanıcıadı/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "Ayarları I<$HOME/.aMule/remote.conf> dosyasına kayıt eder ve daha sonra sadece şunu girmeniz yeterli olacaktır:"
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "Tabii ki bu örneğe harfiyen uymanız zorunlu değildir."
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - her platformda çalışan eMule p2p istemcisi - daemon sürümü"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "Kendisini arkaplana çatallar."
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>yolE<gt>>, B<--pid-file>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "Çatallamadan sonra I<E<lt>yolE<gt>> konumunda bir pid-file dosyası yaratır. I<E<lt>yolE<gt>>un dosya ismini içermesi gerekir."
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "DB (Dış Bağlantılar) Kurulumu."
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Kullanıcı oturum açtığında amuled'nin başlatılmasını etkinleştirir veya devre dışı bırakır.  İşletim sistemine has depo otomatik olarak seçilir: Windows için kayıt defteri (registry) Çalıştırma anahtarı, macOS için LaunchAgent, GNU/Linux için XDG I<.desktop> otomatik başlatma unsuru."
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - Grafik arayüzlü aMule yönetme programı"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>sayıE<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> istemci bir programdır ve amule ya da amuled'e DB yoluyla bağlanabilir. aMule'ü bu şekilde yönetebilirsiniz. Çekirdeğin başka bir bilgisayarda çalışmasına rağmen amule'ün neredeyse tüm işlevlerine erişim sağlar."
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "Bağlantı diyaloğunu geç."
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr "Kullanıcı oturum açtığında amulegui'nin başlatılmasını etkinleştirir veya devre dışı bırakır.  İşletim sistemine has depo otomatik olarak seçilir: Windows için kayıt defteri (registry) Çalıştırma anahtarı, macOS için LaunchAgent, GNU/Linux için XDG I<.desktop> otomatik başlatma unsuru."
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "Bu man sayfası Debian için Julien Delange E<lt>julien AT gunnm DOT orgE<gt> tarafından yazılmıştır"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "Bu kılavuz sayfası Vollstrecker E<lt>amule@vollstreckernet.deE<gt> tarafından yeniden yazılmıştır"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule web sunucusu"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>dilE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>isimE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>portE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>şifreE<gt>>] [B<-G> I<E<lt>şifreE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>yolE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr "B<DEPRECATED:> amuleweb eskimiş olarak kabul edilir ve aMule 3.2 veya daha sonraki bir sürümde kaldırılabilecektir.  Henüz kaldırılmamıştır; REST/SSE API'sı olan amuleapi'ya geçiş yapmayı değerlendirin."
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> amule'e bir ağ tarayıcısı ile erişmenize olanak sağlar. amuleweb'i amule ile aynı anda ya da ayrı olarak, daha sonra ne zaman isterseniz başlatabilirsiniz. Seçenekleri komut satırı ya da yapılandırma dosyası ile belirtmek mümkündür. Komut satırı ile belirtilen seçenekler yapılandırma dosyası ile belirtilenlerden daha yüksek önceliklidir."
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>isimE<gt>>, B<--template>=I<E<lt>isimE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "Adı I<E<lt>isimE<gt>> olan şablonu yükler. Ayrıntılar için B<TEMA DESTEĞİ> bölümüne bakınız."
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "Web sunucusunun HTTP portu. Bu ağ tarayıcınızda kullanmanız gereken port numarasıdır (varsayılan: I<4711>)."
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "UPnP'yi etkinleştirir."
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "UPnP port numarası."
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "Bant genişliğinden tasarruf etmek için gzip sıkıştırmasını etkinleştirir."
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "Gzip sıkıştırmasını devre dışı bırakır (bu varsayılan değerdir)."
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>şifreE<gt>>, B<--admin-pass>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "Sunucuya tam erişim için şifre (parola)."
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>şifreE<gt>>, B<--guest-pass>=I<E<lt>şifreE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "Web sunucusu için misafir şifresi."
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "Misafir erişimini etkinleştirir."
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "Misafir erişimine izin vermez (varsayılan değer)."
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "Web sunucusu ayarlarını uzaktaki aMule'den/aMule'e yükler/kaydeder. Bu amuleweb'in komut satırı ve yapılandırma dosyası ayarlarını görmezden gelmesine yol açar. Ayarlar kaydedilirken hiçbiri yapılandırma dosyasına yazılmaz, aMule'e yazılır. (Tabii ki bu sadece aMule'ün Ayarlar-E<gt>Uzak Denetiminde kurulabilen değerler için geçerlidir.)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP yorumlayıcısını devre dışı bırakır (eskimiş)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "PHP sayfalarını her sorguda yeniden derler."
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>yolE<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule yapılandırma dosyasına erişim yolu.  B<DOĞRUDAN KULLANMAYIN!> aMule bu seçeneği amuleweb'i aMule ile başlatırken kullanır.  Bu seçenek diğer tüm komut satırı ve yapılandırma dosyası ayarlarının görmezden gelinmesine, ayarların verilen yapılandırma dosyasından okunmasına yol açar ve B<-q -L> seçeneklerinin kullanılacağı anlamına da gelir."
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "TEMA DESTEĞİ"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> bilgileri çeşitli temalarda görüntüleyebilir. Bu temalara şablon adı verilir ve amuleweb'in belli bir şablonu yüklemesini B<-t> komut satırı seçeneği ile sağlayabilirsiniz. Şablonlar iki konumda aranır: önce I<~/.aMule/webserver/> konumunda, sonra da, kurulum --prefix=/usr ile yapıldıysa I</usr/share/amule/webserver/> konumunda."
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "Her şablonun şablon isminin alt dizininde bulunması gerekir ve bu dizinin şablonun ihtiyaç duyduğu tüm dosyaları bulundurması şarttır."
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "Tipik olarak amuleweb ilk defada şu şekilde başlayacaktır:"
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<hostismi> B<-p> I<DBport> B<-P> I<DBşifresi> B<-s> I<HTTPport> B<-A> I<AdminŞifresi> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/kullanıcıadı/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "Tabii ki ilk örnek satırında daha az ya da fazla seçenek belirtebilirsiniz, hatta onu tamamen görmezden gelebilirsiniz."
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule eD2k bağlantı çözümleyicisi v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - aMule eD2k bağlantı çözümleyicisi"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>yolE<gt>>] [B<-t> I<E<lt>sayıE<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k-bağlantısıE<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "Herhangi bir I<E<lt>eD2k-bağlantısınıE<gt>> aMule'e gönderir, yani onu ~/.aMule/ED2KLinks dosyasına yazar ki bu dosya aMule tarafından her saniye bağlantılar için sorgulanır."
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr "Kategori belirler, I<E<lt>numE<gt>> unsuruna aktarılan eD2k bağlantıları için.   B<--config-dir> aksine, ayrıştırıcı değeri sonraki argüman olarak okur ve B<--category>=I<E<lt>numE<gt>> söz dizimini kabul etmez."
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "I<E<lt>ed2k-bağlantısıE<gt>> olarak aktarılan bir emule koleksiyonunda bulunan tüm bağlantıları yükler"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "I<E<lt>ed2k-bağlantısıE<gt>> olarak aktarılan bir emule koleksiyonunda bulunan tüm bağlantıları listeler"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k-bağlantısı ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "Çekirdeğe bir eD2k bağlantısı ekler."
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "bir magnet bağlantısı;"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "bir emulecollection dosyası."
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<Parametrelerin giriş sırası önemlidir.> Birden fazla bağlantı girebilirsiniz ve her bağlantının kendine özel parametreleri olabilir. Örneğin B<ed2k E<lt>bağlantı1E<gt> -t2 E<lt>bağlantı2E<gt>> I<E<lt>bağlantı1E<gt>> dosyasını standart kategoriye ve I<E<lt>bağlantı2E<gt>> dosyasını ikinci kategoriye indirecektir."
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - aMule eD2k bağlantı yaratıcısı"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> bilgisayarınızdaki herhangi bir dosya için eD2k bağlantısı yaratabilen grafik arayüzlü bir araçtır."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "Bu uygulama hiçbir argüman almaz."
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule eD2k bağlantı hesaplayıcısı"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - aMule için metin temelli eD2k bağlantı hesaplayıcısı"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>girdidosya_listesiE<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "I<E<lt>girdidosya_listesiE<gt>>nde girilen tüm dosyaların eD2k bağlantılarını hesaplar (bir ya da birden fazla dosya olabilir)."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "Bölümler için hash değerlerini hesaplar ve eD2k bağlantılarına ekler."
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "Geveze olur - hesap adımlarını da gösterir."
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - c aMule istatistikleri"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> çevrimiçi aMule imza dosyanızı konsolda (insanların okuyabileceği bir şekilde) görüntülemeye yarayan bir programdır. Bunun çalışması için aMule'ün ayarlarında \"Çevrim İçi İmza\" seçeneğini etkinleştirmeniz gerekmektedir."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr "Çevrim içi imza resmini yazar.  Uzun biçimli B<--picture> çıktı konumunu belirtmek için seçime dayalı bir I<=E<lt>YOLE<gt>> kabul eder, kısa biçimli B<-o> / B<-P> kendisini hemen izleyen bir I<E<lt>YOLE<gt>> argümanı gerektirmez (B<-P> ve B<-o> argümansız bir seçenektir.   (I<__GD__>) içinde derlenmiş GD desteğine ihtiyaç duyar; aksi takdirde bu seçenek sessizce görmezden gelinir."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr "İstatistikler ve resim içeren HTML sayfası.  Uzun biçimli B<--html> çıktı konumunu belirtmek için seçime dayalı bir I<=E<lt>YOLE<gt>> kabul eder, kısa biçimli B<-p> / B<-H> kendisini hemen izleyen bir I<E<lt>YOLE<gt>> argümanı gerektirmez (B<-H> ve B<-p> argümansız bir seçenektir."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "Hiçbir seçenek belirtilmediği zaman çevrimiçi imzayı standart çıktıda yazar."
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt> tarafından yazılmıştır"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr "aMule-online-sign.png (veya .jpg, B<-o> / B<--picture>kullanıldığında ve GD mevcut olduğunda)"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr "aMule-online-sign.html (B<-p> / B<--html> kullanıldığında)"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - wx c aMule istatistikleri"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> çevrimiçi imzanızın içeriklerini güzel bir wx penceresinde görüntüler. Bunun çalışması için aMule'ün ayarlarında \"Çevrim İçi İmza\" seçeneğini etkinleştirmeniz gerekmektedir."
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "Pedro de Oliveira'nın B<cas>(1) programına dayalıdır. B<wxcas> ThePolish E<lt>thepolish@vipmail.ruE<gt> tarafından yazılmıştır"
 

--- a/docs/man/po/manpages-zh_TW.po
+++ b/docs/man/po/manpages-zh_TW.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule Manual zh_TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 15:00+0200\n"
+"POT-Creation-Date: 2026-07-28 21:54+0200\n"
 "PO-Revision-Date: 2026-07-28 16:31+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -24,1382 +24,1373 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr "AMULE"
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr "@MAN_DATE@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr "aMule v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr "aMule"
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr "名稱"
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr "amule - 跨平台的 eMule P2P 客戶端程式"
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "簡介"
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr "[B<-c> I<E<lt>路徑E<gt>>] [B<-geometry> I<E<lt>視窗狀態E<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr "[B<-w> I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>]"
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr "[B<-t> I<E<lt>號碼E<gt>>] [I<eD2k 連結>]"
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr "說明"
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>路徑E<gt>>, B<--config-dir>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr "從 I<E<lt>pathE<gt>> 讀取設定檔，而不是個人目錄"
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr "B<[ -geometry >I<E<lt>視窗狀態E<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr "設定這個應用程式的視窗狀態。I<E<lt>視窗狀態E<gt>> 使用和 X11 應用程式一樣的格式：\t[B<=>][I<E<lt>寬度E<gt>>{B<xX>}I<E<lt>高度E<gt>>][{B<+->}I<E<lt>X 偏移E<gt>>{B<+->}I<E<lt>Y 偏移E<gt>>]"
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr "將程式記錄顯示在標準輸出。"
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr "將設定重設為預設值。"
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -w> I<E<lt>路徑E<gt>>, B<--use-amuleweb>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "設定 amuleweb 的執行檔位置在 I<E<lt>路徑E<gt>>。"
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr "不停用標準輸入。"
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t>, B<--category>=I<E<lt>號碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr "給輸入成功的 eD2k 連結分類編號為 I<E<lt>號碼E<gt>>"
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr "顯示目前的版本號碼。"
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr "顯示簡短的使用說明。"
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ eD2k-link ]>"
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr "B<[ eD2k 連結 ]>"
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 #, fuzzy
 #| msgid "Adds an eD2k-link or a magnet-link to the core."
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr "將 eD2k 連結或 magnet 加到核心。"
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr "可以使用以下幾種 eD2k 連結："
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr "檔案連結 (ed2k://|file|...)，會將檔案加入下載等候區；"
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr "伺服器連結 (ed2k://|server|...)，會將伺服器加入 aMule 的伺服器清單；"
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr "伺服器清單連結，在清單內的伺服器會被加入 aMule 的伺服器清單；"
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr "magnet 連結。"
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr "附註"
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr "路徑"
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr "對於有 I<E<lt>路徑E<gt>> 的選項，如果 I<路徑> 裏面沒有含目錄 (即只有單純檔名)，則會被認為是在 aMule 的設定檔所在目錄 I<~/.aMule> 下。"
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr "檔案"
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr "~/.aMule/*"
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr "回報問題"
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr "請到我們的論壇 (I<https://github.com/amule-org/amule/discussions>) 或錯誤追蹤網站 (I<https://github.com/amule-org/amule/issues>) 回報發現的問題。請不要用 e-mail 或在我們的群組信件中回報，也不要直接通知某個團隊成員。"
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "版權"
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr "aMule 與附加的工具程式都遵守 GNU 的 GPL 協定。"
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "參考"
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr "作者"
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "說明文件撰寫者： Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr "AMULECMD"
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr "aMuleCmd v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr "aMule 的工具程式"
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr "amulecmd - 終端機模式下控制 aMule 的程式"
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr "[B<-h> I<E<lt>主機E<gt>>] [B<-p> I<E<lt>通訊埠E<gt>>] [B<-P> I<E<lt>密碼E<gt>>] [B<-f> I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr "[B<-l> I<E<lt>語言E<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>指令E<gt>>]B< >}"
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--create-config-from>=I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr "B<amulecmd> 是終端機模式下控制 aMule 的的客戶端程式。"
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr "B<[ -h> I<E<lt>主機E<gt>>, B<--host>=I<E<lt>主機E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr "正在執行 aMule 核心的主機 (預設：I<127.0.0.1>)， I<E<lt>主機E<gt>> 可以是 IP 位址或網域名稱"
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>通訊埠E<gt>>, B<--port>=I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr "aMule 外部連線用的通訊埠，在 偏好設定 E<gt>  遠端控制 設定 (預設：I<4712>)"
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr "B<[ -P> I<E<lt>密碼E<gt>>, B<--password>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr "外部連線密碼。"
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -f> I<E<lt>路徑E<gt>>, B<--config-file>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr "使用指定的設定檔，預設是 I<~/.aMule/remote.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr "不將任何資訊顯示在標準輸出。"
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr "詳細模式 - 也顯示除錯訊息。"
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr "B<[ -l> I<E<lt>語言E<gt>>, B<--locale>=I<E<lt>語言E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr "設定程式的語系 (語言)。請看 B<附註> 章節裏關於 I<E<lt>語言E<gt>> 參數的說明。"
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr "將命令列選項寫入設定檔後離開"
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr "B<[ -c> I<E<lt>指令E<gt>>, B<--command>=I<E<lt>指令E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr "像在 amulecmd 的命令列模式下一樣，執行 I<E<lt>指令E<gt>> 後離開。"
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --create-config-from>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr "參考 I<E<lt>pathE<gt>> 裏的資料來建立設定檔後離開。(I<E<lt>pathE<gt>> 裏必須有有效的 aMule 設定檔)"
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr "指令"
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr "所有指令都不分大小寫。"
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr "將 eD2k 連結或 magnet 加到核心。"
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr "伺服器清單，所有在這個清單內的伺服器都會被加到 aMule 的伺服器清單。"
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr "magnet 連結裏必須包含 eD2k 的 hash 值和檔案大小。"
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "取消下載指定的檔案，指定方式：I<E<lt>hash 值E<gt>> 或 I<E<lt>編號E<gt>>；要查詢數值請用 B<show>。"
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr "連線到網路。"
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr "這樣將會連線到在偏好設定中啟用的所有網路。"
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr "用這個選項參數，你可以指定要連線到哪個網路：用「IP:port」格式指定伺服器的位址 (IP 可以用有小數點的十進位 IPv4 網址，或是可從 DNS 轉換的網域名稱)，aMule 就會只連線到那個伺服器。"
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr "中斷所有已連線的網路，或只中斷指定的網路連線。"
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr "開始下載檔案。"
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr "I<E<lt>編號E<gt>> 指上次搜尋檔案時的結果。例如：「download 12」會下載上次搜尋時編號 12 的檔案。"
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr "始 amule/amuled 斷線，並離開 amulecmd。"
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr "取得並顯示某個偏好設定的值。"
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr "I<E<lt>目標E<gt>> 參數可用的值："
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr "取得頻寬限制。"
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr "取得 IP 過濾器的偏好設定。"
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr "顯示使用說明。如果沒有加參數，會顯示可用的指令一覽；如果加了 I<E<lt>指令E<gt>> 參數，會顯示該指令的簡單說明。"
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "暫停下載指定的檔案，指定方式：I<E<lt>hash 值E<gt>> 或 I<E<lt>編號E<gt>>；要查詢數值請用 B<show>。"
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr "用 I<E<lt>hash 值E<gt>> 或 I<E<lt>編號E<gt>> 設定下載檔案的優先程度。"
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr "可用在 I<E<lt>優先度E<gt>> 的參數："
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr "自動優先權。"
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr "高優先權。"
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr "低優先權。"
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr "一般優先權。"
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "功能和 B<exit> 一樣的指令。"
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr "重新載入指定的物件。"
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr "重新載入分享檔案清單。"
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr "重新載入 IP 過濾器資料。"
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr "清除記錄。"
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr "繼續下載指定的檔案，指定方式：I<E<lt>hash 值E<gt>> 或 I<E<lt>編號E<gt>>；要查詢數值請用 B<show>。"
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'."
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr "用指定的 I<E<lt>關鍵字E<gt>> 搜尋。必須要有搜尋的「種類」加上「關鍵字」，例如：「search kad amule」會開始在 KAD 網路搜尋「amule」。"
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr "可用的搜尋類型："
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr "開始在全球伺服器搜尋。"
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr "開始在 Kad 搜尋。"
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr "開始在本地伺服器搜尋。"
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr "設定指定的偏好設定值。"
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr "設定頻寬限制。"
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr "設定 IP過濾器的偏好設定。"
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr "顯示 上傳/下載 等候區、伺服器清單 或 分享檔案清單。"
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr "顯示下載等候區。"
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr "顯示記錄。"
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr "顯示伺服器清單。"
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 #, fuzzy
 #| msgid "Reload shared files list."
 msgid "Show shared files list."
 msgstr "重新載入分享檔案清單。"
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr "顯示上傳等候區。"
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr "關閉在遠端執行的核心 (amule/amuled)。這樣也會關閉文字模式客戶端程式，因為不能在沒有核心下執行。"
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr "顯示統計資訊。"
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr "I<E<lt>編號E<gt>> 是這個指令的參數之一，用來指定要顯示多少個客戶端程式的版本附加版本；須為 0-255 的數字，輸入 0 或略過不輸入則表示「不限」。"
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr "範例：「statistics 5」只會顯示每個客戶端種類的前 5 個版本。"
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr "顯示 連線狀態、目前的上傳/下載速度 等等。"
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr "語言"
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr "B<-l> 選項的 I<E<lt>語系E<gt>> 參數有以下幾種樣式：I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>]。其中：I<lang> 是主要的語系代碼，I<LANG> 是語系次分類、使用地區代碼，I<encoding> 是使用的編碼，I<modifier> 則讓使用者用一個代號就指定一組語系設定。例如：「zh_TW.UTF-8@Taiwan」"
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr "例如，以下的字串都有效："
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr "雖然上面這些都是合於規定的語系設定參數，但 I<encoding> 和 I<modifier> 目前已經沒在使用了。"
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr "你也可以使用完整的英文名稱來設定語系，例如：B<-l german> 也等於 B<-l de_DE>。"
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr "沒有在命令列或設定檔中設定語系時，會使用系統預設語言。"
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr "~/.aMule/remote.conf"
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "範例"
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr "通常 amulecmd 會優先以這樣執行："
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr "B<amulecmd> B<-h> I<主機名稱> B<-p> I<外部連線通訊埠> B<-P> I<外部連線密碼> B<-w>"
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr "或"
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr "這樣就會將設定儲存到 I<$HOME/.aMule/remote.conf>，然後你只需要再輸入："
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr "當然，你可以不必都遵照這個範例。"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr "AMULED"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr "aMule Daemon v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr "aMule Daemon"
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr "amuled - 跨平台的 eMule P2P 客戶端程式 背景常駐程式版"
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr "[B<-c> I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr "[B<-p> I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr "在背景開啟新程式。"
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ -p> I<E<lt>路徑E<gt>>, B<--pid-file>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr "開啟新程式後，在 I<E<lt>路徑E<gt>> 下建立 pid 檔案。I<E<lt>路徑E<gt>> 裏必須有檔案名稱。"
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr "設定 EC (外部連線)。"
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>名稱E<gt>>, B<--template>=I<E<lt>名稱E<gt>> B<]>"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr "AMULEGUI"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr "aMuleGUI v@PACKAGE_VERSION@"
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr "aMuleGUI"
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr "amulegui - 圖形介面的 aMule 控制程式"
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-t> I<E<lt>號碼E<gt>>]"
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr "B<amulegui> 是個客戶端程式，可以經由外部連線和 amule 或 amuled 連線，可以用它來管理 amule 程式。甚至就算核心程式是在別台電腦上執行時，它也能提供和 amule 幾乎一樣的功能。"
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr "跳過連線對話。"
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr "說明文件撰寫者： Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr "說明文件撰寫者： Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr "AMULEWEB"
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr "aMule webserver v@PACKAGE_VERSION@"
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr "amuleweb - aMule 網頁伺服器"
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr "[B<-l> I<E<lt>語言E<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr "[B<-t> I<E<lt>名稱E<gt>>] [B<-s> I<E<lt>通訊埠tE<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr "[B<-U> I<E<lt>通訊埠E<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr "[B<-A> I<E<lt>密碼E<gt>>] [B<-G> I<E<lt>密碼E<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr "[B<--amule-config-file>=I<E<lt>路徑E<gt>>]"
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr "B<amuleweb> 可以經由網頁瀏覽器來管理 amule。你可以和 B<amule>(1) 一起執行 amuleweb，也可以稍候再另外執行。可以在命令列或是用用設定檔指定參數，命令列參數會優先於設定檔的參數。"
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>名稱E<gt>>, B<--template>=I<E<lt>名稱E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr "載入 I<E<lt>名稱E<gt>> 這個模板。詳細請參考 B<外觀面板支援> 章節。"
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -s> I<E<lt>通訊埠E<gt>>, B<--server-port>=I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr "網頁伺服器的 HTTP 連接埠：要用瀏覽器連線時必須加以指定 (預設：I<4711>)。"
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr "啟用 UPnP。"
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>通訊埠E<gt>>, B<--upnp-port> I<E<lt>通訊埠E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr "UPnP 通訊埠。"
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr "在 HTTP 傳輸時啟用 gzip 壓縮以節省頻寬。"
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr "停用 gzip 壓縮 (這是預設值)。"
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -A> I<E<lt>密碼E<gt>>, B<--admin-pass>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr "網站伺服器的完整存取密碼。"
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr "B<[ -G> I<E<lt>密碼E<gt>>, B<--guest-pass>=I<E<lt>密碼E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr "網站伺服器的訪客密碼。"
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr "允許訪客連線。"
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr "禁止訪客連線 (預設)。"
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr "從遠端的 aMule 載入網頁伺服器設定/將設定儲存到遠端。這個會使 amuleweb 忽略命令列與設定檔內的設定、並從遠端載入新設定；儲存時則只會寫入遠端 aMule 的設定。(當然，只限於 aMule 的 偏好設定 E<gt> 遠端控制 裏的幾個設定項目)"
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "停用 PHP 解譯器 (不建議)"
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr "爲每個要求重編譯 PHP 頁面。"
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr "B<[ --amule-config-file>=I<E<lt>路徑E<gt>> B<]>"
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr "aMule 設定擋路徑。B<請不要直接使用！>這個選項會導致原有命令列和設定檔的設定都被忽略都被忽略。 啟動 aMule 後在開啟 amuleweb 時會用這個選項，從指定的設定檔讀取偏好設定，並自行加上 B<-q -L> 選項。"
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr "外觀面板支援"
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr "B<amuleweb> 可以用不同的外觀面板顯示資訊；這些面板稱為「模板」，你可以用在命令列用 B<-t> 選項讓 amuleweb 載入指定的模板。程式會在兩個地方搜尋模板：先從 I<~/.aMule/webserver/>，然後如果是用 --prefix=/usr 安裝程式，就會再到 I</usr/share/amule/webserver/> 搜尋。"
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr "每個模板都必須被放在以該模板名稱命名的子目錄下，這個目錄裏也必須包含所有模板需要的檔案。"
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr "~/.aMule/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr "I<$(pkgdatadir)>/webserver/"
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr "通常 amuleweb 會優先以這樣執行："
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr "B<amuleweb> B<-h> I<主機名稱> B<-p> I<外部連線通訊埠> B<-P> I<外部連線密碼> B<-s> I<HTTP 通訊埠> B<-A> I<管理者密碼> B<-w>"
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr "當然，你可以指定比第一行範例裏更多或更少的選項，甚至您也可以完全不使用。"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr "ED2K"
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr "aMule 的 eD2k 連結分析程式 v1.5.1"
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr "ed2k - aMule 的 eD2k 連結分析程式"
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr "[B<-c> I<E<lt>路徑E<gt>>] [B<-t> I<E<lt>號碼E<gt>>]"
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr "I<E<lt>eD2k 連結E<gt>>"
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr "將指定的 I<E<lt>eD2k 連結E<gt>> 傳送給 aMule，會寫入 aMule 隨時都在檢查有無新增連結的 ~/.aMule/ED2KLinks 檔案裏。"
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, fuzzy, no-wrap
 #| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>名稱E<gt>>, B<--template>=I<E<lt>名稱E<gt>> B<]>"
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Loads all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "載入所有以 I<E<lt>eD2k 連結E<gt>> 方式指定的 eMule 收藏庫裏找到的連結"
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 #, fuzzy
 #| msgid "Lists all link found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr "列出所有以 I<E<lt>eD2k 連結E<gt>> 方式指定的 eMule 收藏庫裏找到的連結"
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr "B<[ eD2k 連結 ]>"
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr "將 eD2k 連結加到核心。"
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr "magnet 連結；"
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr "eMule 收藏庫檔案。"
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr "B<指定參數時的順序很重要。>你可以指定兩個以上的連結、每個連結都有自己的參數。例如：B<ed2k E<lt>連結一E<gt> -t2 E<lt>連結二E<gt>> 會將 I<E<lt>連結一E<gt>> 放在「預設分類」、將 I<E<lt>連結二E<gt>> 放在「分類2」。"
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr "~/.aMule/ED2KLinks"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr "ALC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr "aLinkCreator"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr "aLinkCreator - aMule 的 eD2k 連結建立程式"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr "B<alc> 是可以用來建立你電腦上任何檔案的 eD2k 連結的圖形介面工具程式。"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr "這個應用程式不接受任何引數。"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr "ALCC"
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr "aMule 的 eD2k 連結計算程式"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr "alcc - aMule 的文字介面 eD2k 連結計算程式"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr "I<E<lt>i輸入檔案清單E<gt>>"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr "計算 I<E<lt>輸入檔案清單E<gt>> 裏所有檔案的 eD2k 連結。(可接受一個或多個檔案)"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr "計算並將暫存檔 hash 值新增到已計算好的 eD2k 連結裏。"
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr "詳細模式 - 也顯示計算的過程。"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr "CAS"
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr "cas v0.8"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr "cas - 以 C 語言撰寫的 aMule 統計資訊程式"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<cas> 是可以在終端機界面以人類可閱讀的形式顯示你的 aMule 線上簽名識別檔的程式。要使用這個功能，你必須在偏好設定裏啟用「線上簽名識別」。"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr "如果沒有選項，會在標準輸出顯示線上簽名識別。"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr "B<cas> 的作者：Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr "~/.aMule/casrc"
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr "WXCAS"
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr "wxCas"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr "wxcas - 以 C 語言、wxWidgets 撰寫的 aMule 統計資訊程式"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr "B<wxcas> 是可以在桌面以更佳的 wx 視窗顯示你的 aMule 線上簽名識別檔的程式。要使用這個功能，你必須在偏好設定裏啟用「線上簽名識別」。"
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr "改寫自 Pedro de Oliveira 的 B<cas>(1)， B<wxcas>的作者：ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 

--- a/docs/man/po/manpages.pot
+++ b/docs/man/po/manpages.pot
@@ -5,1366 +5,1357 @@
 #
 #, fuzzy
 msgid ""
-msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-07-27 15:00+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
+msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-07-28 21:55+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "AMULE"
 msgstr ""
 
 #. type: TH
-#: amule.1.in:1 amulecmd.1.in:1 amuled.1.in:1 amulegui.1.in:1 amuleweb.1.in:1
-#: ed2k.1.in:1 ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "@MAN_DATE@"
 msgstr ""
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule v@PACKAGE_VERSION@"
 msgstr ""
 
 #. type: TH
-#: amule.1.in:1
+#: amule.1.in
 #, no-wrap
 msgid "aMule"
 msgstr ""
 
 #. type: SH
-#: amule.1.in:4 amulecmd.1.in:5 amuled.1.in:4 amulegui.1.in:4 amuleweb.1.in:4
-#: ed2k.1.in:4 ../../src/utils/aLinkCreator/docs/alc.1.in:3
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:4
-#: ../../src/utils/cas/docs/cas.1.in:4 ../../src/utils/wxCas/docs/wxcas.1.in:3
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "NAME"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:6
+#: amule.1.in
 msgid "amule - the all-platform eMule p2p client"
 msgstr ""
 
 #. type: SH
-#: amule.1.in:6 amulecmd.1.in:7 amuled.1.in:6 amulegui.1.in:6 amuleweb.1.in:6
-#: ed2k.1.in:6 ../../src/utils/aLinkCreator/docs/alc.1.in:5
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
-#: ../../src/utils/cas/docs/cas.1.in:6 ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:10 amulegui.1.in:10
+#: amule.1.in amulegui.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-geometry> I<E<lt>geomE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:14 amuled.1.in:16
+#: amule.1.in amuled.1.in
 msgid "[B<-w> I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:18 amuled.1.in:20
+#: amule.1.in amuled.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>] [I<eD2k-link>|I<collection-file>]"
 msgstr ""
 
 #. type: SH
-#: amule.1.in:25 amulecmd.1.in:26 amuled.1.in:26 amulegui.1.in:23
-#: amuleweb.1.in:41 ed2k.1.in:19 ../../src/utils/aLinkCreator/docs/alc.1.in:7
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:14
-#: ../../src/utils/cas/docs/cas.1.in:14 ../../src/utils/wxCas/docs/wxcas.1.in:7
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "DESCRIPTION"
 msgstr ""
 
 #. type: TP
-#: amule.1.in:26 amuled.1.in:27 amulegui.1.in:27 ed2k.1.in:21
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>pathE<gt>>, B<--config-dir>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:29 amuled.1.in:30 amulegui.1.in:30 ed2k.1.in:24
-#: ../../src/utils/cas/docs/cas.1.in:30
+#: amule.1.in amuled.1.in amulegui.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Read config from I<E<lt>pathE<gt>> instead of home"
 msgstr ""
 
 #. type: TP
-#: amule.1.in:29 amulegui.1.in:30
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -geometry >I<E<lt>geomE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:32 amulegui.1.in:33
+#: amule.1.in amulegui.1.in
 msgid "Sets the geometry of the app. I<E<lt>geomE<gt>> uses the same format as standard X11 apps:\t[B<=>][I<E<lt>widthE<gt>>{B<xX>}I<E<lt>heightE<gt>>][{B<+->}I<E<lt>xoffsetE<gt>>{B<+->}I<E<lt>yoffsetE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:35 amuled.1.in:43 amulegui.1.in:36
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Prints log messages to stdout."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:38 amuled.1.in:46 amulegui.1.in:39
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Resets config to default values."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:42
+#: amule.1.in
 msgid "Enable or disable starting aMule on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:42 amuled.1.in:50
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ -w> I<E<lt>pathE<gt>>, B<--use-amuleweb>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:45 amuled.1.in:53
+#: amule.1.in amuled.1.in
 msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:50 amuled.1.in:58 amulegui.1.in:51
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Don't catch fatal exceptions and don't block exit on assertions.  Useful for headless / supervised setups (systemd, watchdog scripts)  where the otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:53 amuled.1.in:61 amulegui.1.in:54
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Does not disable stdin."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:53 amulegui.1.in:54
+#: amule.1.in amulegui.1.in
 #, no-wrap
 msgid "B<[ -t>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:56 amuled.1.in:64 amulegui.1.in:57
+#: amule.1.in amuled.1.in amulegui.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:59 amulecmd.1.in:70 amuled.1.in:67 amulegui.1.in:63
-#: amuleweb.1.in:134 ed2k.1.in:40
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
 msgid "Displays the current version number."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:62 amulecmd.1.in:73 amuled.1.in:70 amulegui.1.in:60
-#: amuleweb.1.in:131 ed2k.1.in:37
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:22
-#: ../../src/utils/cas/docs/cas.1.in:33
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Prints a short usage description."
 msgstr ""
 
 #. type: TP
-#: amule.1.in:62 amuled.1.in:70
+#: amule.1.in amuled.1.in
 #, no-wrap
 msgid "B<[ eD2k-link | collection-file ]>"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:65 amuled.1.in:73
+#: amule.1.in amuled.1.in
 msgid "Adds an eD2k-link, or every link in an eMule collection file, to the core."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:67 amulecmd.1.in:79 amuled.1.in:75 ed2k.1.in:45
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "The eD2k link to be added can be:"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:70 amulecmd.1.in:82 amuled.1.in:78 ed2k.1.in:48
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a file link (ed2k://|file|...), it will be added to the download queue;"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:72 amulecmd.1.in:84 amuled.1.in:80 ed2k.1.in:50
+#: amule.1.in amulecmd.1.in amuled.1.in ed2k.1.in
 msgid "a server link (ed2k://|server|...), it will be added to the server list;"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:74 amuled.1.in:82 ed2k.1.in:52
+#: amule.1.in amuled.1.in ed2k.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list;"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:76 amuled.1.in:84
+#: amule.1.in amuled.1.in
 msgid "a magnet link."
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:82 amuled.1.in:90
+#: amule.1.in amuled.1.in
 msgid "Alternatively the argument can be the path to an .emulecollection file, or a file:// URL naming one, in which case every link it contains is added to the download queue.  This is what lets a file manager open a collection with aMule."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:82 amulecmd.1.in:238 amuleweb.1.in:140
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "NOTES"
 msgstr ""
 
 #. type: SS
-#: amule.1.in:83 amulecmd.1.in:239 amuleweb.1.in:141
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Paths"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:87 amulecmd.1.in:243 amuleweb.1.in:145
+#: amule.1.in amulecmd.1.in amuleweb.1.in
 msgid "For all options which take a I<E<lt>pathE<gt>> value, if the I<path> contains no directory part (i.e. just a plain filename), then it is considered to be under the aMule configuration directory, I<~/.aMule>."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:87 amulecmd.1.in:271 amuled.1.in:90 amuleweb.1.in:179
-#: ed2k.1.in:61 ../../src/utils/cas/docs/cas.1.in:37
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "FILES"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:89 amuled.1.in:92
+#: amule.1.in amuled.1.in
 msgid "~/.aMule/*"
 msgstr ""
 
 #. type: SH
-#: amule.1.in:89 amulecmd.1.in:287 amuled.1.in:92 amulegui.1.in:63
-#: amuleweb.1.in:199 ed2k.1.in:63 ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
-#: ../../src/utils/cas/docs/cas.1.in:43
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "REPORTING BUGS"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Please report bugs either on our forum (I<https://github.com/amule-org/amule/discussions>), or in our bugtracker (I<https://github.com/amule-org/amule/issues>).  Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:92 amulecmd.1.in:290 amuled.1.in:95 amulegui.1.in:66
-#: amuleweb.1.in:202 ed2k.1.in:66 ../../src/utils/aLinkCreator/docs/alc.1.in:14
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:29
-#: ../../src/utils/cas/docs/cas.1.in:46
-#: ../../src/utils/wxCas/docs/wxcas.1.in:19
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "aMule and all of its related utilities are distributed under the GNU General Public License."
 msgstr ""
 
 #. type: SH
-#: amule.1.in:94 amulecmd.1.in:292 amuled.1.in:97 amulegui.1.in:68
-#: amuleweb.1.in:204 ed2k.1.in:68 ../../src/utils/aLinkCreator/docs/alc.1.in:16
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:31
-#: ../../src/utils/cas/docs/cas.1.in:48
-#: ../../src/utils/wxCas/docs/wxcas.1.in:21
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "SEE ALSO"
 msgstr ""
 
 #. type: SH
-#: amule.1.in:96 amulecmd.1.in:294 amuled.1.in:99 amulegui.1.in:70
-#: amuleweb.1.in:206 ed2k.1.in:70 ../../src/utils/aLinkCreator/docs/alc.1.in:18
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:33
-#: ../../src/utils/cas/docs/cas.1.in:50
-#: ../../src/utils/wxCas/docs/wxcas.1.in:23
+#: amule.1.in amulecmd.1.in amuled.1.in amulegui.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "AUTHOR"
 msgstr ""
 
 #. type: Plain text
-#: amule.1.in:97 amulecmd.1.in:295 amuled.1.in:100 amuleweb.1.in:207
-#: ed2k.1.in:71 ../../src/utils/aLinkCreator/docs/alc.1.in:19
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:34
-#: ../../src/utils/cas/docs/cas.1.in:51
-#: ../../src/utils/wxCas/docs/wxcas.1.in:24
+#: amule.1.in amulecmd.1.in amuled.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This manpage was written by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr ""
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "AMULECMD"
 msgstr ""
 
 #. type: TH
-#: amulecmd.1.in:1
+#: amulecmd.1.in
 #, no-wrap
 msgid "aMuleCmd v@PACKAGE_VERSION@"
 msgstr ""
 
 #. type: TH
-#: amulecmd.1.in:1 amuleweb.1.in:1 ed2k.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
-#: ../../src/utils/cas/docs/cas.1.in:1 ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: amulecmd.1.in amuleweb.1.in ed2k.1.in
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
+#: ../../src/utils/cas/docs/cas.1.in ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "aMule utilities"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:7
+#: amulecmd.1.in
 msgid "amulecmd - Console-based program to control aMule"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:13 amuleweb.1.in:12
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<-h> I<E<lt>hostE<gt>>] [B<-p> I<E<lt>portE<gt>>] [B<-P> I<E<lt>passwordE<gt>>] [B<-f> I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:17
+#: amulecmd.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>] {B< >[B<-w>]B< >|B< >[B<-c> I<E<lt>commandE<gt>>]B< >}"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:20 amuleweb.1.in:31
+#: amulecmd.1.in amuleweb.1.in
 msgid "[B<--create-config-from>=I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:29
+#: amulecmd.1.in
 msgid "B<amulecmd> is a console-based client to control aMule."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:29 amuleweb.1.in:50
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -h> I<E<lt>hostE<gt>>, B<--host>=I<E<lt>hostE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 msgid "Host where aMule is running (default: I<127.0.0.1>).  I<E<lt>hostE<gt>> might be an IP address or a DNS name"
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:33 amuleweb.1.in:54
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>portE<gt>>, B<--port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 msgid "aMule's port for External Connections, as set in Preferences-E<gt>Remote Controls (default: I<4712>)"
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:36 amuleweb.1.in:57
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -P> I<E<lt>passwordE<gt>>, B<--password>=I<E<lt>passwordE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 msgid "External Connections password."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:39 amuleweb.1.in:60
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -f> I<E<lt>pathE<gt>>, B<--config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:43 amuleweb.1.in:64
+#: amulecmd.1.in amuleweb.1.in
 msgid "Use the given configuration file.  Default configuration file is I<~/.aMule/remote.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:46 amuleweb.1.in:67
+#: amulecmd.1.in amuleweb.1.in
 msgid "Do not print any output to stdout."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:50 amuleweb.1.in:71
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ -l> I<E<lt>langE<gt>>, B<--locale>=I<E<lt>langE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:54 amuleweb.1.in:75
+#: amulecmd.1.in amuleweb.1.in
 msgid "Sets program locale (language).  See the B<NOTES> section for the description of the I<E<lt>langE<gt>> parameter."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:57 amuleweb.1.in:78
+#: amulecmd.1.in amuleweb.1.in
 msgid "Write command line options to config file and exit"
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:57
+#: amulecmd.1.in
 #, no-wrap
 msgid "B<[ -c> I<E<lt>commandE<gt>>, B<--command>=I<E<lt>commandE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:60
+#: amulecmd.1.in
 msgid "Execute I<E<lt>commandE<gt>> as if it was entered at amulecmd's prompt and exit."
 msgstr ""
 
 #. type: TP
-#: amulecmd.1.in:60 amuleweb.1.in:121
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "B<[ --create-config-from>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:63 amuleweb.1.in:124
+#: amulecmd.1.in amuleweb.1.in
 msgid "Create config file based upon I<E<lt>pathE<gt>>, which must point to a valid aMule config file, and then exit."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:67 amuleweb.1.in:128
+#: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:73
+#: amulecmd.1.in
 #, no-wrap
 msgid "COMMANDS"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:75
+#: amulecmd.1.in
 msgid "All commands are case insensitive."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:77
+#: amulecmd.1.in
 msgid "Adds an eD2k-link or a magnet-link to the core."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:86
+#: amulecmd.1.in
 msgid "a serverlist link, in which case all servers in the list will be added to the server list."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:89
+#: amulecmd.1.in
 msgid "The magnet link must contain the eD2k hash and file length."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:91
+#: amulecmd.1.in
 msgid "Cancels the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:93
+#: amulecmd.1.in
 msgid "Connect to the network."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:95
+#: amulecmd.1.in
 msgid "This will connect to all networks that are enabled in Preferences."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:99
+#: amulecmd.1.in
 msgid "With the optional parameter you can specify which network to connect to. Giving a server address in the form of IP:Port (where IP is either a dotted decimal IPv4 address or a resolvable DNS name) aMule will connect to that server only."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:102
+#: amulecmd.1.in
 msgid "Disconnect from all networks you are connected to, or just disconnect from the specified network."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:104
+#: amulecmd.1.in
 msgid "Start downloading a file."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:108
+#: amulecmd.1.in
 msgid "The I<E<lt>numberE<gt>> of a file from the last search has to be given.  Example: `download 12' will start to download the file with the number 12 of the previous search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:110
+#: amulecmd.1.in
 msgid "Disconnect from amule/amuled and quit amulecmd."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:112
+#: amulecmd.1.in
 msgid "Get and display a preference value."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:114 amulecmd.1.in:149 amulecmd.1.in:202 amulecmd.1.in:212
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>whatE<gt>>:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:117
+#: amulecmd.1.in
 msgid "Get bandwidth limits."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:119
+#: amulecmd.1.in
 msgid "Get IPFilter preferences."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:124
+#: amulecmd.1.in
 msgid "Prints a short usage description.  If called without parameter, it shows a list of available commands.  If called with I<E<lt>commandE<gt>>, it shows a short description of the given command."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:126
+#: amulecmd.1.in
 msgid "Pauses the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:128
+#: amulecmd.1.in
 msgid "Set priority of a download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:130
+#: amulecmd.1.in
 msgid "Available values for I<E<lt>priorityE<gt>>:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:133
+#: amulecmd.1.in
 msgid "Automatic priority."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:135
+#: amulecmd.1.in
 msgid "High priority."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:137
+#: amulecmd.1.in
 msgid "Low priority."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:139
+#: amulecmd.1.in
 msgid "Normal priority."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:143
+#: amulecmd.1.in
 msgid "Shows the progress of an on-going search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:145
+#: amulecmd.1.in
 msgid "A synonym of the B<exit> command."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:147
+#: amulecmd.1.in
 msgid "Reloads a given object."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:152
+#: amulecmd.1.in
 msgid "Reload shared files list."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:154
+#: amulecmd.1.in
 msgid "Reload IP filter tables."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:157
+#: amulecmd.1.in
 msgid "Reset the log."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:161
+#: amulecmd.1.in
 msgid "Shows you the results of a search. Optionally takes a search I<E<lt>idE<gt>> (as printed by B<search>); with no id, shows the most recently started search.  Several searches can be kept on the daemon at once and addressed by id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:163
+#: amulecmd.1.in
 msgid "Resumes the download specified by I<E<lt>hashE<gt>> or I<E<lt>numberE<gt>>. To get the value use B<show>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:169
+#: amulecmd.1.in
 msgid "Makes a search for the given I<E<lt>keywordE<gt>>. A search type and a keyword to search is mandatory to do this.  Example: `search kad amule' performs a kad search for `amule'.  Prints a search id; pass it to B<results> or B<progress> to address this search. Several searches can run at once, each with its own id."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:171
+#: amulecmd.1.in
 msgid "Available search types:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:174
+#: amulecmd.1.in
 msgid "Performs a global search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:176
+#: amulecmd.1.in
 msgid "Performs a search on the Kademlia network."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:178
+#: amulecmd.1.in
 msgid "Performs a local search."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:182
+#: amulecmd.1.in
 msgid "Optional filters can be placed before, after, or interleaved with the search keyword(s):"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:185
+#: amulecmd.1.in
 msgid "Restrict results to the given file type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:187
+#: amulecmd.1.in
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:189
+#: amulecmd.1.in
 msgid "Minimum number of sources a result must report."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:192
+#: amulecmd.1.in
 msgid "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:194
+#: amulecmd.1.in
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:198
+#: amulecmd.1.in
 msgid "Example: `search global linux iso --type Iso --min-size 100M' returns results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:200
+#: amulecmd.1.in
 msgid "Sets a given preferences value."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:205
+#: amulecmd.1.in
 msgid "Set bandwidth limits."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:207
+#: amulecmd.1.in
 msgid "Set IPFilter preferences."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:210
+#: amulecmd.1.in
 msgid "Shows upload/download queue, servers list or shared files list."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:215
+#: amulecmd.1.in
 msgid "Show download queue."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:217
+#: amulecmd.1.in
 msgid "Show log."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:219
+#: amulecmd.1.in
 msgid "Show servers list."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:221
+#: amulecmd.1.in
 msgid "Show shared files list."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:223
+#: amulecmd.1.in
 msgid "Show upload queue."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:227
+#: amulecmd.1.in
 msgid "Shutdown the remote running core (amule/amuled).  This will also shut down the text client, since it is unusable without a running core."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:229
+#: amulecmd.1.in
 msgid "Show statistics tree."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:233
+#: amulecmd.1.in
 msgid "The optional I<E<lt>numberE<gt>> in the range of 0-255 can be passed as argument to this command, which tells how many entries of the client version subtree should be shown. Passing 0, or omitting it means `unlimited'."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:236
+#: amulecmd.1.in
 msgid "Example: `statistics 5' will show only the top 5 versions for each client type."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:238
+#: amulecmd.1.in
 msgid "Show connection status, current up/download speeds, etc."
 msgstr ""
 
 #. type: SS
-#: amulecmd.1.in:243 amuleweb.1.in:145
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "Languages"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:249 amuleweb.1.in:151
+#: amulecmd.1.in amuleweb.1.in
 msgid "The I<E<lt>langE<gt>> parameter for the B<-l> option has the following form: I<lang>[B<_>I<LANG>][B<.>I<encoding>][B<@>I<modifier>] where I<lang> is the primary language, I<LANG> is a sublanguage/territory, I<encoding> is the character set to use and I<modifier> allows the user to select a specific instance of localization data within a single category."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:251 amuleweb.1.in:153
+#: amulecmd.1.in amuleweb.1.in
 msgid "For example, the following strings are valid:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:265 amuleweb.1.in:167
+#: amulecmd.1.in amuleweb.1.in
 msgid "Though all the above strings are accepted as valid language definitions, I<encoding> and I<modifier> are yet unused."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:268 amuleweb.1.in:170
+#: amulecmd.1.in amuleweb.1.in
 msgid "In addition to the format above, you can also specify full language names in English - so B<-l german> is also valid and is equal to B<-l de_DE>."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:271 amuleweb.1.in:173
+#: amulecmd.1.in amuleweb.1.in
 msgid "When no locale is defined, either on command-line or in config file, system default language will be used."
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:273 amuleweb.1.in:181
+#: amulecmd.1.in amuleweb.1.in
 msgid "~/.aMule/remote.conf"
 msgstr ""
 
 #. type: SH
-#: amulecmd.1.in:273 amuleweb.1.in:185
+#: amulecmd.1.in amuleweb.1.in
 #, no-wrap
 msgid "EXAMPLE"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:275
+#: amulecmd.1.in
 msgid "Typically amulecmd will be first run as:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:277
+#: amulecmd.1.in
 msgid "B<amulecmd> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:279 amuleweb.1.in:191
+#: amulecmd.1.in amuleweb.1.in
 msgid "or"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:281
+#: amulecmd.1.in
 msgid "B<amulecmd> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:283 amuleweb.1.in:195
+#: amulecmd.1.in amuleweb.1.in
 msgid "These will save settings to I<$HOME/.aMule/remote.conf>, and later you only need to type:"
 msgstr ""
 
 #. type: Plain text
-#: amulecmd.1.in:287
+#: amulecmd.1.in
 msgid "Of course, you don't have to follow this example."
 msgstr ""
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "AMULED"
 msgstr ""
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon v@PACKAGE_VERSION@"
 msgstr ""
 
 #. type: TH
-#: amuled.1.in:1
+#: amuled.1.in
 #, no-wrap
 msgid "aMule Daemon"
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:6
+#: amuled.1.in
 msgid "amuled - the all-platform eMule p2p client - daemonized version"
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:9 ../../src/utils/cas/docs/cas.1.in:11
+#: amuled.1.in ../../src/utils/cas/docs/cas.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:11
+#: amuled.1.in
 msgid "[B<-p> I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:33
+#: amuled.1.in
 msgid "Forks to background."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:33
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -p> I<E<lt>pathE<gt>>, B<--pid-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:37
+#: amuled.1.in
 msgid "After fork, create a pid-file in the I<E<lt>pathE<gt>>.  I<E<lt>pathE<gt>> has to contain the filename."
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:40
+#: amuled.1.in
 msgid "Configure EC (External Connections)."
 msgstr ""
 
 #. type: Plain text
-#: amuled.1.in:50
+#: amuled.1.in
 msgid "Enable or disable starting amuled on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: TP
-#: amuled.1.in:61
+#: amuled.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr ""
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "AMULEGUI"
 msgstr ""
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI v@PACKAGE_VERSION@"
 msgstr ""
 
 #. type: TH
-#: amulegui.1.in:1
+#: amulegui.1.in
 #, no-wrap
 msgid "aMuleGUI"
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:6
+#: amulegui.1.in
 msgid "amulegui - aMule control program with GUI"
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:17
+#: amulegui.1.in
 msgid "[B<-t> I<E<lt>numE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:27
+#: amulegui.1.in
 msgid "B<amulegui> is a client program, and can be connected to amule or amuled via EC. You can manage your amule program with it. It provides almost the same functionalities as amule, even if the core works on another computer."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:42
+#: amulegui.1.in
 msgid "Skip connection dialog."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:46
+#: amulegui.1.in
 msgid "Enable or disable starting amulegui on user login, then exit.  The OS-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:72
+#: amulegui.1.in
 msgid "This manpage was written by Julien Delange for Debian E<lt>julien AT gunnm DOT orgE<gt>"
 msgstr ""
 
 #. type: Plain text
-#: amulegui.1.in:73
+#: amulegui.1.in
 msgid "This manpage was rewritten by Vollstrecker E<lt>amule@vollstreckernet.deE<gt>"
 msgstr ""
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "AMULEWEB"
 msgstr ""
 
 #. type: TH
-#: amuleweb.1.in:1
+#: amuleweb.1.in
 #, no-wrap
 msgid "aMule webserver v@PACKAGE_VERSION@"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:6
+#: amuleweb.1.in
 msgid "amuleweb - aMule web server"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:15
+#: amuleweb.1.in
 msgid "[B<-l> I<E<lt>langE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:18
+#: amuleweb.1.in
 msgid "[B<-t> I<E<lt>nameE<gt>>] [B<-s> I<E<lt>portE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:20
+#: amuleweb.1.in
 msgid "[B<-U> I<E<lt>portE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:24
+#: amuleweb.1.in
 msgid "[B<-A> I<E<lt>passwordE<gt>>] [B<-G> I<E<lt>passwordE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:40
+#: amuleweb.1.in
 msgid "[B<--amule-config-file>=I<E<lt>pathE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:45
+#: amuleweb.1.in
 msgid "B<DEPRECATED:> amuleweb is deprecated and may be removed in aMule 3.2 or later.  It is not being removed yet; consider migrating to amuleapi, the REST/SSE API."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:50
+#: amuleweb.1.in
 msgid "B<amuleweb> manages your access to amule through a web browser.  You can start amuleweb together with B<amule>(1), or separately, any time later.  Options can be specified via command-line or via config-file.  Command-line options take precedence over config-file options."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:78
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 msgid "Loads the template named I<E<lt>nameE<gt>>. See the B<SKIN SUPPORT> section for details."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:81
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -s> I<E<lt>portE<gt>>, B<--server-port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:84
+#: amuleweb.1.in
 msgid "Webserver's HTTP port. This is the port you must point your browser to (default: I<4711>)."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 msgid "Enable UPnP."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:88
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:91
+#: amuleweb.1.in
 msgid "UPnP port."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:94
+#: amuleweb.1.in
 msgid "Enables using gzip compression in HTTP traffic to save bandwidth."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 msgid "Disables using gzip compression (this is the default)."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:97
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -A> I<E<lt>passwdE<gt>>, B<--admin-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 msgid "Full access password for webserver."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:100
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ -G> I<E<lt>passwdE<gt>>, B<--guest-pass>=I<E<lt>passwdE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:103
+#: amuleweb.1.in
 msgid "Guest password for webserver."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:106
+#: amuleweb.1.in
 msgid "Allows guest access."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:109
+#: amuleweb.1.in
 msgid "Denies guest access (default)."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:115
+#: amuleweb.1.in
 msgid "Load/save webserver settings from/to remote aMule.  This causes amuleweb to ignore command-line and config-file settings, and load them from aMule.  When saving preferences none will be written to the config file, but to aMule.  (Of course, this works only for those settings that can be set in aMule's Preferences-E<gt>Remote Controls.)"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:118
+#: amuleweb.1.in
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:121
+#: amuleweb.1.in
 msgid "Recompiles PHP pages on each request."
 msgstr ""
 
 #. type: TP
-#: amuleweb.1.in:134
+#: amuleweb.1.in
 #, no-wrap
 msgid "B<[ --amule-config-file>=I<E<lt>pathE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:140
+#: amuleweb.1.in
 msgid "aMule config file path.  B<DO NOT USE DIRECTLY!> aMule uses this option when starting amuleweb at aMule startup.  This option causes all other command-line and config-file settings to be ignored, preferences to be read from the given config file, and also implies the B<-q -L> options."
 msgstr ""
 
 #. type: SH
-#: amuleweb.1.in:173
+#: amuleweb.1.in
 #, no-wrap
 msgid "SKIN SUPPORT"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:177
+#: amuleweb.1.in
 msgid "B<amuleweb> is capable of displaying information in different skins.  These skins are called templates, and you can make amuleweb load a specific template via the B<-t> command line option.  Templates are searched in two places: first in I<~/.aMule/webserver/> and then in I</usr/share/amule/webserver/> if you installed with --prefix=/usr."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:179
+#: amuleweb.1.in
 msgid "Each template must be in a subdirectory of the template name, and this directory must contain all files the template needs."
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:183
+#: amuleweb.1.in
 msgid "~/.aMule/webserver/"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:185
+#: amuleweb.1.in
 msgid "I<$(pkgdatadir)>/webserver/"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:187
+#: amuleweb.1.in
 msgid "Typically amuleweb will be first run as:"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:189
+#: amuleweb.1.in
 msgid "B<amuleweb> B<-h> I<hostname> B<-p> I<ECport> B<-P> I<ECpassword> B<-s> I<HTTPport> B<-A> I<AdminPassword> B<-w>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:193
+#: amuleweb.1.in
 msgid "B<amuleweb> B<--create-config-from>=I</home/username/.aMule/amule.conf>"
 msgstr ""
 
 #. type: Plain text
-#: amuleweb.1.in:199
+#: amuleweb.1.in
 msgid "Of course, you may specify any more or less options on the first example line, and you may also totally omit it."
 msgstr ""
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "ED2K"
 msgstr ""
 
 #. type: TH
-#: ed2k.1.in:1
+#: ed2k.1.in
 #, no-wrap
 msgid "aMule eD2k link parser v1.5.1"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:6
+#: ed2k.1.in
 msgid "ed2k - aMule eD2k link parser"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:10
+#: ed2k.1.in
 msgid "[B<-c> I<E<lt>pathE<gt>>] [B<-t> I<E<lt>numE<gt>>]"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:13
+#: ed2k.1.in
 msgid "I<E<lt>eD2k-linkE<gt>>"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:21
+#: ed2k.1.in
 msgid "Sends the given I<E<lt>eD2k-linkE<gt>> to aMule, i.e. writes it to the file ~/.aMule/ED2KLinks, which will be checked by aMule every second for links."
 msgstr ""
 
 #. type: TP
-#: ed2k.1.in:24
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:28
+#: ed2k.1.in
 msgid "Set category for passed eD2k links to I<E<lt>numE<gt>>.  Unlike B<--config-dir>, the parser reads the value as the next argument and does not accept B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:31
+#: ed2k.1.in
 msgid "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:34
+#: ed2k.1.in
 msgid "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr ""
 
 #. type: TP
-#: ed2k.1.in:40
+#: ed2k.1.in
 #, no-wrap
 msgid "B<[ eD2k-link ]>"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:43
+#: ed2k.1.in
 msgid "Adds an eD2k-link to the core."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:54
+#: ed2k.1.in
 msgid "a magnet link;"
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:56
+#: ed2k.1.in
 msgid "an emulecollection file."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:61
+#: ed2k.1.in
 msgid "B<The order in which you give the parameters is important.> You can give more than one link, and every link can have it's own params.  For example B<ed2k E<lt>link1E<gt> -t2 E<lt>link2E<gt>> will download I<E<lt>link1E<gt>> in standard category and I<E<lt>link2E<gt>> in category 2."
 msgstr ""
 
 #. type: Plain text
-#: ed2k.1.in:63
+#: ed2k.1.in
 msgid "~/.aMule/ED2KLinks"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "ALC"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 #, no-wrap
 msgid "aLinkCreator"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:5
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "aLinkCreator - the aMule eD2k link creator"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:9
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
 msgid "B<alc> is a graphical utility to create an eD2k link to any file on your computer."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alc.1.in:11
-#: ../../src/utils/wxCas/docs/wxcas.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alc.1.in
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "This app doesn't take any arguments."
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "ALCC"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:1
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 #, no-wrap
 msgid "aMule eD2k links calculator"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:6
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "alcc - text based eD2k links calculator for aMule"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:11
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "I<E<lt>inputfiles_listE<gt>>"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:16
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute the eD2k links of all the input files given in the I<E<lt>inputfiles_listE<gt>> (There can be one or more files)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:19
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Compute and add part hashes to the computed eD2k links."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/aLinkCreator/docs/alcc.1.in:26
+#: ../../src/utils/aLinkCreator/docs/alcc.1.in
 msgid "Be verbose - show also calculation steps."
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "CAS"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/cas/docs/cas.1.in:1
+#: ../../src/utils/cas/docs/cas.1.in
 #, no-wrap
 msgid "cas v0.8"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:6
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "cas - c aMule statistics"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:18
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> is a program for displaying the contents of your aMule online signature file to console (in a human readable form). For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:23
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Writes the online signature picture.  The long form B<--picture> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-o> / B<-P> do not (B<-P> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:27
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "HTML page with stats and picture.  The long form B<--html> accepts an optional I<=E<lt>PATHE<gt>> to specify the output location; the short forms B<-p> / B<-H> do not (B<-H> requires an immediately following I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:35
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "Without any options, it prints online signature data to stdout."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:37
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "B<cas> was written by Pedro de Oliveira E<lt>falso@rdk.homeip.netE<gt>"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:39
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "~/.aMule/casrc"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:41
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is available)"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/cas/docs/cas.1.in:43
+#: ../../src/utils/cas/docs/cas.1.in
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "WXCAS"
 msgstr ""
 
 #. type: TH
-#: ../../src/utils/wxCas/docs/wxcas.1.in:1
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 #, no-wrap
 msgid "wxCas"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:5
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "wxcas - wx c aMule statistics"
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:11
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "B<wxcas> is a program for displaying the contents of your online signature file in a nice wx Window on your Desktop.  For this to work, you must enable the \"Online Signature\" option in aMule's preferences."
 msgstr ""
 
 #. type: Plain text
-#: ../../src/utils/wxCas/docs/wxcas.1.in:14
+#: ../../src/utils/wxCas/docs/wxcas.1.in
 msgid "Based on Pedro de Oliveira's B<cas>(1).  B<wxcas> was written by ThePolish E<lt>thepolish@vipmail.ruE<gt>"
 msgstr ""

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,100 +18,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr ""
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr ""
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -120,47 +120,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -169,172 +168,165 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,269 +336,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -616,191 +604,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -809,1204 +790,1177 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr ""
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr ""
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr ""
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr ""
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2014,23 +1968,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2038,59 +1992,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2099,2647 +2053,2605 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 msgid "Connection & bandwidth"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 msgid "Connection speed:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr ""
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr ""
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr ""
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr ""
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr ""
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr ""
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr ""
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr ""
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr ""
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4747,11 +4659,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4761,836 +4673,836 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr ""
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr ""
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5600,1444 +5512,1443 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr ""
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 msgid "Connected since:"
 msgstr ""
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr ""
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr ""
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7045,7 +6956,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7053,155 +6964,153 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7210,46 +7119,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7257,35 +7166,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7296,121 +7205,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7429,383 +7338,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr ""
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr ""
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr ""
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7817,177 +7723,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -7998,400 +7896,389 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -21,100 +21,100 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "غير متوفر"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "أضف صديق"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "يجب ان تضيف عنوان شبكي ومنفذ صحيحان!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -123,47 +123,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -172,176 +171,169 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "فشل لفتح %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "فشل"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "معلومات"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "تاكيد الخروج"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,271 +343,267 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ﻻ نضمن انه خالي من اﻻخطاء, قد يتسبب باعطال\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "اعدادت"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -625,195 +613,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "خطأ قاتل :فشل في تكوين الموَقت"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "اﻹتصال فقد"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -822,1214 +803,1187 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "خطأ قاتل :فشل في تكوين الموَقت"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "يتم الإتصال"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going down"
 msgstr "تسجيل الدخول اﻻن"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Ready"
 msgstr "اعد تحميل"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "غير متوفر"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "ﻻ وجود ﻻجزاء الملفات"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "غير معرف"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "بانتظار اﻻتصال ..."
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "طلب:"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 msgstr[1] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 msgstr[1] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "طلب ملف غير معروف"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "فشل غير متوقع اثناء كتابة ملف %s : %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "خطأ أثناء اﻹتصال بي%s (%s:%i): %d"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "صنف"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "اختر مكان الملفات القادمة"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "اضف لي صديق"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "حمل ملف الرصيد, تم التعرف على %u عميل"
 msgstr[1] "حمل ملف الرصيد, تم التعرف على %u عميل"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] "الرصيد منتهى!"
 msgstr[1] "الرصيد منتهى!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "تفاصيل العميل"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "هوية متدنية"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "متصل"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "فصل الإتصال"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "غير مكتمل"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "شخص سيئ"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "تأكيد - صحيح"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "غير متوفر"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "ملف تعليقات"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "اسم مستخدم"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "اسم الملف"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "تقيم"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "بانتظار اﻻتصال ..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "ﻻ تعليق "
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "ﻻ تعليق "
 msgstr[1] "ﻻ تعليق "
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "فشل في تحميل النموذج %s\n"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "ذاتي منخفض"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "ذاتي "
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "ذاتي عالي"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "مرتفع"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "عالي جدا"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "اطلب"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "اتصال من خلال خادم"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "اﻻنتظار ممتلئ"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "في اﻻنتظار"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "تحميل"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "اجزاء غير مطلوبة"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "عدد اتصلات كثيرة"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "حظر"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "اكمل"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "نقل"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "سرعة"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "تقدم"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "مصدر"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "أولوية"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "حالة"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "الوقت المتبقي"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "اخر اكتمال"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "اخر إستقبال"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "ذاتي"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "%إيقاف"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&إيقاف مؤقت"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "%إكمل"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "إ&نتهاء التنظيف"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "خيرات اضافية"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "مشاهدة"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "اعرض الملف &تفاصيل"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "اعرض كل التعليقات"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&فتح الملف"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "تحميل (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "طلب ملف مشاركة من '%s'"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "ﻻ وجود ﻻجزاء الملفات"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "وجد %i جزء ملفات"
 msgstr[1] "وجد %i جزء ملفات"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "تحميل %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "جاري البحث ستم جلب النتيجة في لحظة"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2037,23 +1991,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2061,59 +2015,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2122,2674 +2076,2632 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "يتم الإتصال"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "اتصال"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "تصفح"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "اصدقاء"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "عرض &تفاصيل"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "اضف صديق"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "احذف صديق"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "ارسل &رسالة"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "اعرض الملفات"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "في اﻻنتظار"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "طلب ملف اخر"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "تحميل ينتظر: %i"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "في اﻻنتظار"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "الرفع"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "ﻻ احد"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "ﻻ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "نعم"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "تحميل ..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "سعة نطاق التحميل الحقيقية"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "فشل في حفظ ملف part.met.seeds لي %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "مجموع التحميل"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "سعة نطاق التحميل الحقيقية"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "فشل في تحميل قائمة الخادمات من %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "فشل في تحميل قائمة الخادمات من %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "غير معروف :%i"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "اكتمال"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "اكتمل"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "ايقاف مؤقت"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "خاطئ"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "انتظار"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "اغلق"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "واضح"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "متصل"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "متصل"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "عنوان الخادم: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "عنوان الخادم: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "خروج"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "بلا حدود"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "سرعة-التحميل"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "سرعة-الرفع"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "هوية العميل: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "إسم الخادم: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "عنوان الخادم: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "غير متصل"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "توقيع أثناء الإتصال: ممكن"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "توقيع أثناء الإتصال: معطل"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "فترة التشغيل: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "اضف لي صديق"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "تحميل ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "عدد المستخدمين على الخادم الذي تتصل به..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "مستخدمين: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "رفع :0.0 | تحميل : 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "غير متصل"
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "بحث"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "نوع"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "اي"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "ارشيف"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "سمعي"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "صور"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "برامج"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "فيديو"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "إمتداد"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "اقل حجم"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "بايت"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "اكبر حجم"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "ابدء"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "ايجاد المصدر :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "غير متوفر"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "عام"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "اﻻسم كامل :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "حجم الملف :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "نقل"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "حالة جزء الملف :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "اخر مرة تم اكتمال :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "ايجاد المصدر :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "نقل المصدر :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "احصاء اجزاء الملف :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "متوفر :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "محول :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "حجم المكمل :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "معالجة الفاسد بذكاء"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "فقد بسبب فساد :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "طلبات"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "طلبات مقبوله"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "بينات محوله"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "غير مقيم"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "عنوان :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "سيطر"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "نظف"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "طبق"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "جودة الملف"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "غير مقيم"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "غير صحيح / معطوب / مزيف"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "فقير"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "عادل"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "جيد"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "ممتاز"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "انعش"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "تحميل ,رجاء انتظر..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "مطلوب معلومات"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "عنوان IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "منفذ :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "معلومت إضافية"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "اسم المستخدم :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "اضف"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "معدل الجلسة"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "سرعة-الرفع"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "شجرة اﻻحصائيات"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "اسم المستخدم:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "اﻻنتظار ممتلئ"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "مستعار"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "بدء مصغر"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "مشغل الفيديو"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "الرفع"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "إعادة اﻹتصال عند الفصل"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "إحذ الخادمات التي ﻻ تعمل بعد"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "أعد المحاولة"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "قائمة"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "إستخدم نظام اﻷولوية"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "إتصال أمن"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "جعل الخادمات المضافة يدويا ذو اولوية عالية"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "أضف الملفات للتحميل بوضع متوقف"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "أضف الملفات للتحميل بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "حاول تحميل القطع اﻻولى واﻻخيرة اوﻻ"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "ارفع"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "أضف ملفات مشاركة جديدة بوضع ذاتي"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "رسم بياني"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "تحيدث كل:5 ثواني"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "خلفية"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "شبكة"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "حمل الحالي"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "معدل تحميل الحالي"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "معدل تحميل الجلسة"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "ارفع الحالي"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "معدل رفع الحالي"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "اتصال نشط"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "اختر"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!!تحذير!!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "الحد اﻷعلى للتصالات لكل 5 ثواني"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "اظهر معدل النقل علي العنوان"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4797,11 +4709,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4811,855 +4723,855 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "تعطيل [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "بايت"
 msgstr[1] "بايت"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "بايت"
 msgstr[1] "بايت"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "ثانية"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "دقيقة"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "الكل"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "الكل ماعدا"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "غير مكتمل"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "إيقاف"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "فيديو"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "أرشيف"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "نص"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "خطأ: فشل في تكوين ملف اجزاء)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "خطأ: %s (%s) معطوب, غير قادر لتحميل الملف"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "فشل لفتح %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "خطأ أثناء حفظ ملف اجزاء: %s (%s => %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "فشل في حفظ ملف part.met.seeds لي %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "فشل في تحميل قائمة الخادمات من %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "اتصال"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "مجلدات"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "الخادمات"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "ملفات"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "تحكم عن بعد"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5669,260 +5581,260 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "ذاتي"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "قبل إتصال خارجي جديد\n"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5930,1223 +5842,1222 @@ msgstr ""
 "أضف هنا عنوان لتحميل ملفات server.met \n"
 "عنوان واحد فقط لكل سطر"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "تحيدث كل:5 ثواني"
 msgstr[1] "تحيدث كل:5 ثواني"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "فترة تحديث الإتصال بالخادم %i دقيقة"
 msgstr[1] "فترة تحديث الإتصال بالخادم %i دقيقة"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "فترة تحديث الإتصال بالخادم :معطل"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "تعطيل"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "ملفات مشاركة"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "بحث"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "تعريف ملف"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "غير مقيم"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "طلب ملف اخر"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "إلغاء"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "متصل بي %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "إتصال بي : %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "خطأ قاتل اثناء محاولة اﻹتصال . احتمال أنك غير متصل باﻹنترنت"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "فقد اﻹتصال بي %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) يظهر انه ﻻ يعمل"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
 msgstr[1] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i خادمات وجدت في server.met"
 msgstr[1] "%i خادمات وجدت في server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d خادم مضاف"
 msgstr[1] "%d خادم مضاف"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 #, fuzzy
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "خطأ: ملف server.met معطوب"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "فشل غير متوقع اثناء كتابة ملف %s : %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "فشل في حفظ server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "عنوان شبكي غير صحيح"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "فشل في تحميل قائمة الخادمات من %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "إسم الخادم"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "منفذ"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "وصف"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "مستخدمين"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "ثابت"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "نسخة"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "خادمات (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "خادم"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "الغاء الخادم"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
 msgstr "الغاء الخادم"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "الغاء كل الخادمات"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "عميل جديد هو %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "تلقي %d خادم جديد"
 msgstr[1] "تلقي %d خادم جديد"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "الخادم رفض اخر امر"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "سجل aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "هوية"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "اتصال"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "متصل"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "اعلى سرعة اتصال تقديرية"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "يتم الإتصال"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "متصل بي %s (%s:%i)"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "ايجاد المصدر :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
 msgstr[1] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "اسم مستخدم"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "سرعة-التحميل"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "سرعة-الرفع"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "متوفر :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "ارفع"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Download Status"
 msgstr "تحميل"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "اسم الملف"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "ملفات مشاركة"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "أجزاء مكتسبة"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "اعد تسمية"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "نسخ رابط ED2k للحافظة"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "يجب ان تكون ذا هوية مرتفعة لتتمكن من انشاء رابط مصدر"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "اسم الملف"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "متوسط زمن التحميل : %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "اعادة اﻹتصال : %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "الوقت منذ بدء التحميل: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "متصل بالخادم منذ : %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "عميل"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "غير معروف :%i"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "تم ترشيح : %i"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "حظر"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "إحتلال الخادم: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "مجموع حجم ملفات المشاركة : %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "إتصال نشط (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7154,7 +7065,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7162,156 +7073,154 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "تحميل (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "%s غير متوفر"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7320,47 +7229,47 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "حدث server.met من العنوان"
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7368,35 +7277,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7407,121 +7316,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7540,387 +7449,384 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "إظهار شريط التقدم"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "إظهار شريط التقدم"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "ملفات مشاركة"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "هل أنت متاكد من حذف كل الملفات في هذا المصنف؟"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "مطلوب التاكيد"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "عدد اتصلات كثيرة"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "إختر فلتر العرض"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "اضف مجموعة"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "عرض المجموعة"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "الغاء المجموعة"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7932,178 +7838,170 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 #, fuzzy
 msgid "Cancelled !"
 msgstr "إلغاء"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "معاد"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8114,401 +8012,390 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Amosar aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Control remotu de aMule"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,7 +42,7 @@ msgstr ""
 "Veceru p2p multiplataforma basáu en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -51,79 +51,79 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipu aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte d'aMule básase en \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Direicionamientu P2P basáu na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foru:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar nueva versión al entamu"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Coneutando a Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non disponible"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Amestar a un Collaciu"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Ye necesario introducir una IP y puertu válidos"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Información"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash d'usuariu especificáu nun ye válidu!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -132,49 +132,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Conexón fallida"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -183,103 +182,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Fallu al abrir ficheru ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k teniendo ID baxa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Agora, saliendo de l'aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando instancia amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Terminando núcleu."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Zarru d'aMule completáu."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultaos de depuración de memoria na salida d'aMule: "
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "La to llingua foi camudada a la de por defeutu del sistema, darréu d'un cambéu de configuración. Siéntolo."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +283,70 @@ msgstr ""
 "\n"
 "Configuración EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ALERTA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "FALLU"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "sirvidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nun ye dable direicionar los puertos a la direición especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puertu %u nun ta disponible. Tendrás IDBaxa\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +361,48 @@ msgstr ""
 "\n"
 "Comprueba la to rede y asegúrate de que'l puertu ta abiertu pa entrada y salida."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Fallu al criar el ficheru de RoblaOnline aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La llingua seleicionada nun paez tar instalada. (Nota: Tentará de ponese de toes formes)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ye la primer vegada qu'anicies aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esto ye una versión de preba, actualízate diariamente, y \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nun damos garantía si fraña daqué, ambura to casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o fila la to sidra. Pero *tendría* de ser seguru de toes formes. \n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podrás alcontrar na nuesa web, más información, sofitu y nueves versiones, \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o nel nuesu canal de IRC #aMule en irc.libera.chat. \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Unvíanos cualesquier fallu a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,224 +410,220 @@ msgstr ""
 "El direutoriu qu'especificaste de Robla Online nun ye válidu\n"
 "La Robla Online deshabilitóse hasta que lo igües nes opciones."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espaciu en discu pal ficheru '%s' falló: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FALLU: nun puede abrise'l ficheru de rexistru"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ALERTA: el ficheru de rexistru ta ermu. Hai daqué mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "El rexistru resetióse"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensax del sirvidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Fallu al descargar la llista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Fallu al abrir el ficheru de comprobación de versión descargáu"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Ficheru de comprobación de versión toyíu"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Tas usando una versión antigua de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La to versión de aMule ye %i.%i.%i y la cabera versión ye %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ALERTA: La to versión de aMuled ye obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "LA to copia de aMule ta actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Fallu al descargar el ficheru de comprobación de versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Ensin redes seleicionaes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "con IDBaxa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Coneutáu a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Coneutando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desconeutáu de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad aniciáu."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad deteníu."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Coneutáu a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Red Kad nun pue usase si'l puertu UDP ta deshabilitáu n'opciones, non aniciando."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada n'opciones, nun coneutará."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERROR: el daemon d'aMule nun pue usase cuando tán desactivaes les conexones esternes. P'activales, use o bien un aMule normal, anicie amuled cola opción --ec-config, o bien, afite \"AcceptExternalConnections\" a 1, nel ficheru ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERROR: Contraseña válida ye requería pa usar conexones esternes y el demoniu aMule nun pue usase ensin conexones esternes. P'aniciar el demoniu aMule, tienes d'especificar nel campu \"ECPassword\" del ficheru ~/.aMule/amule.conf col valor apropiáu. Executa amuled col parámetru --ec-config pa especificar la contraseña. Más información pue alcontrase en https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: EnAniciu - Aniciando reló"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Nun puede Crease un Ficheru Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto ye aMule %s basáu en eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,194 +633,187 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Ensin rede"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "control remotu de aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Fallu Grave: Nun pudo criase'l temporizador"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Coneutar a amule remotu"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Conexón perdida"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Entrugar al colar"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -841,728 +822,705 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Fallu Grave: Nun pudo criase'l temporizador"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Diendo a eventu bucle..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Coneutando..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Remanador d'eventu EC n'Interface Remota"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Fallu de conexón. Nun ye dable coneutar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Baxando"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Intentu de conexón con %s (%s:%i) tiempu escosáu."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Coneutáu a la rede."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Fallu de conexón. Nun ye dable coneutar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Llistu"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Toos"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Non disponible"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Ficheru non alcontráu"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Enllaz non válidu o yá ta na llista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo direutoriu '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocíu"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Guetando a un collaciu con conexón idbaxa"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versión Falsa eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Falsu eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsu eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basáu en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nomatu:  %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitáu: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques de ficheru pa esta sesión: %d Aceutada de %d petición, %s tresfería\n"
 msgstr[1] "Estadístiques de ficheru pa esta sesión: %d Aceutaes de %d peticiones, %s tresferíes\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques de ficheru pa toles sesiones: %d Aceutada de %d petición, %s tresfería\n"
 msgstr[1] "Estadístiques de ficheru pa toles sesiones: %d Aceutaes de %d peticiones, %s tresferíes\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Solicitáu un ficheru desconocíu"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensax fieltráu de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuevu mensax de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos del direutoriu %s-> Refugada"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ALVERTENCIA: nun puede abrise known.met."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVISU: Ficheru de llista de compartíos corruptu, tien una testera inválida."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO error lleendo'l ficheru known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Fallu guardando ficheru known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nueva Categoría"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Seleiciona un direutoriu pa los ficheros entrantes"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "¡Tienes d'especificar un nome pa la categoría!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "¡Tienes d'especificar un camín pa la categoría!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "¡Fallu al criar el direutoriu entrante de la categoría. Por favor especifique un camín correutu!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sesión Charra Aniciada: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Coneutáu al Veceru ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Coneutando al veceru ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Fallu al coneutar col veceru / Conexón perdía ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Aprobóse'l captcha, y l'usuariu recibirá'l to mensax. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** La to rempuesta al captcha nun ye correuta y el to mensax va inorase. Puedes solicitar otru captcha unviando un mensax nuevu. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Zarrar llingüeta"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Zarrar toles llingüetes"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Zarrar les otres llingüetes"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Amestar a collacios"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Ficheru de créditos cargáu, %u veceru conocíu"
 msgstr[1] "Ficheru de créditos cargáu, %u veceros conocíos"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - ¡Caducó'l créditu de %u veceru!"
 msgstr[1] " - ¡Caducaron los créditos de %u veceros!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Ficheru 'cryptkey.dat' nun alcontráu, criando."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalles del veceru"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID-Baxa"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID-Alta"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Habilitáu"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Sofitáu"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Non sofitáu"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Deshabilitáu"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Coneutáu"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desconeutáu"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Non completáu"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Veceru sospechosu"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificáu - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Non disponible"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos -> Aceutada"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos -> Refugada"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Usuariu %s (%u) solicitó la to llista de direutorios compartíos -> Aceutada"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Usuariu %s (%u) solicitó la to llista de direutorios compartíos -> Refugada"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos del direutoriu %s -> Aceutada"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos del direutoriu %s-> Refugada"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Usuariu %s (%u) direutorios compartíos %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Usuariu %s (%u) unviáu direutorios compartíos non solicitaos."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Usuariu %s (%u) unviada la llista de ficheros compartíos por direutoriu %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Usuariu %s (%u) finó l'unvíu de la llista de ficheros compartíos"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Usuariu %s (%u) unviada la llista de ficheros compartíos non deseyada"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Usuariu %s (%u) refugó l'accesu a la llista de direutorios/ficheros compartíos"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentarios de ficheru"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nome d'usuariu"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome de ficheru"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentariu"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Nun se pue guetar en Kad si nun ta coneutáu a Kad"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Guetando a un collaciu con conexón idbaxa"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ensin comentarios"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentariu"
 msgstr[1] "%u comentarios"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Veceru %s baneáu por unviar %s datos toyíos de %s en total pal ficheru '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Fallu al descargar GeoIP.dat dende %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ba]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Al]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Mui alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Llanzamientu"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Entrugando"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Coneutando vía sirvidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Cola enllena"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na cola"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Recibiendo hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Partes non necesitaes"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nun se pue coneutar IDBaxa con IDBaxa"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Abondes conexones"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Coneutando vía Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Abondes conexones Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Baneáu"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Fallu de conexón"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Cola remota enllena"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Antiguu MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nuevu MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule Compatible"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Sirvidor llocal"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Intercambéu de Fontes"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasivu"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Enllaz"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Semientes fonte"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultáu de la gueta"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completáu"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "En progresu"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERROR: Nun queda espaciu en discu"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERROR: Partmet non alcontráu"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERROR: Error d'entrada/salida!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERROR: Falló!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "En cola"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Yá tás descargando"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formatu de ficheru temp incorreutu o desconocíu."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Tresferío"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidá"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progresu"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridá"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Estáu"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tiempu Restante"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Cabera comprobación completa"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Cabera receición"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "¿De xuru quies desaniciar esti ficheru?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "¿De xuru quies desaniciar estos ficheros?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1571,109 +1529,106 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Detener"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Posar"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Reanudar"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Llimpiar completaos"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Intercambiar toles fontes (A4AF) a esti ficheru"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Intercambiar toles fontes (A4AF) a esti ficheru (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Intercambiar toles fontes (A4AF) a otru ficheru"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opciones estendíes"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Amosar detalles fi&cheru"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Amosar tolos comentarios"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiar la URL magnético al cartafueyos"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copiar l'en&llaz eD2k al cartafueyos."
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar rempuesta al cartafueyos"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "non asignáu"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Asignar a categoría"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir el ficheru"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Introduza'l nuevu nome pa esti ficheru:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Renomar ficheru"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargues (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1682,351 +1637,350 @@ msgstr ""
 "Pa prevenir l'apaición d'esta alvertencia en cada vista previa,\n"
 "afita'l to reproductor de vídeos nes preferencies (%s por defeutu)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Previsualizar"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR:¡Fallu al executar un reproductor de medios esternu! Comandu: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Guardando ficheru part %u de %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Tolos ficheros part atroxaos."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Cargando ficheros temporales dende %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Cargando ficheru part %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERROR: Nun pudo cargase'l ficheru de copia de seguridá. Llea en https://github.com/amule-org/amule/discussions p'alcontrar soluciones de recuperación d'archivos part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Tolos ficheros part cargaos."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nun s'alcontraron ficheros .part"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Alcontróse %u parte de ficheru"
 msgstr[1] "Alcontráronse %u partes de ficheru"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "El sistema de ficheros del direutoriu Temporal, nun pue remanar ficheros grandes."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "El sistema de ficheros del direutoriu Entrante, nun pue remanar ficheros grandes."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Descargando %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Yá tas descargando esti ficheru '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Yá tienes esti ficheru '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Yá tienes esti ficheru '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Yá tas descargando el ficheru %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Nun pue convertise l'enllaz magnet a eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocolu desconocíu del enllaz: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaz eD2k inválidu! FALLU: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "El veceru unvió un paquete dempués que falló l'autenticación."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Conexón esterna zarrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "¡Conexones esternas deshabilitaes darréu d'una contraseña en blanco!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Conexones esternas deshabilitaes nel ficheru de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FALLU: nun pudo aceutase una nueva conexón esterna"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexón esterna refugada darréu d'una contraseña en blanco nes opciones!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Coneutando con veceru: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versión desconocía"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "EC Incorreutu na ID de versión, tien d'haber una incompatibilidá. Usa núcleu y remotu de la mesma versión."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡Nun pues coneutar a una versión final dende una versión SVN cualesquiera! *sigh* dable fallu evitáu"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versión de protocolu non válida"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Marcador de versión de protocolu inesistente"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autenticación fallía"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitú non válida, tendríes d'autenticate primero."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Accesu concedíu."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intentu d'accesu non autorizáu. Conexón zarrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallu en comandu remotu del ficheru Part: Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de ficheru non alcontráu: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "¡OOPS! ¡Fallu procesando OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Sirvidor non amestáu"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "sirvidor non amestáu: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "necesites definir un sirvidor pa desanicialu"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ta desabilitáu nes preferencies"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Gueta web dende un interface remotu nun tien xacíu"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Gueta en procesu. Resultaos obteníos aína! "
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Ensin puntos pal gráficu."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "El to veceru nun ta configuráu pa esti nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Conexón esterna: apagáu solicitáu"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Yá tas zarrando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexón esterna: amestando enllaz '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Enllaz non válidu o yá ta na llista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Ficheru non alcontráu"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nome de ficheru incorreutu"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nun ye dable renomar ficheru"
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad ta deshabilitáu n'opciones."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Yá tas coneutáu a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Coneutando a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Yá tas coneutáu a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Coneutando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Toles redes tán deshabilitaes"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desconeutando de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desconeutando de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexón esterna: recibíu códigu d'operación inválidu: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode non válidu (¿versión de protocolu incorreuta?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Estensión desconocía '%s' pal comandu '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comandu desconocíu '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2034,7 +1988,7 @@ msgstr ""
 "\n"
 "Esti comandu nun tien un argumentu.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2042,7 +1996,7 @@ msgstr ""
 "\n"
 "Esti comandu tien de tener un argumentu.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2050,7 +2004,7 @@ msgstr ""
 "\n"
 "Esti comandu ta incompletu, tienes d'usar una de les estensiones....\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2058,11 +2012,11 @@ msgstr ""
 "\n"
 "Estensiones disponibles:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comandos disponibles:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2073,17 +2027,17 @@ msgstr ""
 "Tolos comandos son sensibles a les mayúscules.\n"
 "Teclea '%s <comandu>' pa obtener información detallao del <comandu>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Colar de l'aplicación."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Amosar aida"
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2091,7 +2045,7 @@ msgstr ""
 "Pa tener aida d'un comandu, teclea 'help <comandu>'.\n"
 "Pa tener la llista completa de comandos, teclea 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2102,46 +2056,46 @@ msgstr ""
 "Usa '%s' pa la llista de comandos\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "¡Fallu de sintaxis!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Fallu procesando'l comandu - ¡enxamás tendría de pasar! Informa del fallu, por favor\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Esti comandu nun tendría de tener dengún parámetru"
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Esti comandu tien de tener un parámetru."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argumentu non válidu."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Esto ye un comandu incompletu."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Teclea '%s' pa tener más aida.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Esto ye %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Esto ye %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2149,7 +2103,7 @@ msgstr ""
 "\n"
 "Criando veceru...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2158,7 +2112,7 @@ msgstr ""
 "\n"
 "Ok, colando %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2172,331 +2126,326 @@ msgstr ""
 "\n"
 "Colando...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Amosar esta aida."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host au ta executándose aMule. (por defeutu: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Puertu de conexón esterna de aMule. (por defeutu: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Contraseña de conexones esternes"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Lleer configuración dende'l ficheru."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nun amueses denguna salida."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Mou Estendíu - amuesa tamién los mensaxes de depuración"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Seleiciona la llingua del programa."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Escribe opciones de la llinia de comandu al ficheru de configuración."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Criar ficheru de configuración basáu nel ficheru de configuración de aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Imprenta versión del programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalles del ficheru"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% fináu."
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "¡Bienllegáu!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Coneutando a collaciu"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Estáu de conexón:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Redes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Puertu TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puertu UDP estándar (Kad / gueta global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP pal reunvíu de puertu del router"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Coneutar"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Yá tas descargando el ficheru %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar la llista de sirvidores al aniciu"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Desaminar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so llectura !"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escritura !"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Collacios"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Amosar &Detalles"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Amestar un collaciu"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Desaniciar collaciu"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Unviar &Mensax"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ver ficheros"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Afitar puestu reserváu a un collaciu"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "¿Daveres quies desaniciar al collaciu seleicionáu?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "¿Daveres quies desaniciar a los collacios seleicionaos?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2504,11 +2453,11 @@ msgstr ""
 "Nun se-y permite asignar más d'ún puestu reserváu.\n"
 " Namái s'asignó un puestu reserváu."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Seleición múltiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2517,210 +2466,209 @@ msgstr ""
 "Nun se-y permite asignar más d'ún puestu reserváu.\n"
 " Namái s'asignó un puestu reserváu."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Unviar mensax al usuariu"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensax a unviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Desaniciar de collacios"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Unviar mensax"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambia esti ficheru"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "LC: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Pidióse otru ficheru"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Xubíes n'espera: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "Na cola"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Xuba"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Dengún"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP encaboxada"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargaos %d bytes"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descarga HTTP encaboxada"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Descargar nuevu GeoIP.dat dende %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Fallu al descargar ficheru GeoIP.dat, albortando actualización."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Fallu al desaniciar el ficheru GeoIP.dat, albortando actualización."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Fallu al renomar el nuevu ficheru GeoIP.dat, albortando actualización."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Successfully updated %s"
 msgstr "Actualizacion GeoIP.dat satisfactoria"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Fallu actualizando GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Fallu al descargar GeoIP.dat dende %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Cargando fieltros IP 'ipfilter.dat' y 'ipfilter_static.dat'"
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Fallu al cargar ipfilter.dat '%s', alcontráu formatu desconocíu."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Fallu al cargar ipfilter.dat '%s', nun ye dable abrir el ficheru."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Cargáu %u rangu IP dende '%s'."
 msgstr[1] "Cargáu %u rangos IP dende '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u llinia malformada descartóse"
 msgstr[1] "%u llinies malformaes descartáronse"
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Fallu al renomar el nuevu ficheru GeoIP.dat, albortando actualización."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2728,877 +2676,845 @@ msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP non válida pa coneutar"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Puertu non válidu pa coneutar"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Por favor enllene tolos campos requeríos"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mensax"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "¿De xuru quies descargar un nuevu nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Si lo faes, desaniciarás tolos tos nodos actuales y reaniciarás la conexón Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "¿Siguir?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: pallabra de gueta enforma curtia"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Pallabra de gueta enforma curtia:"
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Lleíu %u contautu Kad"
 msgstr[1] "Lleíos %u contautos Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Contautos non alcontraos, por favor descarga un ficheru nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Namái %d contautu Kad disponible, nodes.dat non escritu"
 msgstr[1] "Namái %d contautos Kad disponible, nodes.dat non escritu"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Escritu %d contautu Kad"
 msgstr[1] "Escritos %d contautos Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Rede Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nome ficheru"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tamañu ficheru"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Media compartío"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Pidío"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aceutao"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fontes completes"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "AVISU: Ficheru de llista de compartíos corruptu, tien una testera inválida."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Versión desconocía"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Codificando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Completando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Completáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Posáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Aguardando"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Tienes d'especificar una contraseña non erma"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Contraseña incorreuta, nun ye un códigu MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Fallu de conexón"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Conexón esterna zarrada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "La conexón EC falló. Rempuesta erma."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Conexón esterna: Rempuesta del sirvidor incorreuta, falló handshake. Conexón zarrada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "¡Fecho! Conexón afitada con aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "¡Fecho! Conexón afitada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Conexón esterna: Accesu denegáu, xida:"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Socket d'escucha: Ok"
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "FALLU: Nun pue escuchase nel puertu TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "FALLU:"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVISU:"
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Zarrar"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Apegar"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Llimpiar"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Esbillar too"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Coneutáu"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Coneutáu"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Coneutáu a Kad (tres torgafueos)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP del sirvidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP Sirvidor:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Non coneutáu"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Puertu TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Puertu TCP: Nun ta llistu"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Puertu UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Puertu UDP: Nun ta llistu"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Información del veceru"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Llímite de xuba"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Llímite de descarga"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Amosar aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Anubrir aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Colar"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Illimitáu"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menú aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Llímites de velocidá"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "XU: Dengún"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "XU: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DE: Denguna, "
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DE: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocidá de descarga: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocidá de xuba: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Nomatu: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "¡Dengún nomatu conseñáu!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID Veceru:"
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nome del sirvidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP del sirvidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Non coneutáu"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Robla Online: Activada"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Robla Online: Desactivada"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Tiempu d'execución: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Ficheros compartíos: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Veceros na cola: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total DE: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total XU: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Amiesta un enllaz eD2k o magnet al núcleu."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Amestar a collacios"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Fai Click equí p'amestar l'enllaz eD2k de la entrada de testu de control a la cola de descargues."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Los eventos son amosaos equí. Pa una llista completa d'eventos, empobina al rexistru de la llingüeta de sirvidores."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Cargando ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Númberu d'usuarios nel sirvidor al que tas coneutáu ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Usuarios: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Usuarios coneutaos al sirvidor actual y una estimación del númberu total d'usuarios."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Xu: 0.0 | Desc: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Índiz actual de xubíes y descargues. Si habilites los númberos signifiquen los gastos indireutos na comunicación del veceru."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Amuesa l'estáu de conexón y les tresferencies actives. Les fleches bermeyes quieren dicir que tas desconeutáu, les marielles que tienes ID-Baxa (darrera d'un torgafueos) y les verdes que tienes ID-Alta (La triba de conexón ye bona)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Non Coneutáu ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Coneutáu al sirvidor."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Guetar"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Triba"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Llocal"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Opciones estendíes"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Fieltrar"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Triba de ficheru"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archivos"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imáxenes de CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Imáxenes"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programes"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Testos"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Estensión"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Tamañu mín"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Tamañu Máx"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilidá"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Fieltru:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Fieltrar Resultaos"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Invertir Resultáu"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Anubrir Ficheros Conocíos"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Entamar"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Más"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Encaboxar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarga"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Llimpiar Campos"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultaos"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Llimpiar descargues completaes"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Fontes completes"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Xeneral"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nome Completu :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Ficheru-met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tamañu :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Tresferencia"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Estáu ficheru part :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Cabera comprobación completa :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fontes alcontraes :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Tresfiriendo fontes :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Númberu de partes :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibles :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Tiempu Descarga Activa: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Tresferío :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamañu Completáu :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Xestión intelixente de corrupción"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdío por corrupción :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Ganao por compresión :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paquetes salvaos por I.C.H.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Compartiendo:"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Peticiones"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Peticiones aceutaes"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Datos tresferíos"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Media Compartíu"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fontes completes"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Ficheros compartíos"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Xubío:"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Títulu :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nomes de ficheru"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Tomar"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Llimpiar"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comentariu/Calificación del ficheru (El testu podrán velu tolos usuarios)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3606,1275 +3522,1271 @@ msgstr ""
 "Pa una película, pues poner la so duración, la so hestoria, la llingua ...\n"
 "y si ye una falsificación (fake) pues informar a los demás usuarios d'aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Calificación de ficheru"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Inválidu / Toyíu / Falsificación"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Probe"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Aceutable"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bonu"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Mui bonu"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Camudar la calificación del ficheru o alvertir a otros usuarios si nun ye válidu"
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Desconeutáu de Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Descargando, por favor aguarda ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Tamañu desconocíu"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Información requería"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Señes IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Puertu :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nome d'usuariu :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Amestar"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Media de la sesión"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidá de xuba"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Descargues actives"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Árbol d'estadístiques"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hash d'usuariu:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software del veceru:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versión del veceru:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Señes IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID usuariu:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP Sirvidor:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nome sirvidor:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Ofuscación:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Tresferencies al veceru"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Solicitú actual:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Velocidá media de xuba :"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Velocidá media de descarga :"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Xubíu (sesión):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Descargáu (sesión):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Xubíu (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Descargáu (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultaos"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador DE/XU:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Ident Segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "En cola"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Puntuación cola:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nomatu"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - la mula multi-plataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Esti ye'l nome que verán los otros usuarios verán cuando se coneuten a tí."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Llingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Allanciu enantes d'amosar los mensaxes emerxentes."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Esto especifica la llingua usada nos controles."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Comprobar nueva versión al entamu"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Habilitando esto, fadrá que aMule compruebe si esiste una nueva versión al entamu."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Aniciar minimizáu"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Habilitando esto, faes que aMule se minimice nel aniciu."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Entrugar al colar"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Facer que aMule entrugue enantes de colar."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Habilitar iconu de sistema"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Esto habilita/deshabilita iconu de sistema (o de la barra de xeres)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizar al iconu de la bandexa"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Activando esto fadrás que aMule se minimice na bandexa del sistema, asemeyao a la barra de xeres."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Tiempu d'allanciu de los mensaxes emerxentes: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Seleición del restolador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Abrir en nueva llingüeta si ye dable"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir cuando seya dable, la páxina web nuna nueva llingüeta n'arroú de nuna nueva ventana"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Reproductor de vídeu"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Llímites del anchor de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Xuba"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Asignación de puestu reserváu"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Esti ye'l puertu eD2k estándar y nun pue deshabilitase"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puertu UDP pa peticiones del sirvidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Esti puertu UDP úsase pa peticiones estendíes de eD2k y la rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puertu UPnP TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Max. fontes descargando un ficheru:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autoconeutar al aniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconeutar al perder la conexón"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Desaniciar sirvidores cayíos tres"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la llista de sirvidores al coneutar a un sirvidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualizar la llista de sirvidores cuando un veceru se coneuta"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usar sistema de prioridaes"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente de IDBaxa al coneutar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Conexón segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconeutar namái a Sirvidores fixos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridá a los sirvidores amestaos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Amestar ficheros pa descargar en mou posáu"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Amestar nueves descargues con auto prioridá"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar enantes la primer y cabera parte"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Descargar siguiente ficheru posáu cuandu otru se complete"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Namái na mesma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espaciu en discu pa los nuevos ficheros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pa los nuevos ficheros reservar tol espaciu del ficheru, esto amenorga la fragmentación"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener descargues cuando s'algame l'espaciu llibre en discu"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleiciona esta opción si quies que aMule comprebe l'espaciu en discu"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Introduz l'espaciu mínimu de discu deseyáu."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes en ficheros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Xubíes"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Amestar nuevos ficheros compartíos con auto prioridá"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Remanador Intelixente de Corrupciones (I.C.H)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avanzáu, confiar en tolos hash (non recomendáu)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Desaniciar"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click drechu n'iconu de carpeta, pa compartición recursiva)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Compartir ficheros anubríos"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Intervalu d'actualización : 5 segs"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempu de promediu del gráficu: 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráficu de les conexones: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Descargar escala gráfica:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fondu"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rexella"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Promediu descarga n'execución"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Promediu Descarga/sesión"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Xuba actual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Promediu Xuba/tiempu"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Conexones actives"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidá del iconu de sistema"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-nodos actual"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-nodos executando"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seleicionar"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Númberu de versiones de veceros a amosar (0=ensin llímite)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISU !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Nueves conexones máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamañu del buffer de ficheru: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamañu cola d'espera: 5000 veceros"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalu d'actualización de conexón al sirvidor: Desactiváu"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar \"Xestor rápidu d'enllaces eD2k\", en toles ventanes."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Amosar info estendía nes llingüetes de les categoríes"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Amosar índices de tresferencia nel títulu"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Enantes del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Dempués del nome de l'aplicación"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Amosar anchor de banda escedente"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de ferramientes"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Ficheros de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Amosar porcentax de progresu"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Amosar barra de progresu"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Planu"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar accesu a invitáu"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Contraseña d'invitáu pa sirvidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4794,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,852 +4808,852 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Deshabilitáu [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "segs"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "mins"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "hores"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "díes"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "too"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "el restu"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompletu"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Deteníu"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeu"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Ficheru"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Testu"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Activu"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando a ficheru part matando filu..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importando %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lleendo direutoriu temp"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Obteniendo información básica de ficheru info de descarga"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Criando ficheru de destín"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Cargando datos dende l'antigua descarga del ficheru (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Atroxando bloque de datos nun nuevu ficheru de descarga (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Obteniendo información del ficheru fonte de descarga"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Amestando descarga y guardando nuevu ficheru part"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importar ficheros part"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estáu"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash de ficheru"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Discu: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "¡Por favor escueye un direutoriu pa guetar por descargues temporales! (incluyiránse subdireutorios)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "¿Quies que los ficheros fonte d'una descarga importada satisfactoriamente seyan desaniciaos?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "¿Desaniciar fontes?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "ERROR: Fallu al criar el ficheru part"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Intentando cargar copia de seguridá del ficheru met dende %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERROR: Nun pudo abrise'l ficheru part.met: %s ===> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERROR: el ficheru part.met tien tamañu 0: %s ===> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERROR: Versión de ficheru part.met Inválida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "ERROR: %s (%s) ta toyíu (cuenta d'etiquetes errónea), nun se pue cargar el ficheru."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERROR: %s (%s) ta toyíu (cuenta d'etiquetes errónea), nun se pue cargar el ficheru."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Intentando recuperar info de ficheru..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Recuperando ficheru ensin nome - recuperarase como RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperóse tola info disponible del ficheru :D - Tentando usala..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Nun pudo recuperase la info de ficheru..."
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Fallu al abrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVISU: %s pue tar toyíu (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "FALLU salvando ficheru part: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "ERROR E/S atroxando ficheru part: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Fallu al guardar ficheru part.met.seeds por %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Guardáu %i semiente de fontes en ficheru part: %s (%s)"
 msgstr[1] "Guardaes %i semientes de fontes en ficheru part: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Guardáu %i semiente de fontes en ficheru part: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fallu lleendo semientes del ficheru part (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte toyía alcontrada (%i) en %d parte del ficheru %s - Resultáu del hash del ficheru |%s| Hash del ficheru |%s|"
 msgstr[1] "Parte toyía alcontrada (%i) en %d partes del ficheru %s - Resultáu del hash del ficheru |%s| Hash del ficheru |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte (%i) completa alcontrada en %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Recodificación finada %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Fallu inesperáu mientres se completaba %s. Ficheru posáu"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Descarga finada: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Descarga finada: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Desaniciando ficheru: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISU: Nun pue criase'l hash de la parte descargada, set de hashes incompletu pa '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: Nun pue criase'l hash de la parte descargada, set de hashes incompletu pa (%s). Esto nun tendría de pasar enxamás"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISU: Nun hai espaciu llibre nel discu! Posando ficheru: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte descargada %i toyía nel ficheru: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte toyía %i de %s -> Bytes salvaos: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Asignando"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espaciu en discu insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargáu"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Conexón"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direutorios"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Seguridá"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Fieltros"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Robla online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avanzáu"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5757,35 +5669,35 @@ msgstr ""
 "aMule furrulará bien ensin que camudes dengún\n"
 "d'estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al coneutar configuración con programa, col ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al tresferir datos dende la configuración al programa, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "La triba de proxy a la que tas coneutando"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al tresferir datos dende'l programa a la configuración, col ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Comprobando contraseña\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5793,45 +5705,45 @@ msgstr ""
 "aMule tien de reaniciase p'aplicar los cambeos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Puertu TCP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Puertu UDP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nueva conexón esterna, aceutada"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Conexón esterna zarrada."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscación de protocolu"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5839,7 +5751,7 @@ msgstr ""
 "La to llista Auto-actualizable de sirvidores ta erma.\n"
 "La llista de sirvidores auto-actualizable al entamu desactivaráse."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5847,33 +5759,33 @@ msgstr ""
 "Tienes habilitao les conexones externes, pero nun tienes especificada una contraseña.\n"
 "Les conexones externes nun puen ser habilitaes sacante qu'especifiques una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Llingua camudada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Direutoriu TEMP camudáu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión de protocolu non válida"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5881,7 +5793,7 @@ msgstr ""
 "eD2k y Kad tán desactivaos.\n"
 "Nun podrás coneutate hasta qu'actives a lo menos ún d'ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5889,7 +5801,7 @@ msgstr ""
 "Kad nun s'aniciará si'l to puertu UDP ta deshabilitáu.\n"
 "Habilita un puertu UDP o deshabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5899,69 +5811,69 @@ msgstr ""
 "Hai de reaniciar aMule agora.\n"
 "Si nun reanicies agora, nun sabemos si pasará daqué malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto recargar, aniciáu"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta pa los ficheros temporales de descargues"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contraseña fixada y conexones esternes habilitaes."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5971,66 +5883,66 @@ msgstr ""
 "Por favor introduz a lo menos una URL con un ficheru server.met válidu.\n"
 "Click nel botón \"Llista\" d'esta caxella  pa introducir una URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Ficheros temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Ficheros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Robles online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escueye una carpeta pa %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Esplorar"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleiciona restolador"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Por defeutu"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editar llista de sirvidores"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6038,1221 +5950,1220 @@ msgstr ""
 "Amesta equí les URL's pa descargar los ficheros server.met.\n"
 "Namái una url per llinia."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completes"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estáu:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalu d'actualización: %d seg"
 msgstr[1] "Intervalu d'actualización: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempu mediu del gráficu: %d min"
 msgstr[1] "Tiempu mediu del gráficu: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamañu del buffer de ficheru: %d byte"
 msgstr[1] "Tamañu del buffer de ficheru: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamañu de la cola de xuba: %d veceru"
 msgstr[1] "Tamañu de la cola de xuba: %d veceros"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalu de refrescu de la conexón al sirvidor: %d minutu"
 msgstr[1] "Intervalu de refrescu de la conexón al sirvidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalu de refrescu de la conexón al sirvidor: Deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "deshabilitáu"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comandu nel eventu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Habilitar execución de comandu nel núcleu"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comandu del núcleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execución de comandu na Interface"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comandu de la Interface: "
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Les siguientes variables trocaránse:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartíes"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu inoráu."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Alerta de gueta"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Nun pue facese una gueta en eD2k si nun se ta coneutáu a eD2k"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Pallabra clave pa gueta: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Fallu non esperáu mentantu tentaba guetar en Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID Ficheru"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Non evaluada"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Amestar URLs opcionales pa esti ficheru"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Guetar ficheros rellacionaos (eD2k, gueta llocal)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Conseñar como ficheru conocíu"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar l'enllaz eD2k al cartafueyos"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Tas coneutáu al sirvidor, que tentes desaniciar. Por favor desconéutate primero."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Encaboxar"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Fallu al coneutar a tolos sirvidores ofuscaos llistaos. Tentándolo de nuevu ensin ofuscación."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Fallu al coneutar a tolos sirvidores ofuscaos llistaos. Tentándolo de nuevu ensin ofuscación."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Fallu al coneutar a tolos sirvidores."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Fallu al coneutar a tolos sirvidores."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolu eD2k deshabilitáu nes preferencies, nun se coneuta."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Nun s'alcontraron sirvidores válidos pa coneutar na llista de sirvidores"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Coneutáu a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Conexón afitada en: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Fallu fatal coneutando. La conexón a Internet podría tar desactivada"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Conexón perdía con %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) paez tar cayíu."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) paez tar enllenu."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Reintentaráse la conexón automática al sirvidor en %d segundu"
 msgstr[1] "Reintentaráse la conexón automática al sirvidor en %d segundos"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Coneutando con %s (%s:%i) fallíu"
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERROR: Socket inválidu al comprobar el timeout"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Intentu de conexón con %s (%s:%i) tiempu escosáu."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Recibióse'l caberu resultáu de la to gueta DNS, descartando."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Cargando ficheru server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "¡Nun s'alcontró ficheru server.met!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Fallu al cargar el ficheru server.met '%s', alcontróse formatu desconocíu."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "¡Fallu al abrir server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Ficheru server.met toyíu, alcontróse versión non válida: 0x%x, tamañu %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i sirvidor alcontráu en server.met"
 msgstr[1] "%i sirvidores alcontraos en server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d sirvidor amestáu"
 msgstr[1] "%d sirvidores amestaos"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "IO error lleendo'l ficheru known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Sirvidor non amestáu: [%s:%d] nun especificaste un puertu válidu."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Sirvidor non amestáu: La IP de [%s:%d] ta fieltrada o nun ye válida."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Sirvidor non amestáu: Sirvidor IP:Puertu [%s:%d] alcontráu na llista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Sirvidor amestáu: Sirvidor en [%s:%d] usando'l nome '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Tas coneutáu al sirvidor, que tentes desaniciar. Por favor desconéutate primero."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Fallu al abrir '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "¡Fallu al guardar server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL non válida"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Descarga finada de la llista de sirvidores de %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Nun s'alcontró una entrada de direición en 'addresses.dat'. Por favor, apega una llista de sirvidores válida nesti ficheru pa poder actualizar de mou automáticu la llista de sirvidores."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Descargando llista de sirvidores de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ALVERTENCIA: especificada una URL inválida pa l'actualización automática de sirvidores : %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Fallu en addresses.dat, server.met de la url de auto descarga inválidu"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Fallu al descargar la llista de sirvidores dende %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Sirvidor llocal ye fieltráu polos Fieltros IP, ¡coneutando a un sirvidor distintu!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome del Sirvidor"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Direición"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Puertu"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descripción"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Usuarios"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Sirvidor fixu"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Tas coneutáu a un sirvidor, que tas tentando desaniciar. Desconéutate enantes. El sirvidor NUN se desaniciará."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nome desconocíu)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "De xuru quies desaniciar el sirvidor fixu %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Sirvidores (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Sirvidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Coneutar al sirvidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Conseñar como sirvidor fixu"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Conseñar como sirvidor non-fixu"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Conseñar sirvidores como fixos"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Conseñar sirvidores como non-fixos"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Desaniciar sirvidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Desaniciar sirvidores"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Desaniciar tolos sirvidores"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copiar los enllaces eD2k al cartafueyos"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconeutar al sirvidor"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "¿De xuru quies desaniciar tolos sirvidores?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "¿De xuru quies desaniciar el sirvidor seleicionáu?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "¿De xuru quies desaniciar los sirvidores seleicionaos?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERROR: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVISU: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "El nuevU ID-Veceru ye %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVISU: ¡Recibiste ID-Baxa!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tEsto asocede porque tas darrera d'un torgafueos o d'un router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPa mas información, por favor ve a https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "¡Información recibía del sirvidor desconocía! - enforma pequeña"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Recibíu %d nuevu sirvidor"
 msgstr[1] "Recibiéronse %d nuevos sirvidores"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Guardáu de llista de sirvidores fechu."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "El sirvidor refuga'l caberu comandu"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Paquete bogus recibíu dende'l sirvidor: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Fallu mientres que se taba procesando un paquete dende'l sirvidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Nun pue criase un filu de resolución de DNS pa coneutar con %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Sirvidor IP %s (%s) ta fieltráu. Nun coneutará."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "usando ofuscación de protocolu."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Coneutando a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Imposible resolver dns pal sirvidor %s: ¡Imposible coneutar! "
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Rexistru"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Sirvidor non amestáu: IP o nome de host non especificáu."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Sirvidor non amestáu: Sirvidor-puertu especificáu non válidu."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Estáu de eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Estáu de conexón:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Coneutáu"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Estáu Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Executándose en %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Executando"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Estáu Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Estáu:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estáu de conexón:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tres torgafueos - abre'l puertu TCP %d nel to router o torgafueos"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estáu de conexón UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tres torgafueos - abre'l puertu UDP %d nel to router o torgafueos"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estáu tres tornafueos:"
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nun se requier collaciu - puertu TCP abiertu"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nun se requier collaciu - puertu UDP abiertu"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Non collaciu"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Coneutando a collaciu"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Coneutáu a collaciu en %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fontes indizaes: %s"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Pallabres clave indizaes:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notes indizaes: "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Notes indizaes:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Media d'usuarios:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Media de ficheros:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Non executando"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Amestando ficheru %s a compartíos"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Alcontróse %i ficheru compartíu, %i desconocíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos, %i desconocíos"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "FALLU: Tentando compartir %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Direutoriu compartíu non alcontráu, saltando: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ensin ficheros que compartir en direutoriu: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Nome usuariu:"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Velocidá de descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Velocidá de xuba"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Disponibles :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Estáu de la xuba"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Estáu de la descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Nome de ficheru"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Fich compartíos"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Partes obteníes"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Direutoriu"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Amestar Comentariu/Valoración"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editar Comentariu/Valoración"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Renomar"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Amestar ficheros en colleición a la llista de descargues"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiar &URL magnéticu al cartafueyos"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (&Fonte)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (Fonte) (&Con opciones de cifráu)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (&Nome del host)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (Nome del host) (Co&n opciones de cifráu)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (Información &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiar l'enllaz eD2k al cartafueyos (Información &AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Necesites IDAlta pa criar un enllaz fonte válidu"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Nome de ficheru"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Datos xubíos (Sesión (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Total por tráficu escedente (Paquetes): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Escedente por peticiones de ficheru (Paquetes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Escedente por intercambéu de fontes (Paquetes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Tráficu escedente de sirvidores (Paquetes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Tráficu escedente Kad (Paquetes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Cifráu escedente (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Xubíes actives: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Xubíes n'espera: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total de xubíes satisfactories: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de xubíes fallíes: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tiempu mediu de xuba: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Datos descargaos (Sesión (Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fontes alcontraes: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Descargues actives (partes): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Índiz XU:DE Sesión (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Velocidá media de descarga (Sesión): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Velocidá media de xuba (Sesión): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Velocidá máxima de descarga (Sesión): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Velocidá máxima de xuba (Sesión): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconexones: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tiempu dende la primer tresferencia: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Coneutáu al sirvidor dende: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Conexones actives (estimáu): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Algamóse'l llímite máximu de conexones: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Media de conexones (estimáu): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Picu de conexones (estimáu): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Veceros"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Desconocíu: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtráu: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Baneáu: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i Conocíu(os): %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Sirvidores activos: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Sirvidores cayíos: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Sirvidores desaniciaos: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Sirvidores fieltraos: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Usuarios en sirvidores activos: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Ficheros en sirvidores activos: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Usuarios totales: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Ficheros totales: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupación de Sirvidores: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Númberu de ficheros compartíos: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Tamañu total de ficheros compartíos: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Tamañu mediu de ficheru: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema Operativu"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Non recibíu"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Conexones actives (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Non disponible"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Enxamás"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Comandu `%s' con pid `%d' finó con códigu `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> y cuela."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formatu IP non válidu. Usa xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Esti comandu requier un argumentu. Argumentos válidos: 'all (too)' o un númberu.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Procesando por hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Procesando por nome de ficheru: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Esti comandu requier un argumentu. Argumentos válidos: un hash de ficheru.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Númberu inválidu\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Hash non válidu (la llonxitú tendría de ser esautamente 32 carauteres)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7261,7 +7172,7 @@ msgstr "Teclea '%s' pa tener más aida.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7270,89 +7181,87 @@ msgstr "Teclea '%s' pa tener más aida.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Teclea '%s' pa tener más aida.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Tamañu de descarga: %i"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Solicitú fallía con un fallu desconocíu."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operación satisfactoria."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Solicitú fallía col siguiente fallu: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "El Fieltru IP pa veceros ye %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "APAGÁU"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "ENCENDÍU"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "El Fieltru IP pa sirvidores ye %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "El nivel de fieltráu de IP actual ye %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Llímites del anchor de banda: Xuba: %u kB/s, Baxada: %u kB/s\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Coneutáu a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Coneutando agora"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "tres tornafueos"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7361,7 +7270,7 @@ msgstr ""
 "\n"
 "Descarga:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7370,7 +7279,7 @@ msgstr ""
 "\n"
 "Xuba:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7379,7 +7288,7 @@ msgstr ""
 "\n"
 "Veceros na cola:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7388,47 +7297,47 @@ msgstr ""
 "\n"
 "Fontes totales:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Ficheru part]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Númberu de resultaos de la gueta: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "Amosar porcentax de progresu"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Recibióse una rempuesta desconocía dende'l sirvidor, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Amosar una información curtia sobro l'estáu."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Amosar estáu de conexón, velocidá xuba/descarga actual, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Amosar árbol d'estadístiques ensembre."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7442,11 +7351,11 @@ msgstr ""
 "\n"
 "Exemplu: 'statistics 5' amosará namái les 5 versiones que más se repiten de cualesquier veceru.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Finar aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7456,40 +7365,40 @@ msgstr ""
 "Esto finará tamién el veceru mou testu, darréu que nun se pue\n"
 "usar ensin un núcleu en funcionamientu.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Recargar l'oxetu dau."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Recargar tabla de fieltru de IP dende ficheru."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Seleición nivel de fieltráu de IP"
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Recargar tabla de fieltru de IP dende ficheru."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Coneutáu a la rede."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7501,36 +7410,36 @@ msgstr ""
 "coneutar a esi sirvidor namái. La IP tien de ser una direición IPv4,\n"
 "o un nome DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Coneutar namái a eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Coneutar namái a Kad"
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desconeutáu de la rede."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Esto desconeutaráte de toles redes nes que tas coneutáu nesti intre.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desconeutar de eD2k namái."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desconeutar de Kad namái."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Amiesta un enllaz eD2k o magnet al núcleu."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7547,52 +7456,52 @@ msgstr ""
 "amestaránse a la llista de sirvidores.\n"
 "\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Asigna un valor d'opción"
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Asignar opciones de fieltráu de IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activa el fieltru pa veceros y sirvidores."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Desactiva el fieltru pa veceros y sirvidores."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activa/Desactiva el fieltru IP pa veceros."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activa el fieltru pa veceros."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Desactiva el fieltru pa veceros."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activa/Desactiva el fieltru pa sirvidores."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activa el fieltru pa sirvidores."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Desactiva el fieltru pa sirvidores."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Seleición nivel de fieltráu de IP"
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7600,80 +7509,80 @@ msgstr ""
 "Niveles válidos nel fieltru 0-255, y el valor por defeutu (inicial)\n"
 "ye 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Asignar llímites d'anchor de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "El valor dau a estos comandos han ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Asignar un llímite de xuba."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "El valor dau a estos comandos han ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Asignar un llímite de descarga."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "El valor dau a estos comandos han ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obtener y amosar un valor d'opciones"
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Obtener opciones de fieltráu de IP"
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obtener estáu del fieltru IP pa veceros y sirvidores."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Obtener estáu del fieltru IP pa veceros."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Obtener estáu del fieltru IP pa sirvidores."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Seleición nivel de fieltráu de IP"
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obtener llímites d'anchor de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Fai una gueta en kad."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7692,48 +7601,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Fai una gueta global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Fai una gueta llocal."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Fai una gueta en kad."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Amuesa los resultaos de la cabera gueta."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Amuesa'l progresu d'una gueta."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Entamar descargando un ficheru"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7741,82 +7650,82 @@ msgstr ""
 "El númberu d'un ficheru de la cabera gueta tien de dase.\n"
 "Exemplu: 'download 12' aniciará la descarga del ficheru col númberu 12 de la gueta anterior.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Posar descarga."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Resumir descarga."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Encaboxar descarga."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Asignar prioridá de descarga."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Fixa prioridá de la descarga a Baxa, Normal, Alta o Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Afitar la prioridá a baxa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Afitar la prioridá a normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Afitar la prioridá a alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Afitar la prioridá a auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Amosar coles/llistes."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Amosar cola xuba/descarga, llista de sirvidores o llista de ficheros compartíos.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Amosar cola de xuba"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Amosar cola de descarga."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Amosar rexistru."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Amosar llista de sirvidores."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Recargar llista de ficheros compartíos."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Llimpiar rexistru."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comandu en desusu, usa %s."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7825,262 +7734,259 @@ msgstr ""
 "Esti ye un comandu en desusu, y desaniciaráse nel futuru.\n"
 "Usa '%s' en so llugar.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Veceru de testu aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convirtiendo antiguos hashsets AICH en  '%s' a 64b en '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ALERTA: El nome de ficheru '%s' ye incorreutu y sedrá renomáu a '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ALERTA: El ficheru '%s' yá esiste, renomando el nuevu a '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "¿Daveres quies encaboxar y desaniciar tolos ficheros d'esta categoría?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Requierse Confirmación"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Abondes conexones"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Ensin catalogar"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Amestar categoría"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editar categoría"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Desaniciar categoría"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset solicitáu de ficheru desconocíu: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Resumiendo xubíes del ficheru: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendiendo xuba del ficheru: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Fallu al executar el comandu '%s' nel eventu `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Descarga fecha ensembre"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "El camín completu al ficheru."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "El nome del ficheru ensin el camín."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "El hash eD2k del ficheru."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "El tamañu del ficheru en bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tiempu d'actividá de descarga acumuláu."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Aniciada Nueva sesión de charra"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remitente del mensax."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Ensin espaciu"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partición de discu"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Fallu completando"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Procesando númberu de ficheru %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Entrugaste por hashes de partes (Namái usáu por ficheros > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s --->¡ Nun esiste'l ficheru !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, el criador d'enllaces eD2k p'aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "¡Bienllegáu!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parámetros d'entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Ficheru a codificar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Amestar URLs opcionales pa esti ficheru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Introduz equí el ficheru del que quieras calcular l'enllaz eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Introduz equí la URL que quies amestar al enllaz eD2k: Amiesta / al final pa permitir a aLinkCreator amestar el nome del ficheru actual"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Criar enllaz con hashes de partes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Aida pa separtar ficheros nuevos y raros más aína, el costu sedrá un tamañu d'enllaz mayor"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hash de ficheru MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Hash de ficheru eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Enllaz eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Guardar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiar al cartafueyos"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Abrir un ficheru pa calcular el so enllaz eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiar l'enllaz eD2k calculáu al cartafueyos"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Guardar como"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Guardar l'enllaz eD2k calculáu nun ficheru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Tocante a aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Seleiciona el ficheru del que quieras calcular l'enllaz eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Nun pue abrise'l cartafueyos"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "¡Res pa copiar agora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleiciona'l ficheru pal enllaz eD2k calculáu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Imposible abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Por favor, introduz un nome de ficheru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "¡Nun hai res agora pa guardar!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8100,167 +8006,159 @@ msgstr ""
 "\n"
 "Distribuyíu baxo la llicencia GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Calculando hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator trabayando pa ti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calculando MD4 Hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calculando eD2k Hashes..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "¡ Encaboxáu !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Fináu en %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "¡ Yá amestaste esa URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Por favor, introduz una URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Nun ye dable abrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i día(es) %i hora(es) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Estadístiques aMule en llinia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Máximu índiz Desc dende que wxCas ta executándose: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Máximu índiz Desc absolutu durante execuciones anteriores de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Reafitar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Parar auto recargar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Salvar imaxe d'estadístiques en llinia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprentar imaxe d'estadístiques en llinia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Opciones"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Tocante a wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Aniciar Auto Recargar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Auto recargar, deteníu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Auto recargar, aniciáu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Salvar imaxe d'estadístiques"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estadístiques aMule en llinia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8268,11 +8166,11 @@ msgstr ""
 "Hebo un fallu imprentando.\n"
 "Seique la to imprentadora actual nun tea configurada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Imprentando"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8290,403 +8188,392 @@ msgstr ""
 "\n"
 "Distributed under GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Eeepa, aMule nun ta executándose..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule yá ta executándose"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule ta executándose, pero ta desconeutáu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule ta coneutando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, l'estáu d'aMule ye desconocíu..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " foi executáu durante "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " ¡ ta deteníu !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ¡ nun ta coneutáu !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " ta coneutando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " ta faciendo daqué raro, ¡ compruébalo !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " ta coneutáu a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "apagáu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " coneutáu "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " con "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Total Descargáu: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Xubío:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Descarga de sesión"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Descargáu:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Xuba: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Compartiendo:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " ficheru(os), Veceros na cola: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tiempu:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " en "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Media de carga del sistema (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Tiempu d'execución del sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Direutoriu que contién el ficheru amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Introduz el direutoriu au s'alluga'l to ficheru amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervalu de refrescu en segundos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Xenerar un ficheru d'estadístiques siempres que s'actualice"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Introduz el direutoriu au quies xenerar la imaxe d'estadístiques"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Xube periódicamente la to imaxe d'estadístiques al sirvidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Url FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Direutoriu FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Introduz la URL del to sirvidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Introduz el direutoriu del to sirvidor FTP au poner la to imaxe d'estadístiques"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Usuariu"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Introduz el nome d'usuariu pa coneutate al to sirvidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Introduz la contraseña d'usuariu pa coneutate al to sirvidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalu d'actualización de FTP en minutos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validáu"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Direutoriu que contién el to ficheru de robla"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Direutoriu au se xenera la imaxe d'estadístiques"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carga la plantía <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Puertu HTTP del sirvidor web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Puertu UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usar compresión gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Contraseña d'accesu total pal sirvidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Contraseña d'invitáu pa sirvidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permitir accesu a invitáu"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Denegar accesu a invitáu"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Cargar/guardar la configuración del sirvidor web dende/a aMule remotu"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Camín al ficheru config de aMule. ¡NUN USAR DIREUTAMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deshabilitar intérprete PHP (desusu)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompila páxines PHP pa otra solicitú"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Sirvidor Web aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "conexón aceutada del veceru web\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "FALLU: nun pue aceutase la conexón del veceru web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Solicitú fallía col siguiente fallu: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Ficheru índiz non alcontráu: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesión finada - solicitando conexón\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesión ok, coneutáu\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesión ok, non coneutáu\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nun hai denguna sesión - coneute de nuevu\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sesión criada - solicitando conexón\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Procesando solicitú [orixinal]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nun s'especificó dengún password, nun se permite l'accesu."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Comprobando contraseña\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash de la contraseña incorreutu\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Contraseña ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Contraseña incorreuta\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Nun introduxisti denguna contraseña. Nun ta permitía una contraseña en blancu.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Desconexón solicitada\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Procesando solicitú [redirixía]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Conexón fallida"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -22,100 +22,100 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "форум:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Добавяне на приятел"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Трябва да въведете валиден адрес и порт"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -124,47 +124,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -173,175 +172,168 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Грешка при запис на файла с кредити"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Грешка"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Потвърждение за изход"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -351,269 +343,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -623,195 +611,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Няма мрежа"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Фатална грешка: не можах да създам брояч"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Връзката е прекъсната"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -820,1201 +801,1174 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Фатална грешка: не можах да създам брояч"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Свързва"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "всички"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Не са открити части от файлове"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестен"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "изчакване за свързване..."
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Fake съревновавам)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Поискан:"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 msgstr[1] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 msgstr[1] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Заявен е несъществуващ файл"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Изберете папка за входящи файлове"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Чат"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Файлът с кредити зареден, %u клиента са разпознати"
 msgstr[1] "Файлът с кредити зареден, %u клиента са разпознати"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Клиентските Детайли"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "изваден от строя"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Връзкате е установена"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Връзката е разпадната"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Коментари за файла"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Потребителско име"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Име на файл"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Оценка"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "коментар"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "изчакване за свързване..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Няма коментари"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "Няма коментари"
 msgstr[1] "Няма коментари"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Грешка при зареждане на файла с кредити"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Автоматичен [Lo]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Автоматичен [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Автоматичен [Hi]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Високо"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Запитване"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Свързване чрез сървър"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Опашката е пълна"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "На опашката"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Изтегляне"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Получаване на hash сумите"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Не може LowID да се свърже към LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Твърде много връзки"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завършен"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Пренесен"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорост"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Прогрес"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Източници"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Статус"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Стоп"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Пауза"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "В&ъзобновява"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Преглед"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Файлове за сваляне (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Искане на споделени файлове от '%s'"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Не са открити части от файлове"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Открити са %i части от файлове"
 msgstr[1] "Открити са %i части от файлове"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Сваляне %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2022,11 +1976,11 @@ msgstr ""
 "\n"
 "Налични разширения:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2034,23 +1988,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2058,59 +2012,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2119,2668 +2073,2626 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Добре дошли!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Свързва"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Връзка"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Избери"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Приятели"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Показване на &детайли"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Добавяне на приятел"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Изтриване на приятел"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Изпращане на &съобщение"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Преглед на файловете"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Създаване на приятелска връзка"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "На опашката"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Поискан му е друг файл"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Файлове за качване: %i"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "На опашката"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Качване"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "никой"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Не"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Да"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Изтеглям..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Свален:"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Файлове за сваляне (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Изтегляне"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Име на файл"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Размер на файла"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "признат"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "неизвестна грешка %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Завършено"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Пауза"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Връзката е прекъсната"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Затвори"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "копие"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Изчисти"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Връзкате е установена"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Връзкате е установена"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "Сървър"
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Сървър"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Изход"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "кБ/с"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "неограничен"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Изтегляне"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Време на качване"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Зареждам..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Търсене"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Име:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Архиви"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Аудио"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-изображения"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Картинки"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Програми"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Клипове"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Разширение"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Минимален размер"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Байта"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Максимален размер"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Старт"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Намерени източници: %i"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Няма"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Общи"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Трансфер"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Заявки"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Приети заявки"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Пренесени данни"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Споделени файлове (%i)"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Няма оценки"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Заглавие :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Изчистване"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Потвърди"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Няма оценки"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Грешен / Развален / Фалшив"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Лош"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Средно добър"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Добър"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Отличен"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Опресняване"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Добавяне"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Име на потребител:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Точки"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Опашката е пълна"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "език: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "секунди"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Видео плеър"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Списък"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Премахване"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Диаграми"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Цветове: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Мрежа"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Избор"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4788,11 +4700,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4802,845 +4714,845 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "Байта"
 msgstr[1] "байта"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "Байта"
 msgstr[1] "Байта"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "сек."
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "мин."
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "часа"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "дни"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "Всички"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "всички останали"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Незавършен"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Спрян"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Видео"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Архив"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Текст"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Активен"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "Фатална грешка: не можах да създам брояч"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Грешка:файлът known.met е повреден,зареждането на списъка пропадна"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Сваляне %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Връзка"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Директории"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Сървъри"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Файлове"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Дистанционни управления"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "напреднал"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5650,255 +5562,255 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "парола"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Език променило.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматично"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Вие вече опитвате да свалите файла %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Търсене на видео плеър"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5906,1221 +5818,1220 @@ msgstr ""
 "Тук добавете линкове за сваляне на .met файлове.\n"
 "Само по един URL на ред."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "деактивиране"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Търсене"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Няма оценки"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Поискан му е друг файл"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Отказ"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Свързан към %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Връзката установена на: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Фатална грешка при опит за свързване,вероятно не сте се включили към интернет"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Връзката към %s (%s:%i) бе прекъсната"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) изглежда не отговаря"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
 msgstr[1] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i сървъра бяха намерени в server.met"
 msgstr[1] "%i сървъра бяха намерени в server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d сървъра бяха добавени"
 msgstr[1] "%d сървъра бяха добавени"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 #, fuzzy
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Грешка: файлът server.met е повреден"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Грешка при записа на server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Грешен URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Име на сървър"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "адрес"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Порт"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Описание"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Потребители"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Статичен"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "версия"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Неизвестно име)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Сървъри (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Сървър"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Премахване на сървър"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
 msgstr "Премахване на сървър"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Изтриване на всички сървъри"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Новият номер на клиента е %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tНай-вероятно това е така, защото вие сте зад защитна стена или маршрутизатор."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Получени са %d нови сървъра"
 msgstr[1] "Получени са %d нови сървъра"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Сървърът отхвърли последната команда"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Връзка"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Връзкате е установена"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Максимален брой връзки (изчисляване)"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Свързва"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Свързан към %s (%s:%i)"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Намерени източници: %i"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Потребителско име"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Изтегляне"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Време на качване"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Наличен"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Лимит за качване"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Download Status"
 msgstr "Изтегляне"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Име на файл"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Споделени файлове (%i)"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "преименувам"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Копиране на ED2k линк в системния буфер (име на хост)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Трябва да имате HighID, за да създадете валиден сорс линк"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Име на файл"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Средно време за качване: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Повторни свързвания: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Изтекло време от пърия трансфер: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Свързан към сървъра от : %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Клиенти"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Неизвестно: %i"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Филтрирани: %i"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Общ размер на споределните файлове : %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Операционна система"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Активни връзки (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "никога"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7128,7 +7039,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7136,109 +7047,107 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Файлове за сваляне (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7247,46 +7156,46 @@ msgstr ""
 "\n"
 "Общо източници:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7295,46 +7204,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7342,35 +7251,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7381,121 +7290,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7514,385 +7423,382 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Споделени файлове (%i)"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Сигурни ли сте,че желаете да откажете и изтриете всички файлове в тази категория?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Изисква потвърждение"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Твърде много връзки"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Избор на филтър"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Добавяне на категория"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Промяна на категория"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Премахване на категория"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Добре дошли!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7904,178 +7810,170 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 #, fuzzy
 msgid "Cancelled !"
 msgstr "Отказ"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Нулира"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8086,401 +7984,390 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,100 +17,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr ""
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr ""
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -119,47 +119,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -168,172 +167,165 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,269 +335,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,191 +603,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -808,1204 +789,1177 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr ""
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr ""
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr ""
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr ""
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2013,23 +1967,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2037,59 +1991,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2098,2647 +2052,2605 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 msgid "Connection & bandwidth"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 msgid "Connection speed:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr ""
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr ""
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr ""
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr ""
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr ""
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr ""
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr ""
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr ""
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr ""
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4746,11 +4658,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4760,836 +4672,836 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr ""
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr ""
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5599,1444 +5511,1443 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr ""
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 msgid "Connected since:"
 msgstr ""
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr ""
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr ""
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7044,7 +6955,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7052,155 +6963,153 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7209,46 +7118,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7256,35 +7165,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7295,121 +7204,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7428,383 +7337,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr ""
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr ""
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr ""
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7816,177 +7722,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -7997,400 +7895,389 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -25,25 +25,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.7\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "Quant a l'aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Control remot de l'aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Versió:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr "Client P2P 'Multiplataforma' basat en eMule \n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -51,79 +51,79 @@ msgstr ""
 "Quant a l'aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Part de l'aMule està basat en \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminament p2p basat en la mètrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Lloc web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Fòrum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Documentació:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Problemes:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprova si hi ha noves versions a l'inici"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "S'està connectant a Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "No disponible"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Afegeix un amic"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Heu d'introduir una IP i port vàlids!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informació"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "El resum d'usuari especificat no és vàlid!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -132,49 +132,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Després del nom de l'aplicació"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "La connexió ha fallat "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -183,103 +182,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "No s'ha pogut obrir el fitxer de enllaços ED2K."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu ID Baixa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Sortint del programa..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Fallades"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "S'està aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Aturant el procés amuleweb amb pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Sortida: Finalitzant nucli."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Aturada aMule completada."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultat de la depuració de la memòria a la sortida de l'aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "S'ha establert l'idioma Predeterminat del Sistema a causa d'un canvi de configuració. Disculpeu."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informació"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +283,70 @@ msgstr ""
 "\n"
 "Configuració EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "AVÍS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executant-se al pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No s'han pogut vincular els ports a l'adreça especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El port %u no està disponible. Tindreu ID BAIXA\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +361,48 @@ msgstr ""
 "\n"
 "Comproveu la configuració de la xarxa per a assegurar-vos que el port està obert."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "No s'ha pogut crear el fitxer de la signatura en línia de l'aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'idioma seleccionat no està instal·lat al PC. (Nota: s'intentarà establir igualment)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "És la primera vegada que executeu l'aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Aquesta és una versió de prova, actualitzada diàriament, i\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no podem garantir que no trenqui res, cremi casa vostra,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o mati al gos. Tanmateix el seu ús *hauria* de ser segur.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Podeu trobar més informació, ajuda i noves versions a la nostra pàgina web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o al nostre canal IRC #aMule de irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Podeu informar de qualsevol error a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,224 +410,220 @@ msgstr ""
 "La carpeta especificada per als fitxers de la signatura en línia és INVÀLIDA!\n"
 " S'INHABILITARÀ la signatura en línia fins que ho resolgueu a les preferències."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La preassignació d'espai per al fitxer '%s' ha fallat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no es pot obrir el fitxer de registre"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVÍS: el fitxer de registre està buit. Alguna cosa no va bé."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "S'ha reiniciat el registre"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Missatge del servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "S'ha omès la baixada de %s perquè el fitxer sol·licitat no és més recent."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "No s'ha pogut baixar la llista de nodes."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "No s'ha pogut obrir el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Fitxer de comprovació de versió corrupte"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Esteu usant una versió antiga de l'aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La vostra versió de l'aMule és %i.%i.%i i l'última versió és %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVÍS: La vostra versió d'aMuled és antiga: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "La vostra versió de l'aMule és l'última."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "No s'ha pogut baixar el fitxer de comprovació de versió"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuaris: %s | Fitxers: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuaris: E: %s K: %s | Fitxers: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "No s'han seleccionat xarxes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "amb ID Baixa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "amb ID Alta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connectat a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "S'està connectant a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desconnectat de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "S'ha engegat la xarxa Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "S'ha aturat la xarxa Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Connectat a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "No es pot usar la xarxa Kad si el port UDP està inhabilitat a les preferències, no s'engegarà."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "La xarxa Kad està inhabilitada a les preferències, no es connectarà."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERROR: no es pot usar el dimoni aMule quan les connexions externes estan inhabilitades. Per a activar les connexions externes, feu servir l'aMule normal, inicieu l'amuled amb la opció --ec-config o establiu el paràmetre \"AcceptExternalConnections\" a 1 al fitxer ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERROR: És obligatori l'ús d'una contrassenya vàlida per usar connexions externes, el dimoni de l'aMule no pot usar-se sense connexions externes. Per executar el dimoni aMule, el camp \"ECPassword\" del fitxer ~/.aMule/amule.conf ha de tenir un valor assignat. Executa amuled amb els paràmetres --ec-config per establir una contrassenya. Més informació a https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: A l'Inici - Iniciant timer"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "No s'ha pogut crear el fitxer Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s basat en eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,192 +633,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Cap xarxa"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Control remot de l'aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Error Fatal: Ha fallat la creació del Core Timer"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Connecta a l'amule remot"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "S'ha perdut la connexió"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Confirmació per a eixir"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -839,727 +820,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Error Fatal: Ha fallat la creació del Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "S'està executant un bucle..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Connectant..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Gestor d'esdeveniments de la IGU EC Remota"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connexió fallida. No ha estat possible connectar-se a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Aturant"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "L'intent de connexió a %s (%s:%i) ha excedit el temps."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Connecta a la xarxa."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Connexió fallida. No ha estat possible connectar-se a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "A punt"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Tots"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "No disponible"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "No s'ha trobat el fitxer."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantindrà el directori '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscant amic per connexió amb ID Baixa"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versió d'eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule fals)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule fals)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basat en l'eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Sobrenom: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Demanat: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques dels fitxers per a aquesta sessió: %d petició acceptada de %d, %s transferida\n"
 msgstr[1] "Estadístiques dels fitxers per a aquesta sessió: %d peticions acceptades de %d, %s transferides\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques dels fitxers per a totes les sessions: %d petició acceptada de %d, %s transferida\n"
 msgstr[1] "Estadístiques dels fitxers per a totes les sessions: %d peticions acceptades de %d, %s transferides\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "S'ha demanat un fitxer desconegut"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Missatge filtrat de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nou missatge de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'usuari %s (%u) ha demanat la llista de fitxers compartits del directori inexistent '%s' -> Ignorat"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "AVÍS: No es pot obrir %s."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVÍS: La llista dels fitxers cancel·lats és malmesa, conté una capçalera no vàlida."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Error d'E/S metre es llegia el fitxer %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Error mentre es desava el fitxer %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nova categoria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Carpeta per als fitxers entrants"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Heu d'especificar un nom per a la categoria!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Heu d'especificar un directori per a la categoria!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "No s'ha pogut crear el carpeta d'entrada per a la categoria. Si us plau, especifiqueu un directori vàlid!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "S'ha iniciat una sessió de xat: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Connectat amb el client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** S'està connectant amb el client ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** No s'ha pogut connectar amb el client / Connexió perduda ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Has superat el procés de comprovació del captcha i l'usuari ha rebut el teu missatge. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** La teva resposta al captcha he estat errònea i el teu missatge ha estatignorat. Pots demanar un nou captcha enviant un nou missatge. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Xat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Tanca la pestanya"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Tanca totes les pestanyes"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Tanca les altres pestanyes"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Afegeix a la llista d'amics"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "El fitxer de crèdits ha estat carregat, %u és un client conegut"
 msgstr[1] "El fitxer de crèdits ha estat carregat, %u són clients coneguts"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Han vençut els crèdits de %u client!"
 msgstr[1] " - Han vençut els crèdits de %u clients!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "No s'ha trobat el fitxer 'cryptkey.dat', creant-lo."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalls del client"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID Baixa"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID Alta"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Habilitada"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Suportada"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "No suportada"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Inhabilitada"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connectat"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desconnectat"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Sense completar"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Dolent"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificat - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "No disponible"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "L'usuari %s (%u) ha demanat la llista de fitxers compartits -> Acceptada"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "L'usuari %s (%u) ha demanat la llista de fitxers compartits -> Denegada"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "L'usuari %s (%u) ha demanat la llista de directoris compartits -> Acceptada"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "L'usuari %s (%u) ha demanat la llista de directoris compartits -> Denegada"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "L'usuari %s (%u) ha demanat la teva llista de fitxers compartits del directori '%s' -> Acceptada"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "L'usuari %s (%u) ha demanat la teva llista de fitxers compartits del directori '%s' -> Denegada"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "L'usuari %s (%u) comparteix el directori '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "L'usuari %s (%u) ha enviat directoris compartits no demanats."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "L'usuari %s (%u) ha enviat la llista de fitxers compartits del directori '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "L'usuari %s (%u) ha acabat l'enviament de la llista de fitxers compartits"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "L'usuari %s (%u) ha enviat una llista de fitxers compartits no desitjada"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "L'usuari %s (%u) ha denegat l'accés a la llista de fitxers/directoris compartits"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentaris del Fitxer"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Usuari"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxer"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoració"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentari"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "No es pot fer una cerca Kad si la xarxa Kad no està engegada"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Buscant amic per connexió amb ID Baixa"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Sense comentaris"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentari"
 msgstr[1] "%u comentaris"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "S'ha expulsat el client %s per haver enviat %s dades corruptes d'un total de %s del fitxer '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "No s'han pogut carregar les dades de país per a '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ba]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Al]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Molt alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Llançament"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Preguntant"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "S'està connectant via servidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Cua plena"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Cua"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "S'està baixant"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Rebent el conjunt de resums"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "No es necessiten parts"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "No és possible connectar d' ID Baixa a ID Baixa"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Massa connexions"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "S'està connectant via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Massa connexions Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Expulsats"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Error de la connexió"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Cua remota plena"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "MLDonkey antic"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "MLDonkey nou"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatible amb eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Servidor local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Intercanvi de fonts"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiu"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Enllaç"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Llavors font"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultat de la cerca"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completat"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "En progrés"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERROR: Sense espai al disc"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERROR: No s'ha trobat el partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERROR: error d'E/S!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERROR: Ha fallat!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "En cua"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Ja s'està baixant"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Format de fitxer temporal desconegut o defectuós."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Part"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferit"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocitat"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progrés"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonts"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritat"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Estat"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Temps Restant"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Últim cop vist complet"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Última recepció"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Esteu segur que voleu esborrar el fitxer seleccionat?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Esteu segur que voleu esborrar els fitxers seleccionats?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1568,109 +1526,106 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Atura"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Continua"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Neteja els completats"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Intercanvia cada A4AF a aquest fitxer ara"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Intercanvia cada A4AF a aquest fitxer (Automàtic)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Intercanvia cada A4AF a qualsevol altre fitxer ara"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opcions avançades"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Previsualitza"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Mostra els &detalls del fitxer"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Mostra els comentaris"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copia l'enllaç amb format Magnet al porta-retalls"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copia &l'enllaç eD2k al porta-retalls"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copia la &informació al porta-retalls"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "Cap categoria"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Assigna a una categoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Obre el fitxer"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Introduïu un nom nou per al fitxer:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Reanomena"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%d/%m/%y %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Baixades (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1679,348 +1634,347 @@ msgstr ""
 "Per a evitar que en cada previsualització aparegui aquest avís, configureu\n"
 "un reproductor de vídeo a les preferències (per defecte s'usa %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Previsualització"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: No s'ha pogut executar un reproductor multimèdia extern! Ordre: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Desant fitxer de parts %u de %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Tots els fitxers de parts desats."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "S'estan carregant els fitxers de %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "S'està carregant els fitxer de descarrega %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERROR: No s'ha pogut carregar la còpia de seguretat. Cerqueu '.part.met recovery solutions' a https://github.com/amule-org/amule/discussions."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Tots els fitxers de parts carregats."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "No s'han trobat fitxers de parts"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Trobat %u fitxer de parts"
 msgstr[1] "Trobats %u fitxers de parts"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "El sistema de fitxers del directori Temp no pot gestionar fitxers de grans dimensions."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "El sistema de fitxers per al directori Incoming no pot gestionar fitxers de grans dimensions."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "S'està baixant %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Ja esteu intentant baixar el fitxer '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Ja disposeu del fitxer '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Ja disposeu del fitxer '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ja esteu intentant baixar el fitxer %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "No s'ha pogut convertir l'enllaç magnet a eD2k: %s+"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocol desconegut de l'enllaç: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Enllaç eD2k invàlid! ERROR: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "El client ha enviat un paquet després d'una autenticació fallida."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Connexió externa tancada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes han estat inhabilitades per manca d'una contrasenya!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes estan inhabilitades al fitxer de configuració"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nova connexió externa acceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no s'ha pogut acceptar una nova connexió externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "S'ha rebutjat la connexió externa per manca d'una contrasenya a les preferències!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "S'està connectant al client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versió desconeguda"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versió EC incorrecta, pot haver-hi incompatibilitat binaria. Useu un nucli i un client remot del mateix llançament (versió)."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "No us podeu connectar a una versió final des d'una versió de desenvolupament arbitrària! *buf* s'ha evitat una possible fallada"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versió del protocol invàlida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Marcador de la versió del protocol inexistent."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "L'autenticació ha fallat: el resum especificat com a contrasenya d'EC no és vàlid."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Ha fallat l'autenticació: contrasenya incorrecta"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Ha fallat l'autenticació: falta la contrasenya"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Petició invàlida, primer heu d'autenticar-vos."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Accés concedit."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "S'ha enviat el missatge d'error \"%s\" al client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intent d'accés no autoritzat de %s. Connexió tancada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ha fallat una ordre remota de fitxer de parts: No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "No s'ha trobat el resum del fitxer: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Error en processar el codi d'opció!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "No s'ha afegit el servidor"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "no s'ha trobat el servidor: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "és necessari definir el servidor a esborrar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k és inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La recerca web des de la interfície remota no té sentit."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Cerca en procés. S'obtindran resultats en un moment!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Cap punt per al gràfic."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "El vostre client no està configurat per a aquest nivell de detall."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Connexió externa: s'ha demanat l'aturada"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Ja s'està aturant."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: afegint l'enllaç '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "No s'ha trobat el fitxer."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nom de fitxer invàlid."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "No s'ha pogut canviar el nom del fitxer."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad està inhabilitada a les preferències."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Ja esteu connectat a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Connectant a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Ja esteu connectat a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "S'està connectant a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Totes les xarxes estan inhabilitades."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desconnectat de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desconnectat de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexió externa: s'ha rebut un codi d'opció invàlid: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Codi d'opció invàlid (versió de protocol errònia?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensió '%s' desconeguda per a l'ordre '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Ordre '%s' desconeguda.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2028,7 +1982,7 @@ msgstr ""
 "\n"
 "Aquesta ordre no pot tenir un argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2036,7 +1990,7 @@ msgstr ""
 "\n"
 "Aquesta ordre ha de tenir un argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Aquesta ordre és incompleta, heu d'usar una de les extensions de sota.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2052,11 +2006,11 @@ msgstr ""
 "\n"
 "Extensions disponibles:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Ordres disponibles:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2067,17 +2021,17 @@ msgstr ""
 "Les majúscules no influeixen a les ordres.\n"
 "Escriviu '%s <ordre>' per a aconseguir informació sobre l' <ordre>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Surt de l'aplicació."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Mostra l'ajuda."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2085,7 +2039,7 @@ msgstr ""
 "Per a aconseguir ajuda sobre una ordre, escriviu 'help <ordre>'.\n"
 "Per a veure la llista completa d'ordres escriviu 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2096,46 +2050,46 @@ msgstr ""
 "Useu '%s' per a la llista d'ordres\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Error de sintaxi!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "S'ha produït un error processant una ordre - això no hauria de passar mai! Informeu de l'error, si us plau\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Aquesta ordre ha de tenir un paràmetre."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argument invàlid."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Aquesta ordre és incompleta."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Escriviu '%s' per a aconseguir més ajuda.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Això és %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Això és %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2143,7 +2097,7 @@ msgstr ""
 "\n"
 "S'està creant el client...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2152,7 +2106,7 @@ msgstr ""
 "\n"
 "D'acord, eixint %s ...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2166,331 +2120,326 @@ msgstr ""
 "\n"
 "Eixint...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Mostra aquest text d'ajuda."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Ordinador on està executant-se l'aMule. (per defecte: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port de l'aMule per a connexions externes. (per defecte: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Contrasenya per a les connexions externes."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Llegeix la configuració des del fitxer."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "No mostra res per la sortida estàndard."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Detallat - mostra també els missatges de depuració."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Estableix la localització del programa (idioma)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Escriu al fitxer de configuració les opcions de la línia d'ordres."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un fitxer de configuració basat en el de l'aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Mostra la versió del programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalls del fitxer"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% fet"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Benvinguts!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Connectant amb un amic"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Estat de la connexió:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Xarxes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Port TCP per defecte:"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extès (Kad / cerca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activa UPnP per redirecció de ports"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Arrancada"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ja esteu intentant baixar el fitxer %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Actualitza automàticament la llista de servidors a l'inici"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Explora"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per a lectura!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per a escriptura!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amics"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Mostra els &detalls"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Afegeix un amic"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Elimina l'amic"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Envia un &missatge"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Veure els compartits"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Estableix posició (slot) d'amic"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Esteu segur que voleu esborrar l'amic seleccionat?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Esteu segur que voleu esborrar els amics seleccionats?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2498,11 +2447,11 @@ msgstr ""
 "No podeu establir més d'una posició d'amic.\n"
 " Només s'ha assignat una posició."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selecció múltiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2511,206 +2460,205 @@ msgstr ""
 "No podeu establir més d'una posició d'amic.\n"
 " Només s'ha assignat una posició."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Envia un missatge a l'usuari"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Missatge a enviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Elimina'l dels amics"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Envia un missatge"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercanvia cap a aquest fitxer"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En cua: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "S'ha preguntat per un altre fitxer"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Esperant un lloc de pujada"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "En cua: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Pujant"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Cap"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "S'està baixant..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Descàrrega HTTP cancel·lada"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "L'adreça URL a baixar no pot estar buida"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "S'han baixat %d bytes"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'adreça URL %s ha retornat: %i - Error (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descàrrega HTTP cancel·lada"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Baixant nou GeoIP.dat de %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Baixada del fitxer GeoIP.dat fallida, actualització interrompuda."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Fallada a l'esborrar el fitxer %s, actualització interrompuda."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Fallada al canviar de nom el fitxer %s, actualització interrompuda."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Actualització de %s correcta"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Error actualitzant GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Fallada descarregant %s de %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "S'estan carregant els filtres IP 'ipfilter.dat' i 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "No s'ha pogut carregar el fitxer ipfilter.dat '%s', s'ha trobat un format desconegut."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "No s'ha pogut carregar el fitxer ipfilter.dat '%s', ha estat impossible obrir el fitxer."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "S'ha carregat %u rang IP des de '%s'."
 msgstr[1] "S'han carregat %u rangs IP des de '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "S'ha descartat %u línia malformada."
 msgstr[1] "S'han descartat %u línies malformades."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Fallada al canviar de nom el nou fitxer %s, actualització interrompuda."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "El filtre d'IP està llest"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2718,876 +2666,844 @@ msgstr ""
 "Inicia des dels \n"
 "clients coneguts"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodes (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP invàlida per a l'arrancada"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Port invàlid per a l'arrancada"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Si us plau empleneu tots els camps requerits"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Missatge"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Esteu segur que voleu baixar un nou fitxer nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Fer-ho esborrarà els nodes actuals i reiniciarà la connexió Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Voleu continuar?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: la paraula clau de cerca és massa curta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Paraula clau de cerca ja es troba a la llista de cerca: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "No s'ha pogut llegir el fitxer nodes.dat - és massa antic. Aquesta versió (0) ja no és compatible."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "S'ha llegit %u contacte Kad"
 msgstr[1] "S'han llegit %u contactes Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "No es troben contactes, si us plau reinicia o baixa un nou fitxer nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Només %d contacte Kad disponible, nodes.dat no es pot escriure"
 msgstr[1] "Només %d contactes Kad disponibles, nodes.dat no es pot escriure"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "S'ha escrit %d contecte Kad"
 msgstr[1] "S'han escrit %d contactes Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Xarxa Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nom del fitxer"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Mida"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Ràtio"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Peticions"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Acceptades"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fonts completes"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ALERTA: Llista de fitxers coneguts malmesa, conté una capçalera no vàlida."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "No s'ha pogut carregar l'entrada a la llista de fitxers coneguts, el fitxer podria estar corrupte"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada no vàlida a la llista de fitxers coneguts, el fitxer podria estar corrupte: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Error desconegut %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "No s'ha pogut obtenir la descripció de l'error per a l'error %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Resumint"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Completant"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Complet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroni"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperant"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Heu d'especificar una contrasenya (no buida)."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Contrasenya invàlida, no és un resum MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Fallada en la connexió"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Connexió externa tancada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "La connexió externa ha fallat. Resposta buida."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Connexió externa: Resposta incorrecta, confirmació de connexió fallida. S'ha tancat la connexió."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Connexió establerta amb l'aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Connexió establerta amb èxit."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Connexió externa: Accés denegat perquè: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Connexió externa: Conformitat de connexió denegada."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERROR: No s'ha pogut escoltar el port TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERROR: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVÍS: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Tanca"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Retalla"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Enganxa"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Neteja"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Connectat"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Connectat"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Connectat a Kad (tallafocs)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP del Servidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP del servidor:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Desconnectat"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Port TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Port TCP: No està llest"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Port UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Port UDP: No està llest"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informació del client"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Límit de pujada"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Límit de baixada"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostra l'aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Amaga l'aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Surt"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Il·limitat"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menú de la icona d'estat"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Límits de velocitat:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "PU: cap"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "PU: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "BA: cap"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "BA: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocitat de baixada: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocitat de pujada: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Sobrenom: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "No heu seleccionat cap sobrenom!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID de client: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Servidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP del Servidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Desconnectat"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Signatura en línia: Habilitada"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Signatura en línia: Inhabilitada"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Funcionant: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Fitxers compartits: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clients en cua: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total BA: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total PU: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Afegeix un enllaç magnet o eD2k al nucli."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Afegeix a la llista d'amics"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Feu clic per a afegir l'enllaç eD2k del camp de text a la cua de descàrregues."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Els esdeveniments es mostren aquí. Per a veure la llista completa, mireu el registre de la pestanya Servidors."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Carregant ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Número d'usuaris al servidor on esteu connectat ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Usuaris: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Usuaris connectats al servidor actual i una estimació del nombre total d'usuaris."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "PU: 0.0 | BA: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "La mitjana de pujada i baixada actuals. Si està habilitat, el valor entre parèntesis mostra la sobrecàrrega provinent de les comunicacions amb els clients."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Mostra l'estat de la connexió i les transferències actives. El vermell vol dir que no esteu connectat actualment, el groc que teniu ID baixa (bloquejat per un tallafocs) i el verd que teniu ID alta (el tipus de connexió òptim)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Desconnectat ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Servidor connectat actualment."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Cerca"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nom:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Cerca avançada"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtratge"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipus de fitxer"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Qualsevol"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arxius"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Àudio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imatges de CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Imatges"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programes"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Documents"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vídeos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensió"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Mida Mín."
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Mida Màx."
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilitat"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtre:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Resultat del filtre"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverteix el resultat"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Amaga els fitxers coneguts"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Inicia"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Més"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Atura"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Baixada"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Buida els camps"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultats"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Neteja les baixades completades"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonts del fitxer:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "General "
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nom Complet:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Fitxer-met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Resum:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Mida:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferència "
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Estat de les parts:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Últim cop vist complet:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fonts trobades:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Fonts transferint:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Compte de parts:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibilitat:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Temps actiu de baixada:"
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferit:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Completats:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestió intel·ligent de la corrupció "
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdut per corrupció:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Guanyat per compressió:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paquets recuperats per I.C.H.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Compartint: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Peticions"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Peticions acceptades"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Dades transferides"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Ràtio"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fonts completes"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Compartits"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", pujat: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Sense Valorar"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Títol:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Noms del fitxer "
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Copia"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Neteja"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplica"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comenta o valora el fitxer (visible per a tots els usuaris)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3595,1269 +3511,1265 @@ msgstr ""
 "Per una pel·lícula es pot definir la seva durada, la seva història, llenguatge...\n"
 "i si és falsa, es pot informar a altres usuaris d'aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Qualitat del fitxer"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Sense Valorar"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Invàlid / Corrupte / Fals"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Pobre"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Correcte"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bo"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excel·lent"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Seleccioneu una valoració, o aviseu si el fitxer no és correcte ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Desconnectat de Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Refresca"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "S'està baixant, si us plau espereu ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Mida desconeguda"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informació requerida"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Adreça IP:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informació addicional"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Usuari:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocitat de pujada"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Baixades actives"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Arbre d'estadístiques"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Programari:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versió del client:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Adreça IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID de l'usuari:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP del servidor:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nom del servidor:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Ofuscació:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferències amb el client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Petició actual:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Mitjana de pujada:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Mitjana de baixada:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Pujat (sessió):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Baixat (sessió):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Pujat (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Baixat (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Puntuacions"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador PU/BA:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificació segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Posició a la cua:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Puntuació (a la cua):"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Sobrenom"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - el Mule multi-plataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Aquest és el (vostre) nom que els altres usuaris veuran en connectar-se."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "El retard abans de mostrar els consells (notes emergents)."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Açò especifica la llengua que s'usarà."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Comprova si hi ha noves versions a l'inici"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "L'aMule comprovarà si hi ha noves versions durant l'inici"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Inicia minimitzat"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "L'aMule es minimitzarà automàticament a l'inici."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Confirmació per a eixir"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Sol·licita confirmació al sortir."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Habilita la icona d'estat"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Habilita/Inhabilita la icona d'estat a la safata del sistema."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Amaga la finestra de l'aplicació en prémer el botó de tancar"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimitzar a la safata de sistema"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "L'aMule es minimitzarà a la safata de sistema (icona), enlloc de a la barra de tasques (llista de programes)."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Mostra notificacions en finalitzar les baixades"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si s'habilita, l'aMule mostrarà notificacions quan hagin finalitzat les baixades."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Temps de retard de l'indicador de funció:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segons"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selecció del navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Obre en una nova pestanya si és possible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Obre la pàgina web en una nova pestanya en comptes de obrir una nova finestra si és possible"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Límits d'ample de banda "
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Pujada"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Per posició (slot)"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Ports "
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Aquest és el port eD2k estàndard i no es pot inhabilitar."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP per sol·licituds del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Aquest port UDP és utilitzat per sol·licituds eD2k i Kad exteses"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP Port TCP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Nombre màxim de fonts per descàrrega:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autoconnecta a l'inici"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconnecta en perdre la connexió"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Elimina els servidors morts després de"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "intents"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Llista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualitza la llista de servidors quan es connecti amb un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualitza la llista de servidors quan es connecta un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usa el sistema de prioritats"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Usa la comprovació intel·ligent d'ID Baixa en connectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Connexió segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconnecta només a servidors de la llista estàtica"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Estableix prioritat Alta per als servidors afegits manualment"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Afegeix les noves baixades en mode pausat"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Afegeix les noves baixades amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Intenta baixar abans les parts inicials i finals"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Inicia el següent fitxer pausat quan s'acabi una descàrrega"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "De la mateixa categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "En ordre alfabètic"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Preassigna l'espai al disc per als fitxers nous"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per a fitxers nous reserva l'espai que ocuparà el fitxer complet. Açò redueix la fragmentació"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Atura les descàrregues quan l'espai buit al disc arribi a "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccioneu-ho si voleu que l'aMule comprovi l'espai del disc"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Poseu l'espai mínim de disc desitjat."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Recorda 10 fonts dels fitxers rars (amb < 20 fonts)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Pujades"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Afegeix els nous fitxer compartits amb prioritat automàtica"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestió d'Errors Inteligent (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Activa"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançat confia en totes les comprovacions (no recomanat)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Carpetes compartides"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Per a compartir recursivament feu clic dret sobre el directori)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Comparteix els fitxers ocults"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gràfics"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Actualitza cada: 5 segs"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Temps per al gràfic de mitjana: 100 mins"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del Gràfic de Connexions: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Escala del gràfic de descàrrega:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala del gràfic de pujada:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Colors: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Graella"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Baixada actual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Mitjana de baixada total"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Mitjana de baixada de la sessió"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Pujada actual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Mitjana de pujada total"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocitat de la icona d'estat"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nodes-Kad actuals"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nodes-Kad funcionant"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Selecciona"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions de client a mostrar (0=il·limitat)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! AVÍS !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Connexions noves màx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Mida del buffer de fitxer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Mida de la cua de pujades: 5000 clients"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Inhabilita el mode d'espera programat de l'ordinador"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Aparença a usar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra \"Gestor ràpid de links eD2k\" en totes les finestres."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informació estesa a les pestanyes de les categories"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Mostra la versió de l'aplicació al títol"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Mostra les velocitats de transferència al títol"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Abans del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Després del nom de l'aplicació"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Mostra ample de banda sobrecarregat"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientació vertical de la barra d'eines"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Cua de descàrregues"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Mostra el percentatge de descàrrega"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Mostra barra de descàrrega"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denega l'accés de convidats"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Contrasenya de convidat per al servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4865,11 +4777,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4879,519 +4791,519 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Compartits"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Inhabilitat [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "segs"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "mins"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "hores"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dies"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "tot"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "tota la resta"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incomplet"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Aturat"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeos"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arxius"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Documents"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Actiu"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Directori de configuració: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperant que el fil de conversió de fitxers de parts acabi..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "S'està important %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "S'està llegint la carpeta temporal"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "S'està recuperant la informació bàsica del fitxer d'informació de baixada"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "S'està creant el fitxer de destí"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "S'està carregant les dades del fitxer de baixada antic (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "S'està desant el bloc de dades a un nou fitxer de baixada únic (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "S'està recuperant informació del fitxer de baixada font"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "S'està afegint la baixada i desant un nou fitxer de parts"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importa fitxers de parts"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estat"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Resum del fitxer"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disc: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Seleccioneu una carpeta amb baixades temporals! (recursiu)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Voleu que s'esborrin els fitxers originals de les baixades importades amb èxit?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Voleu esborrar les fonts?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERROR: No s'ha pogut crear el fitxer de parts"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "S'està intentant carregar la còpia del fitxer met des de %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERROR: el fitxer part.met té mida 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERROR: Versió del fitxer part.met invàlida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Error: %s (%s) és corrupte (etiquetes incorrectes: %s), no s'ha pogut carregar el fitxer."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERROR: %s (%s) és corrupte (compte d'etiquetes erroni), no s'ha pogut carregar el fitxer."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "S'està intentant recuperar la informació del fitxer..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "S'està recuperant un fitxer sense nom - s'intentarà recuperar com a RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "S'ha recuperat tota la informació disponible :D - S'està intentant usar-la..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "No s'ha pogut recuperar la informació del fitxer :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "No s'ha pogut obrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVÍS: %s pot ser corrupte (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERROR mentre es desava un fitxer de parts: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "ERROR E/S mentre es desava un fitxer de parts: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "No s'ha pogut desar el fitxer part.met.seeds per a %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i llavor font desada per al fitxer de parts: %s (%s)"
 msgstr[1] "%i llavors fonts desades per al fitxer de parts: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "No es pot llegir el fitxer de llavors per al fitxer de parts: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Error en llegir el fitxer de llavors del fitxer de parts (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "S'ha trobat una part corrupta (%d) en el fitxer de parts %d %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "S'ha trobat una part corrupta (%d) en els fitxers de parts %d %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "S'ha trobat una part completa (%i) a %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "S'ha acabat de refer els resums de %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "S'ha produït un error inesperat mentre es completava %s. S'ha pausat el fitxer."
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "S'ha acabat de baixar: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5400,307 +5312,307 @@ msgstr ""
 "S'ha acabat de baixar:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "S'està esborrant el fitxer: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVÍS: No ha estat possible fer el resum de la part descarregada - conjunt de resums incomplet per a '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: No ha estat possible fer el resum de la part descarregada - conjunt de resums incomplet (%s). Açò no hauria de passar mai."
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "S'ha arribat al final del fitxer (EOF) mentre es calculava el resum de la part baixada %u amb longitud %u (màx %u) del fitxer de part '%s' amb longitud %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVÍS: No hi ha suficient espai al disc dur! S'està pausant el fitxer: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Corrupció a la part baixada %i del fitxer: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: S'ha recuperat la part corrupta %i de %s -> Bytes desats: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Assignant"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espai en disc insuficient"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixat"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Connexió"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directoris"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidors"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Seguretat"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfície"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Servidor intermediari"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Control remot"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Signatura en línia"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avançat"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Depuració"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5710,15 +5622,15 @@ msgstr ""
 "    %PARTFILE - camí complet al fitxer\n"
 "    %PARTNAME - només el nom del fitxer"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5734,35 +5646,35 @@ msgstr ""
 "L'aMule anirà bé sense canviar cap\n"
 "d'aquests paràmetres."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Connexió fallida entre Cfg i el giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades de Cfg al giny amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "El tipus de servidor intermediari al que connecteu"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Fallida en l'enviament de dades del giny al Cfg amb ID %d i clau %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5770,41 +5682,41 @@ msgstr ""
 "S'ha de reiniciar l'aMule per a habilitar aquests canvis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- El port TCP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- El port UDP ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- S'ha canviat el port de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- S'ha canviat l'acceptació de la connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- S'ha canviat la interfície de connexió externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- S'ha canviat el suport d'ofuscació de protocol.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5812,7 +5724,7 @@ msgstr ""
 "La llista d'actualització de servidors és buida.\n"
 "L'actualització de servidors a l'inici serà desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5820,33 +5732,33 @@ msgstr ""
 "Heu habilitat les connexions externes però no heu especificat una contrasenya.\n"
 "Les connexions externes no poden ser habilitades a menys que s'hagi especificat una contrasenya externa vàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- L'idioma ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- El directori temporal ha canviat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Xarxa ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versió del protocol invàlida."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5854,7 +5766,7 @@ msgstr ""
 "Les xarxes eD2k i Kad estan inhabilitades.\n"
 "No podreu connectar fins que n'habiliteu almenys una."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5862,7 +5774,7 @@ msgstr ""
 "La xarxa Kad no s'engegarà si el port UDP està inhabilitat.\n"
 "Habiliteu el port UDP o inhabiliteu la xarxa Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5872,69 +5784,69 @@ msgstr ""
 "HEU de reiniciar l'aMule ara mateix.\n"
 "Si no reinicieu ara, no vos queixeu dels possibles problemes.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Autorefresc iniciat"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Carpeta on desar les descàrregues temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Contrassenya definida i connexions externes activades."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5944,66 +5856,66 @@ msgstr ""
 "Si us plau, ompliu-la amb una URL que apunti a un fitxer server.met vàlid.\n"
 "Feu clic sobre el botó \"Llista\" d'aquest quadre de verificació per afegir una adreça."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Fitxers temporals"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Fitxers entrants"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Signatures en línia"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Carpeta per a %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Explora per a trobar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecciona navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminat"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Edita la llista de servidors"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6011,1206 +5923,1205 @@ msgstr ""
 "Afegiu adreces URL d'on baixar el fitxer server.met.\n"
 "Només una adreça a cada línia."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Fonts completes"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estat:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Retard de l'actualització: %d seg"
 msgstr[1] "Retard de l'actualització: %d segs"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps per al gràfic de mitjanes: %d min"
 msgstr[1] "Temps per al gràfic de mitjanes: %d mins"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala del gràfic de connexions: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Mida de la memòria intermèdia de fitxer: %d byte"
 msgstr[1] "Mida de la memòria intermèdia de fitxer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Mida de la cua de pujada: %d client"
 msgstr[1] "Mida de la cua de pujada: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Interval de refresc de la connexió amb el servidor: %d minut"
 msgstr[1] "Interval de refresc de la connexió amb el servidor: %d minuts"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval de refresc de la connexió amb el servidor: Inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "inhabilitat"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executa una ordre per a l'esdeveniment '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Activa l'execució d'ordres al nucli"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Odre del nucli:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Activa l'execució d'ordres a la interfície gràfica"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Ordre de la IGU:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Les següents variables seran reemplaçades:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartides"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Error en la cerca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màxima."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Avís de cerca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "No es pot executar una cerca eD2k si la xarxa eD2k no està connectada"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "No hi ha cap paraula clau per a la cerca Kad - s'està avortant"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Error inesperat mentre s'intentava fer una cerca Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Resum del fitxer"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Sense Valorar"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Baixa a la categoria"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obté %s per aquest fitxer"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca fitxers relacionats (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marca com a fitxer conegut"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia l'enllaç eD2k al porta-retalls"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Esteu connectat al servidor què intenteu eliminar. Si us plau, primer desconnecteu-vos."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Cancel·lat"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nou"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "No s'ha pogut connectar amb els servidors ofuscats de la llista. Intentant-ho de nou sense ofuscació."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "No s'ha pogut connectar amb els servidors ofuscats de la llista. Intentant-ho de nou sense ofuscació."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "No s'ha pogut connectar amb cap servidor de la llista. Intentant-ho de nou."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "No s'ha pogut connectar amb cap servidor de la llista. Intentant-ho de nou."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "La xarxa eD2k és inhabilitada a les preferències, no es connectarà."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "No s'han trobat a la llista servidors vàlids als que connectar"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Connectat a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Connexió establerta amb: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Error fatal en intentar connectar. La connexió a Internet pot haver caigut"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "S'ha perdut la connexió a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) sembla estar aturat."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) sembla estar ple."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Es reintentarà la connexió al servidor en %d segon"
 msgstr[1] "Es reintentarà la connexió al servidor en %d segons"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "No s'ha pogut connectar a %s (%s:%i)."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERROR: Sòcol invàlid en comprovar el temps d'espera"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "L'intent de connexió a %s (%s:%i) ha excedit el temps."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Resposta de DNS rebuda a destemps, omitint."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "S'està carregant el fitxer server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "No s'ha trobat el fitxer server.met!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "No s'ha pogut carregar el fitxer server.met '%s', s'ha trobat un format desconegut."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "No s'ha pogut obrir el server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Fitxer server.met corrupte, s'ha trobat una etiqueta de versió invàlida: 0x%x, mida %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "S'ha trobat %i servidor al server.met"
 msgstr[1] "S'han trobat %i servidors al server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d servidor afegit"
 msgstr[1] "%d servidors afegits"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Error: el fitxer 'server.met' està corrupte: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Error d'E/S mentre es llegia el fitxer 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "No s'ha afegit el servidor: [%s:%d] no s'especifica un port vàlid."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "No s'ha afegit el servidor: L'IP de [%s:%d] ha estat filtrada o no és vàlida."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "No s'ha afegit el servidor: S'ha trobat un servidor amb IP:Port [%s:%d] iguals."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "S'ha afegit un Servidor: [%s:%d] s'està usant el nom '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Esteu connectat al servidor què intenteu eliminar. Si us plau, primer desconnecteu-vos."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "No s'ha pogut obrir '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "No s'ha pogut desar el server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Adreça invàlida"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "S'ha acabat de baixar la llista de servidors des de %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "No s'ha trobat cap adreça d'una llista de servidors al fitxer 'addresses.dat'. Enganxeu una adreça cap a una llista de servidors vàlida a aquest fitxer per a que es pugui actualitzar automàticament la llista de servidors"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Comença a baixar la llista de servidors des de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "AVÍS: s'ha especificat una URL invàlida per a l'actualització automàtica de servidors: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "No s'ha trobat una URL per a baixar un server.met al fitxer addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "No s'ha pogut baixar la llista de servidors des de %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "El servidor local està filtrat pels filtres IP, s'està reconnectant a un servidor diferent!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adreça"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descripció"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Usuaris"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Estàtic"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versió"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Esteu intentant esborrar un servidor al què esteu connectat. Si us plau, desconnecteu-vos primer. NO s'ha esborrat el servidor."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nom desconegut)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Esteu segur que voleu esborrar el servidor estàtic %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servidors (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Servidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connecta al servidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marca el servidor com a estàtic"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marca el servidor com a no estàtic"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marca els servidors com a estàtics"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marca els servidors com a no estàtics"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Esborra el servidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Esborra els servidors"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Esborra tots els servidors"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copia els enllaços eD2k al porta-retalls"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconnecta amb el servidor"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Esteu segur que voleu esborrar tots els servidors?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Esteu segur que voleu esborrar el servidor seleccionat?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Esteu segur que voleu esborrar els servidors seleccionats?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERROR: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVÍS: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "La nova ID d'usuari és %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVÍS: Heu rebut una ID Baixa!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tAixò normalment és perquè esteu darrere d'un tallafocs o un encaminador."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPer a rebre més informació, si us plau visiteu https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "S'ha rebut una informació desconeguda del servidor! - massa curta"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "S'han rebut %d servidor nou"
 msgstr[1] "S'han rebut %d servidors nous"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "S'ha desat la llista de servidors."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "El servidor ha rebutjat l'última ordre"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "S'ha rebut un paquet fals del servidor: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "S'ha produït un error sense tractament mentre es processava un paquet del servidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "No es pot crear el fil per a resoldre DNSs per a connectar amb %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "L'IP del servidor %s (%s) està filtrada.  No es connectarà."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "S'està utilitzant l'ofuscació de protocol."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "S'està connectant a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "No es pot resoldre el dns per al servidor %s: Ha estat impossible connectar!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Registre de l'aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "No s'ha afegit el servidor: No s'ha especificat cap IP o nom de servidor."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "No s'ha afegit el servidor: El port del servidor especificat és invàlid."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Estat eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Estat de la connexió:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Connectat"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Estat Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Executant en mode LAN (xarxa d'àrea local)"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Funcionant"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID del client Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Estat:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estat de la connexió:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Bloquejat - obre el port TCP %d en el teu encaminador o tallafocs"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estat de la connexió UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Bloquejat - obre el port UDP %d en el teu encaminador o tallafocs"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estat rere-tallafocs: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Cap amic necessari - Port TCP obert"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Cap amic necessari - Port UDP obert"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Cap amic"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Connectant amb un amic"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connectat amb l'amic a %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fonts indexades:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Paraules clau indexades:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notes indexades:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Càrrega indexada:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Mitjana d'usuaris:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Mitjana de fitxers:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Aturat"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Afegint fitxer %s a compartits"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "S'ha trobat %i fitxer compartit conegut, %i desconeguts"
 msgstr[1] "S'han trobat %i fitxers compartits coneguts, %i desconeguts"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERROR: S'ha intentat compartir %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Carpeta compartida no trobada, omitint: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No s'ha trobat cap fitxer en el directori: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nom d'usuari"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocitat de baixada"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocitat de pujada"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Parts disponibles"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Estat de pujada"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Estat remot"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nom de fitxer local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Llista de fitxers compartits"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Parts obtingudes"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Ubicació"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Afegeix comentari / valoració"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Edita comentari / valoració"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Reanomena"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Afegeix els fitxers de la col·lecció a les transferències"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copia l'enllaç en format &Magnet al porta-retalls"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (&Font)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (Font) (amb les opcions de &xifrat)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (&Nom de l'ordinador)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (Nom de l'ordinador) (amb les &opcions de xifrat)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (amb l'informació &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copia l'enllaç eD2k al porta-retalls (informació &AICH + font)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Necessiteu ID Alta per crear un enllaç font vàlid"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom de fitxer remot"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Dades pujades (sessió (total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Sobrecàrrega total (paquets): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Sobrecàrrega per peticions de fitxers (paquets): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Sobrecàrrega en l'intercanvi de fonts (paquets): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Sobrecàrrega del servidor (paquets): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Sobrecàrrega Kad (paquets): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Excedent per xifrat (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Pujades actius: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Pujades en espera: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total de sessions de pujada resoltes: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de sessions de pujada fallades: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Temps mitjà de pujada: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Dades baixades (sessió (total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fonts trobades: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Baixades actives (trossos): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Raó PU:BA de la sessió (total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Raó de baixada mitjana (Sessió): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Raó de pujada mitjana (Sessió): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Raó de baixada màxima (Sessió): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Raó de pujada màxima (Sessió): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconnexions: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Temps des de la primera transferència: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Connectat al servidor des de fa: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Connexions actives (aprox.): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "S'ha arribat al límit de connexions màxim: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Mitjana de connexions (aprox.): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pic de connexions (aprox.): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clients"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Desconegut: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrat: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Expulsat: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i Coneguts: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servidors funcionant: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servidors que han fallat: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servidors esborrats: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servidors filtrats: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Usuaris en servidors funcionant: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Fitxers en servidors funcionant: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Usuaris totals: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Fitxers totals: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Càrrega del servidor: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Fitxers compartits: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Mida total dels fitxers compartits: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Mida mitjana de fitxer: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema operatiu"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "No s'ha rebut"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Connexions actives (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "No disponible"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Mai"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "L'ordre '%s' amb pid '%d' ha finalitzat amb el codi d'estat '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> i surt."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Format IP invàlid. Useu xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Aquesta ordre requereix un argument. Arguments vàlids: 'all', nom del fitxer, o un número.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "S'està processant per resum: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "S'està processant per nom del fitxer: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Aquesta ordre requereix un argument. Arguments vàlids: un resum de fitxer (hash).\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Número invàlid\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "No és un resum vàlid (la longitud hauria de ser exactament de 32 caràcters)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7221,7 +7132,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7232,7 +7143,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7240,82 +7151,80 @@ msgstr ""
 "No s'ha definit cap tipus de cerca.\n"
 "Escriviu 'help search' per obtenir més ajuda.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Baixant el fitxer: %lu %s\r\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "La petició ha fallat amb un error desconegut."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "La operació ha finalitzat amb èxit."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "La petició ha fallat amb el següent error: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "El filtre IP per a clients és: %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Desactivat"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Activat"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "El filtre IP per a servidors és: %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "El nivell actual del filtre IP és %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Límits d'ample de banda: Pujada: %u kB/s, Baixada: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Connectat a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Connectant"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "protegit per un tallafocs"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "correcte"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7324,7 +7233,7 @@ msgstr ""
 "\n"
 "Baixada:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7333,7 +7242,7 @@ msgstr ""
 "\n"
 "Pujada:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7342,7 +7251,7 @@ msgstr ""
 "\n"
 "Clients a la cua:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7351,46 +7260,46 @@ msgstr ""
 "\n"
 "Fonts totals:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Fitxer de parts]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultats de la cerca: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progrés de la cerca: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progrés de cerca no disponible"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "S'ha rebut una resposta desconeguda del servidor, codi d'opció = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Mostra la informació d'estat resumida."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Mostra l'estat de la connexió, velocitat de pujada/baixada actuals, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Mostra l'arbre d'estadístiques complet."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7404,11 +7313,11 @@ msgstr ""
 "\n"
 "Exemple: 'statistics 5' només mostrarà les 5 versions més usades de cada tipus de client.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Atura l'aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7418,35 +7327,35 @@ msgstr ""
 "Açò també aturarà el client de text, ja que no és pot usar sense\n"
 "haver un nucli en execució.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recarrega l'objecte donat."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recarrega la llista de fitxers compartits."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recarrega la taula de filtrat IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Recarrega la taula de filtrat IP actual."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Recarrega la taula de filtrat IP des d'una URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Si s'omet l'URL s'usa l'URL de les preferències."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Connecta a la xarxa."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7458,35 +7367,35 @@ msgstr ""
 "connectar només amb aquest servidor. L'IP ha de ser una adreça IPv4 decimal puntejada,\n"
 "o un nom DNS resoluble."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Connecta només a eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Connecta només a Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desconnecta de la xarxa."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Desconnectarà de totes les xarxes que estiguin connectades ara.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desconnecta només de eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desconnecta només de Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Afegeix un enllaç magnet o eD2k al nucli."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7504,51 +7413,51 @@ msgstr ""
 "\n"
 "L'enllaç magnet ha de contenir el resum (hash) eD2k i la mida del fitxer.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Defineix un valor de configuració."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Defineix les preferències del filtrat IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activa el filtre IP per a clients i servidors."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Atura el filtre IP per a clients i servidors."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activa/Desactiva el filtre IP per a clients."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activa el filtre IP per a clients."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Atura el filtre IP per a clients."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activa/Desactiva el filtre IP per a servidors."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activa el filtre IP per a servidors."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Atura el filtre IP per a servidors."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Selecciona el nivell de filtratge IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7556,73 +7465,73 @@ msgstr ""
 "Els nivells de filtratge vàlids són en el rang 0-255, i el valor per defecte\n"
 "(inicial) és 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Defineix els límits d'ample de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "El valor donat ha de ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Defineix el límit d'ample de banda de pujada."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "El valor donat ha de ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Defineix el límit d'ample de banda de baixada."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "El valor donat ha de ser en kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obté i mostra un valor de les preferències."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obté les preferències del filtratge IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obtenir l'estat del filtre IP per a clients i servidors."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obtenir l'estat del filtre IP només per a clients."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obtenir l'estat del filtre IP només per a servidors."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Selecciona el nivell de filtratge IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obté els límits d'ample de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Realitza una cerca."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7641,44 +7550,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Realitza una cerca global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Realitza una cerca local"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Realitza una cerca kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Mostra els resultats de l'última cerca."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Mostra el progrés d'una cerca."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Comença a baixar un fitxer"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7686,80 +7595,80 @@ msgstr ""
 "S'ha de donar el número d'un fitxer de l'última recerca.\n"
 "Exemple: 'download 12' començarà a baixar el fitxer amb el número 12 de la recerca anterior.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pausa la baixada."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Reprèn la baixada."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Cancel·la la baixada."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Assigna una prioritat de baixada."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Estableix la prioritat d'una baixada a Baixa, Normal, Alta o Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Estableix la prioritat a baixa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Estableix la prioritat a normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Estableix la prioritat a alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Estableix la prioritat a auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Mostra les cues/llistes."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Mostra la cua de pujades/baixades, la llista de servidors o la llista de fitxers compartits.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostra la cua de pujades."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostra la cua de baixades."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostrar el registre."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostra la llista de servidors."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Mostra la llista de fitxers compartits."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Buida el registre."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Ordre obsoleta, useu '%s' en el seu lloc."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7768,261 +7677,258 @@ msgstr ""
 "Aquesta és una ordre obsoleta, i pot ser s'elimini en el futur.\n"
 "Useu '%s' en el seu lloc.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "client de text de l'aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "S'està convertint els conjunts de resums AICH antics en '%s' a 64b en '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVÍS: El nom de fitxer '%s' és invàlid i ha estat reanomenat com a '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVÍS: El fitxer '%s' ja existeix, el fitxer nou ha estat reanomenat com a '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Esteu segur que voleu cancel·lar i esborrar tots els fitxer d'aquesta categoria?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Es Requereix Confirmació"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Només s'admeten 99 categories."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Massa categories!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Tota la resta"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Selecciona un filtre de vista"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Afegeix una categoria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Edita la categoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Elimina la categoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "S'ha demanat un conjunt de resums d'un fitxer desconegut: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "S'està reprenent la pujada del fitxer: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "S'està suspenent la pujada del fitxer: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Error en executar l'ordre '%s' per a l'esdeveniment '%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Descàrrega completada"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "La ruta completa al fitxer."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "El nom del fitxer sense la ruta."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "El resum eD2k del fitxer."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "La mida del fitxer en bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Temps d'activitat de baixada acumulat."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Inici d'una nova sessió de xat"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remitent del missatge."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Sense espai"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partició de disc."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Error completant"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "S'està processant el fitxer número %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Heu preguntat per els resums de les parts (Només per a fitxers > 9.5MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fitxer inexistent !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, el creador d'enllaços eD2k de l'aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Benvinguts!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Paràmetres d'entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fitxer"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Afegeix URL opcionals per al fitxer"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Introduïu el fitxer per al qual voleu calcular l'enllaç eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Introduïu la URL que voleu agregar a l'enllaç eD2k: Afegiu / al final perqué aLinkCreator integri el nom del fitxer actual"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Crea l'enllaç amb resums per a cada part"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ajuda a escampar més ràpidament els fitxer nous i rars, a costa d'un enllaç més gros"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Resum MD4 del fitxer"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Resum eD2k del fitxer"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Enllaç eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Desa"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copia al porta-retalls"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Obre"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Obre un fitxer per a crear-ne l'enllaç eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copia l'enllaç eD2k al porta-retalls"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Anomena i desa"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Desa l'enllaç eD2k a un fitxer"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Quant a l'aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Seleccioneu el fitxer per al qual voleu crear l'enllaç eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "No es pot obrir el porta-retalls"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "No hi ha res a copiar!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleccioneu el fitxer per a l'enllaç eD2k creat"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "No s'ha pogut obrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Si us plau, introduïu un nom que no sigui buit"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "No hi ha res a desar!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8042,167 +7948,159 @@ msgstr ""
 "\n"
 "Distribuït sota llicència GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Fent el resum..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator està funcionant"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calculant comprovació MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calculant comprovació eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Cancel·lat !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Fet en %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ja heu afegit aquesta adreça URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Si us plau, introduïu una URL que no sigui buida"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "No s'ha pogut obrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "S'ha esgotat la memòria mentre es calculava el resum eD2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dies %i hores %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Estadístiques en línia de l'aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Raó de BA màxima des que el wxCas funciona"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Velocitat màxima de BA des que s'usa l'wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Reinicia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Atura l'autorefresc"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Desa la imatge de les estadístiques en línia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimeix la imatge de les estadístiques en línia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Paràmetre de les preferències"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Quant al wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Inicia l'autorefresc"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Autorefresc aturat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Autorefresc iniciat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Desa la imatge de les estadístiques"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estadístiques en línia de l'aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8210,11 +8108,11 @@ msgstr ""
 "Ha hagut un problema en imprimir.\n"
 "Tal volta la impressora actual no està configurada correctament?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Imprimint"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8232,403 +8130,392 @@ msgstr ""
 "\n"
 "Distribuït sota GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "L'aMule no s'està executant..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "L'aMule s'està executant"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "L'aMule s'està executant, però desconnectat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "L'aMule s'està connectant..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "L'estat de l'aMule és desconegut..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " ha estat funcionant durant "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " està aturat!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " no està connectat!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " està connectant..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " està fent alguna cosa estranya, comproveu-lo!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " està connectat a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "inactiu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " és a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " amb "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Total baixat: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", pujat: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Baixat durant la sessió: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Baixant: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, pujant: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Compartint: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fitxers, clients a la cua: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Hora: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Mitjana de càrrega del sistema (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Sistema en funcionament des de: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "El directori on està el fitxer amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Introduïu el directori on es troba el fitxer amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Interval de refresc en segons"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Genera una imatge a cada refresc"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Introduïu el directori on es generarà la imatge d'estadístiques"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Puja periòdicament la imatge d'estat a un servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Adreça FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Directori FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Introduïu l'adreça del servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Introduïu el directori del servidor FTP on es desarà la imatge"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Usuari"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Introduïu el nom d'usuari per a entrar al servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Introduïu la contrasenya per a entrar al servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Interval d'actualització de l'FTP en minuts"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "D'acord"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Directori on està el fitxer de signatura"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Directori on es genera la imatge"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carrega la plantilla <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Port HTTP del servidor web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Usa l'encaminament UPnP al port del servidor web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Port UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usa la compressió gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Contrasenya d'accés total per al servidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Contrasenya de convidat per al servidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permetre l'accés de convidats"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Denega l'accés de convidats"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Carrega / desa la configuració del servidor web des de / a l'aMule remot"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Directori del fitxer de configuració de l'aMule. NO L'USEU DIRECTAMENT!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Inhabilita el intèrpret PHP (obsolet)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompila les pàgines PHP a cada petició"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Servidor web de l'aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "s'ha acceptat la connexió del client web\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERROR: no es pot acceptar connexions de clients web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Ha fallat la petició amb el següent error: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "No s'ha trobat el fitxer d'índex: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "La sessió ha caducat - s'està demanant la identificació\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessió correcta, identificat\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessió correcta, sense identificar\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "No hi ha cap sessió oberta - es demanarà identificació\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessió creada - s'està demanant la identificació\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "S'està processant la petició [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "No s'ha especificat cap contrasenya, no es permetrà la identificació."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "El resum de la contrasenya és invàlid\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Contrasenya correcta\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Contrasenya incorrecta\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "No heu especificat cap contrasenya. No es permet una contrasenya en blanc.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Eixida sol·licitada\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "S'està processant la petició [redirigit]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "La connexió ha fallat "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -21,19 +21,19 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "O aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Vzdálené ovládání aMule"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "Multiplatformní p2p klient založený na eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -49,79 +49,79 @@ msgstr ""
 "Copyright (c) 2003-2026 Tým aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Část aMule je založena na \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Dokumentace:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Problémy:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrola nové verze po spuštění"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Připojuji se k síti Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nedostupný"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Přidat kamaráda"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Musíte zadat platnou IP adresu a port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informace"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Zadaný userhash je neplatný!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -130,49 +130,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za názvem programu"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Připojení selhalo "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -181,103 +180,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Selhalo otvírání souboru ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když máte LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Ukončuji hlavní aplikaci..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Selhal"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Ukončuji instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabíjím instanci amuleweb s PID `%d'..."
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Ukončuji jádro."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Ukončení aMule dokončeno."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše nastavení locale bylo změněno na výchozí systémové nastavení kvůli změně v konfiguraci. Pardon."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -285,71 +281,67 @@ msgstr ""
 "\n"
 "Konfigurace EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "VAROVÁNÍ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sítě"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "CHYBA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver běží s PID %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u je nedostupný. Budete mít LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -364,271 +356,267 @@ msgstr ""
 "\n"
 "Zkontrolujte nastavení vaší sítě a ujistěte se, že je port v obou směrech otevřený."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Selhalo vytvoření OnlineSig souboru"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Selhalo vytvoření aMule OnlineSig souboru"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Toto je vaše první spuštění aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Toto je testovací verze, která je denně aktualizovaná a\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "my nezaručujeme, že nemůže nic pokazit, zapálit váš dům,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nebo zabít vašeho psa. Nicméně i tak by *mělo* být její používání bezpečné.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Více informací, podporu a nová vydání naleznete na naší domovské stránce,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, nebo na našem IRC kanálu #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Hlašte chyby na adrese https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Předalokace místa na disku pro soubor '%s' selhala: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "CHYBA: nelze otevřít logovací soubor"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROVÁNÍ: log je prázdný. Něco je špatně."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Log byl vymazán"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Zpráva od serveru: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Selhalo stahování seznamu uzlů."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Selhalo otvírání staženého kontrolního souboru s verzí"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Porušený soubor pro kontrolu verze"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Používáte zastaralou verzi aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Vaše verze aMule je %i.%i.%i a poslední verze je %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROVÁNÍ: Vaše verze aMuled je zastaralá: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Vaše verze aMule je aktuální."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Selhalo stahování kontrolního souboru s verzí"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uživatelů: %s | Souborů: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uživatelů: E: %s K: %s | Souborů: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nezvoleny žádné sítě"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "s LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "s HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Připojen k %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Připojování k %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Odpojen od eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad spuštěn."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad zastaven."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Připojen ke Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Síť Kad nelze použít, když je v nastavení zakázán UDP port."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Síť Kad je zakázána v nastavení, nepřipojuji se."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "CHYBA: démon aMule nelze použít, když jsou zakázaná externí připojení. Pro jejich povolení použijte buď normální aMule, nebo klíči \"AcceptExternalConnections\" v souboru ~/.aMule/amule.conf nastavte hodnotu 1"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Nelze vytvořit soubor s PID"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "CHYBA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Toto je aMule %s založená na eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -638,193 +626,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Žádná síť"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Vzdálené ovládání aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Kritická chyba: Selhalo vytváření časovače jádra"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Připojit se ke vzdálené amuli"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Připojení ztraceno."
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Ptát se na ukončení programu"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -833,153 +814,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Kritická chyba: Selhalo vytváření časovače pro dotazování"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Zahajuji smyčku událostí..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Připojuji..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Ukončuji"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Pokusu o připojení k %s (%s:%i) vypršel čas."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Připojit se k síti."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Připraven"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Vše"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nedostupný"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Soubor nenalezen."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Hledám kamaráda pro LowID připojení"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (falešná eMule verze %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (falešná eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falešná eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (založeno na eMule v.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Přezdívka: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Vyžádáno: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -987,7 +958,7 @@ msgstr[0] "Statistika souboru pro toto sezení: Přijat %d z %d požadavku, %s p
 msgstr[1] "Statistika souboru pro toto sezení: Přijato %d z %d požadavků, %s přeneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -995,119 +966,119 @@ msgstr[0] "Statistika souboru pro všechna sezení: Přijat %d z %d požadavku, 
 msgstr[1] "Statistika souboru pro všechna sezení: Přijato %d z %d požadavků, %s přeneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Vyžádán neznámý soubor"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Zpráva od '%s' filtrována (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nová zpráva od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů v adresáři %s -> zakázáno"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "VAROVÁNÍ: %s nelze otevřít."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "VAROVÁNÍ: Soubor je porušen, obsahuje neplatnou hlavičku."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "I/O chyba při čtení souboru known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Došlo k chybě při ukládání souboru known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nová kategorie"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Zvolte adresář pro stažené soubory"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Musíte zadat název kategorie!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Musíte zadat cestu pro kategorii!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Nemohu vytvořit příchozí adresář pro kategorii. Zadejte prosím platnou cestu!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Připojen ke klientovi ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Připojuji se ke klientovi ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Připojování ke klientovi selhalo / připojení ztraceno ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Zavřít tab"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Zavřít všechny taby"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Zavřít ostatní taby"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Přidat do přátel"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1115,7 +1086,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1123,173 +1094,170 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Soubor 'cryptkey.dat' nenalezen, vytvářím."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Podrobnosti klienta"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Podporováno"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nepodporováno"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Zakázáno"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Připojen"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Odpojeno"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nekompletní"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Zloduch"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Ověřeno - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nedostupný"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů -> přijato"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů -> odmítnuto"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených adresářů -> přijato"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených adresářů -> odmítnuto"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů v adresáři %s -> přijato"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů v adresáři %s -> zakázáno"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Uživatel %s (%u) sdílí adresář %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů v adresáři %s -> zakázáno"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Komentáře k souboru"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Jméno"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Název souboru"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentář"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Nemohu vyhledávat přes Kad, když není spuštěn"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Hledám kamaráda pro LowID připojení"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Žádné komentáře"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1297,268 +1265,258 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Stahování seznamu serverů z %s selhalo"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ní]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Vy]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Vysoká"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Velmi vysoká"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Vydání"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Vyžaduji"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Připojuji se přes server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Plná fronta"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ve frontě"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Stahuji"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Získávám hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Bez potřebných částí"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nelze spojit LowID s LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Příliš mnoho připojení"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Připojuji se přes Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Příliš Kad připojení"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Zabanován"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Chyba připojení"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Vzdálená fronta je plná"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Starý MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nový MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule kompatibilní"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Lokální server"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Výměna zdrojů"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasivní"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Odkaz"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Výsledek hledání"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Dokončeno"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Probíhá"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "CHYBA: Došlo místo na disku"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "CHYBA: I/O chyba!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "CHYBA: Selhání!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Ve frontě"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Již stahuji"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Neznámý nebo špatný formát dočasného souboru."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Část"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Přeneseno"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Rychlost"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Průběh"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Zdroje"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorita"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Stav"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Zbývající čas"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Naposledy spatřen kompletní"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Poslední příjem"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Opravdu si přejete smazat vybraný soubor?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Opravdu si přejete smazat vybrané soubory?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1567,156 +1525,153 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Zastavit"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pozastavit"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Obnovit"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "V&yčistit dokončené"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Přesunout A4AF zdroje k tomuto souboru"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Přesunout A4AF zdroje k tomuto souboru (automaticky)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Přesunout A4AF zdroje k jinému souboru"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Rozšířené nastavení"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Náhled"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Zobrazit &podrobnosti souboru"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Zobrazit všechny komentáře"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Zkopírovat magnet URI do schránky"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Zkopírovat eD2k &odkaz do schránky"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Uložit odezvu do schránky"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "zrušit přiřazení"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Zařadit do kategorie"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otevřít tento soubor"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Zadejte nový název pro tento soubor:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Přejmenování souboru"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Stahování (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Náhled souboru"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "CHYBA: Nezdařilo se spustit externí přehrávač! Příkaz: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Načítám dočasné soubory z %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nenalezeny žádné částečné soubory"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1724,50 +1679,50 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Stahování %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Soubor '%s' se již pokoušíte stáhnout"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Soubor '%s' již máte"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Soubor '%s' již máte"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1775,251 +1730,250 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neplatný eD2k odkaz! CHYBA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Klient odeslal paket poté, co selhala autentizace."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Externí připojení uzavřeno."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Externí připojení jsou zakázány kvůli prázdnému heslu!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Externí připojení jsou zakázány v konfiguračním souboru"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nové externí připojení přijato"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externí připojení odmítnuto kvůli prázdnému heslu v nastavení!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Připojuji klienta: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Neznámá verze"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Neplatná verze protokolu."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Autentizace selhala: nesprávné heslo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Autentizace selhala: chybějící heslo."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Neplatný požadavek, nejdřív se prosím autentizujte."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Přistup povolen."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odeslána chybová hláška \"%s\" pro klienta."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Neautorizovaný pokus o přístup z %s. Připojení uzavřeno."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nenalezen: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Server nepřidán"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "server nenalezen: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je zakázané v nastavení."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Žádné údaje pro graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Vás klient není nakonfigurován pro tuto úroveň detailů."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Již se ukončuji."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Soubor nenalezen."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Neplatný název souboru."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nelze přejmenovat soubor."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad je zakázaný v nastavení."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Již připojen k eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Připojuji se k eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Již jste připojen k síti Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Připojuji se k síti Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Všechny sítě jsou zakázány."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Odpojen od eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Odpojen od Kademlia."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Neznámé rozšíření '%s' pro příkaz '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Neznámý příkaz '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2027,7 +1981,7 @@ msgstr ""
 "\n"
 "Tento příkaz nesmí dostat argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2035,13 +1989,13 @@ msgstr ""
 "\n"
 "Tento příkaz musí dostat argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2049,11 +2003,11 @@ msgstr ""
 "\n"
 "Dostupná rozšíření:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Dostupné příkazy:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2061,23 +2015,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Ukončí aplikaci."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Zobrazit nápovědu."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2085,46 +2039,46 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Chyba syntaxe!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Chyba při zpracování příkazu - to by se nikdy nemělo stát! Prosím, nahlašte chybu\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Tento příkaz by neměl mít parametry."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Tento příkaz musí mít parametr."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Neplatný argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Toto je nekompletní příkaz."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Pro nápovědu spusťte '%s'.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Tohle je %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Tohle je %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2132,7 +2086,7 @@ msgstr ""
 "\n"
 "Vytvářím klienta...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2141,7 +2095,7 @@ msgstr ""
 "\n"
 "OK, opouštím %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2150,331 +2104,326 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Zobrazí tuto nápovědu."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Hostitel, kde běží aMule. (výchozí: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port aMule pro externí připojení. (výchozí: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Heslo pro externí připojení."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Načíst konfiguraci ze souboru."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nevypisovat nic na stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Buď upovídaný - ukaž také debugovací hlášky"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Nastaví locale programu (jazyk)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Vypíše verzi programu."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Podrobnosti souboru"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% dokončeno"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Vítejte!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Připojuji se ke kamarádovi"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Stav připojení:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Sítě"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standardní TCP port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozšířený UDP port (Kad / globální vyhledávání)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Povolit UPnP port forwarding"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Automaticky aktualizovat seznam serverů po spuštění"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Cílový adresář pro stahování"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Kamarádi"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Zobrazit &podrobnosti"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Přidat kamaráda"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Odstranit kamaráda"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Poslat &zprávu"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Zobrazit soubory"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Založit kamarádský slot"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Opravdu si přejete odstranit vybraného kamaráda?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Opravdu si přejete odstranit vybrané kamarády?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2482,11 +2431,11 @@ msgstr ""
 "Nemůžete založit více než jeden kamarádský slot.\n"
 " Byl přidělen pouze jeden slot."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Vícenásobný výběr"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2495,184 +2444,183 @@ msgstr ""
 "Nemůžete založit více než jeden kamarádský slot.\n"
 " Byl přidělen pouze jeden slot."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Poslat zprávu uživateli"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Zpráva k odeslání:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Odstranit z přátel"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Poslat zprávu"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Vyžádán jiný soubor"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Čekání na odesílací slot"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "Ve frontě"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Odesílám"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nic"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ano"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Stahuji..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP stahování zrušeno"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "URL pro stahování nesmí být prázdné"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Staženo %d bytů"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s vrátilo: %i - Chyba (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP stahování zrušeno"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Stahování %s z %s selhalo"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Přejmenování souboru %s selhalo, přerušuji aktualizaci."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Přejmenování souboru %s selhalo, přerušuji aktualizaci."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Přejmenování souboru %s selhalo, přerušuji aktualizaci."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Úspěšně aktualizováno: %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Selhala aktualizace GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Stahování %s z %s selhalo"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Načítám IP filtry 'ipfilter.dat' a 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Nemohu načíst ipfilter.dat (%s), neznámý formát."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Nemohu načíst ipfilter.dat (%s), soubor nelze otevřít."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2680,7 +2628,7 @@ msgstr[0] "Načteno %u IP rozsahů z '%s'. %u vadných řádků bylo vyřazeno."
 msgstr[1] "Načteno %u IP rozsahů z '%s'. %u vadných řádků bylo vyřazeno."
 msgstr[2] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2688,16 +2636,16 @@ msgstr[0] "Načteno %u IP rozsahů z '%s'. %u vadných řádků bylo vyřazeno."
 msgstr[1] "Načteno %u IP rozsahů z '%s'. %u vadných řádků bylo vyřazeno."
 msgstr[2] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP filtr je připraven"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2705,56 +2653,52 @@ msgstr ""
 "Bootstrap od \n"
 "známých klientů"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Uzly (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Neplatná IP pro bootstrap"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Neplatný port pro bootstrap"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Prosím vyplňte všechna potřebná pole"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Zpráva"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Opravdu chcete stáhnout nový soubor nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Odstraní se tak současné uzly a restartuje se připojení ke Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Pokračovat?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: hledaný výraz je příliš krátký"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, fuzzy, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2762,12 +2706,11 @@ msgstr[0] "Přečteno %u Kad kontaktů"
 msgstr[1] "Přečteno %u Kad kontaktů"
 msgstr[2] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2775,7 +2718,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2783,2072 +2726,2041 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Síť Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Název souboru"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Velikost souboru"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Poměr sdílení"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Vyžádáno"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Přijato"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Kompletní zdroje"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Neznámá verze"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Nemohu otevřít soubor se skinem %s pro čtení"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashuji"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Dokončování"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Dokončeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Poškozený"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Čekám"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Musíte zadat (neprázdné) heslo."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Neplatné heslo, není MD5 hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Chyba při připojování"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Externí připojení uzavřeno."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Špatná odpověď od serveru. Spojení uzavřeno."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Připojení k aMule uspělo"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Připojení uspělo."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Naslouchací socket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "CHYBA: Nemohu naslouchat na TCP portu"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "CHYBA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Zavřít"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Vložit"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Vyprázdnit"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Označit vše"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Připojen"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Připojen"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Připojen ke kad (za firewallem)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP serveru: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP serveru:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nepřipojen"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP port: nepřipraven"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP port: nepřipraven"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informace o klientu"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limit odesílání"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limit stahování"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Zobrazit aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Skrýt aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Ukončit"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Neomezený"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Tray menu aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Rychlostní limity:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: žádný"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: žádný"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Rychlost stahování: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Rychlost odesílání: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Přezdívka: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nezvolena žádná přezdívka!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID klienta: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Název serveru: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP serveru: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Nepřipojen"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online podpis: Povolen"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online podpis: Zakázán"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Uptime: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Sdílené soubory: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Klienti ve frontě: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Celkem DL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Celkem UL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Přidat eD2k nebo magnet odkaz do jádra."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Přidat do přátel"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Načítání ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Uživatelů: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Nepřipojen ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Aktuální připojený server."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Vyhledávání"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Název:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokální"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globální"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Rozšířené parametry"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrování"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Typ souboru"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Cokoliv"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archívy"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Obrazy CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Obrázky"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programy"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Texty"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videa"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Přípona"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min. velikost"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "bajtů"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Max. velikost"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtr:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrování výsledků"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Invertovat výsledek"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Skrýt známé soubory"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Spustit"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Více"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Zastavit"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Stahování"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Vyprázdnit pole"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Výsledky"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Vyčistí dokončená stahování"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Zdroje souboru:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Hlavní"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Celá název:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Soubor .met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Velikost:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Přenos"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Naposledy spatřen kompletní:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Nalezené zdroje:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Dostupný:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Doba stahování:"
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Přeneseno:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Dokončeno:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Chytré zacházení s poškozenými částmi"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Ztraceno poškozením:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Získáno kompresí:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Balíčků zachráněných pomocí I.C.H.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Sdílení:"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Požadavky"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Přijaté požadavky"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Přenesená data"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Poměr sdílení"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Kompletní zdroje"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Odesláno:"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nehodnocené"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titulek:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Názvy souborů"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Převzít"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Upravit"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Použít"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Kvalita souboru"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nehodnocené"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Neplatný / porušený / podvod"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Špatný"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "V pořádku"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Dobrý"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Výborný"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Odpojen od Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Stahuji, prosím čekejte ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Neznámá velikost"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Nezbytné informace"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP adresa :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatečné informace"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Uživatelské jméno:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Přidat"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Průměr sezení"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Rychlost odesílání"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Strom statistik"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Jméno:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software klienta:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Verze klienta:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP adresa:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID uživ.:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP serveru:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Název serveru:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Zatemnění:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Přenosy ke klientovi"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Průmerná rychlost odesílání:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Průměrná rychlost stahování:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Odesláno (sezení):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Staženo (sezení):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Odesláno (celkem):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Staženo (celkem):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skóre"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DL/UP poměr:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Pořadí ve frontě"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Přezdívka"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Toto jméno uvidí ostatní uživatelé, kteří se k vám připojí."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Prodleva před zobrazením tooltipů."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Jazyk ovládání programu"
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Kontrola nové verze po spuštění"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "aMule po spuštění zkontroluje, zda nevyšla nová verze"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Minimalizace po spuštění"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "aMule se po spuštění minimalizuje"
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Ptát se na ukončení programu"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Povolit ikonu v trayi"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Povolí/zakáže ikonu v systray."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimalizovat do tray ikony"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Povolením tohoto se aMule minimalizuje do traye (místo pruhu úloh)."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Výběr prohlížeče"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Otevřít pokud možno v novém tabu"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otevřít webovou stránku v novém tabu místo otvírání nového okna, pokud je to možné"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video přehrávač"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limity šířky pásma"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Přidělování slotů"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Porty"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tohle je standardní eD2k port a nelze jej zakázat."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port pro požadavky serveru (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tento UDP port je použit pro rozšířené požadavky eD2k a pro síť Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (volitelné):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Max. zdrojů na stahovaný soubor:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automatické připojení po spuštění"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Po odpojení znovu připojit"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Odstranit mrtvý server po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "pokusech"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Použít systém priorit"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Použít po připojení chytrou kontrolu LowID"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Bezpečné připojení"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaticky se připojit jen ke stálým serverům"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Přidělit ručně přidaným serverům vysokou prioritu"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Přidávat soubory ke stažení do fronty pozastavené"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Přidávat soubory ke stažení do fronty s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Pokusit se nejprve stáhnout první a poslední části"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Ze stejné kategorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Předalokovat místo na disku pro nové soubory"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Toto zvolte chcete-li, aby aMule kontrolovala místo na disku"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Zadejte minimum místa na disku."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Odesílání"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Přidat nově sdílené soubory s \"auto\" prioritou"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentní zpracování poškození (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Sdílet skryté soubory"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafy"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Prodleva aktualizace: 5 sekund"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Barvy: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Na pozadí"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Mřížka"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktivní připojení"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ukazatel rychlosti v tray ikoně"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Vyberte"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Strom"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Počet verzí klientů k zobrazení (0=neomezeně)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROVÁNÍ !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Max. nových připojení za 5 sek."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Velikost zásobníku pro soubory: 240000 bytů"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost fronty odesílání: 5000 klientů"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Vzhled: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Zobrazit rozšířené informace na tabech kategorií"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Zobrazit rychlosti přenosu v titulku okna"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Před názvem programu"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Za názvem programu"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Zobrazit šířku pásma režie"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Vertikální umístění nástrojové lišty"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Zobrazit ukazatel průběhu"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plochý"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zakázat přístup hostům"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Heslo pro omezený přístup k webserveru"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4856,11 +4768,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4870,483 +4782,483 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Zakázaný [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sek."
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min."
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "hod."
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dní"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "vše"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "vše ostatní"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Nekompletní"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Zastaveno"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archív"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Text"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktivní"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Používám konfigurační adresář: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importování %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Čtení dočasného adresáře"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Vytvářím cílový soubor"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Přidávám do stahování a ukládám nový částečný soubor"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Import částečných souborů"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Stav"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash souboru"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (disk: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Prosím zvolte adresář pro vyhledávání dočasných souborů! (budou zahrnuty i podadresáře)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Přejete si smazat zdrojové soubory úspěšný importovaných stahování?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Odstranit zdroje?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "CHYBA: Částečný soubor nelze vytvořit)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Zkouší se načíst záloha .met souboru z %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "CHYBA: Selhalo otevírání souboru part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "CHYBA: Soubor part.met má nulovou velikost: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "CHYBA: Neplatná verze souboru part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Chyba: %s (%s) je porušený (špatný \"tagcount\"), nelze načíst soubor."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Zkouším obnovit info o souboru..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Obnovuje se soubor bez názvu - bude obnoven s názvem RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Všechny dostupné informace o souboru obnoveny :D - Zkouším je použít..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Nelze obnovit info o souboru :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Nelze otevřít %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "VAROVÁNÍ: %s je možná poškozený (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "CHYBA během ukládání částečného souboru: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "I/O chyba během ukládání části: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Selhalo ukládání souboru part.met.seeds pro %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5354,17 +5266,17 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5372,350 +5284,350 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Dokončeno přehashování %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Dokončené stahování: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Dokončené stahování: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Mazání souboru: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VAROVÁNÍ: Nedostatek volného místa na disku! Pozastavuji soubor: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Stažená část %i souboru '%s' je poškozená."
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Alokuji"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Nedostatek místa na disku"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Staženo"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Připojení"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servery"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Soubory"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Bezpečnost"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Rozhraní"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Vzdálené ovládání"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online podpis"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Události"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debugování"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5731,35 +5643,35 @@ msgstr ""
 "aMule poběží v pohodě bez změny\n"
 "nastavení na tomto tabu."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Typ proxy, ke které se připojujete"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrola hesla\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5767,89 +5679,89 @@ msgstr ""
 "Restartujte aMule, aby se projevily následující změny:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP port změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nové externí připojení přijato"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Externí připojení uzavřeno."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Zatemnění protokolu"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Jazyk byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Dočasný adresář byl změněn.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Síť eD2k povolena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neplatná verze protokolu."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5857,7 +5769,7 @@ msgstr ""
 "Kad se nespustí, když máte zakázaný UDP port.\n"
 "Povolte UDP port, nebo zakažte připojování na Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5867,93 +5779,93 @@ msgstr ""
 "Nyní MUSÍTE restartovat aMule.\n"
 "Pokud to neuděláte, tak si pak nestěžujte, když se přihodí něco špatného.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Soubor %s se již pokoušíte stáhnout"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Heslo nastaveno a externí připojení povoleno."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Dočasné soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Příchozí soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online podpisy"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zvolte adresář pro %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5961,42 +5873,42 @@ msgstr[0] "Znovu načíst vaše sdílené soubory"
 msgstr[1] "Znovu načíst vaše sdílené soubory"
 msgstr[2] "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Zvolit přehrávač videa"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Výběr prohlížeče"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Spustitelný soubor %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Upravit seznam serverů"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6004,42 +5916,42 @@ msgstr ""
 "Sem přidejte URL pro stažení server.met souborů.\n"
 "Pouze jedno URL na každý řádek."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletní zdroje"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stav:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6047,7 +5959,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6055,12 +5967,12 @@ msgstr[0] "Čas pro průměrný graf: %d minut"
 msgstr[1] "Čas pro průměrný graf: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6068,7 +5980,7 @@ msgstr[0] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[1] "Velikost zásobníku pro soubory: %d bajtů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6076,7 +5988,7 @@ msgstr[0] "Velikost fronty pro odesílání: %d klientů"
 msgstr[1] "Velikost fronty pro odesílání: %d klientů"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6084,235 +5996,235 @@ msgstr[0] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[1] "Interval pro obnovení připojení k serveru: %d minut"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval pro obnovení připojení k serveru: Zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "zakázáno"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Spustí příkaz při událost `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Povolit jaderné příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Příkaz jádra:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Povolit GUI příkazy"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Příkaz GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Následující proměnné budou nahrazeny:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Sdílené adresáře"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Sdílené adresáře"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velikost."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Varování při vyhledávání"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Hlavní"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Nelze vyhledávat na eD2k, když nejste připojen"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Neočekávaná chyba během vyhledávání v síti Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID souboru"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nehodnocené"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Přidat volitelné URL pro tento soubor"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Vyhledat související soubory (eD2k, lokální server)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Označit jako známý soubor"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Zkopírovat eD2k odkaz do schránky"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Snažíte se smazat server, na který jste právě připojen(a). Nejprve se prosím odpojte."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Zrušeno"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nový"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Selhalo připojení ke všem serverům s obfuskací. Zkouším to znovu bez obfuskace."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Selhalo připojení ke všem serverům s obfuskací. Zkouším to znovu bez obfuskace."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Selhalo připojení ke všem serverům na seznamu. Zkouším znovu."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Selhalo připojení ke všem serverům na seznamu. Zkouším znovu."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Síť eD2k je zakázána v nastavení, nepřipojuji se."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Připojen k %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Připojení vytvořeno k %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Kritická chyba během pokusu o připojení. Možná je vypnuté/nefunkční připojení k Internetu"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Ztracené připojení k %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) se zdá být mrtvý."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) se zdá být plný."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6320,48 +6232,48 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Připojování k %s (%s:%i) selhalo."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Pokusu o připojení k %s (%s:%i) vypršel čas."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Načítám soubor server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Soubor server.met nenalezen!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Otevření souboru server.met (%s) selhalo: neznámý formát."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Nelze otevřít server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Soubor server.met je porušený, nalezena neplatná verze: 0x%x, velikost %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6369,7 +6281,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6377,239 +6289,238 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "I/O chyba při čtení souboru known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Server nebyl přidán: [%s:%d] neudává platný port."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Server nebyl přidán: IP adresa [%s:%d] je neplatná, nebo blokovaná."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Server nebyl přidán: Server s totožnou IP a portem [%s:%d] je již v seznamu."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Server byl přidán: [%s:%d] pod názvem '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Snažíte se smazat server, na který jste právě připojen(a). Nejprve se prosím odpojte."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Nemohu otevřít '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ukládání server.met selhalo!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Neplatná URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Stahování seznamu serverů z %s selhalo"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Stáhnout seznam serverů z %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "V addresses.dat není žádná platná URL pro automatické stahování server.met"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Stahování seznamu serverů z %s selhalo"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Název serveru"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresa"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Popis"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Uživatelé"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Stálý"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verze"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Jste připojen(a) na server, který se pokoušíte smazat. Nejprve se prosím odpojte. Server NEbyl smazán."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(neznámý název)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Opravdu si přejete smazat stálý server %s?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servery (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Připojit k serveru"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Označit server jako stálý"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Označit server jako nestálý"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Označit servery jako stálé"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Označit servery jako nestálé"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Odstranit server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Vzdálené servery"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstranit všechny servery"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Znovu připojit k serveru"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Opravdu si přejete smazat všechny servery?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Opravdu si přejete smazat vybrané servery?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Opravdu si přejete smazat vybrané servery?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Nové ID klienta je %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tPravděpodobně je to způsobeno tím, že jste za firewallem či routerem."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPro více informací prosím běžte na https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6617,178 +6528,178 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Uložení seznamu serverů dokončeno."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server odmítl poslední příkaz"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Chybný paket obdržen od serveru: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Došlo k neznámé chybě při zpracovávání paketu od serveru: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP serveru %s (%s) je filtrována. Nepřipojuji se."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "používám zatemňování protokolu (obfuscation)."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Připojování k %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Log aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Stav eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Stav připojení:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Připojen"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Stav Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Běží na %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Běží"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Stav Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Stav:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Stav připojení:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Za firewallem - otevřete TCP port %d na vašem routeru či ve firewallu"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Stav UDP připojení:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Za firewallem - otevřete UDP port %d na vašem routeru či ve firewallu"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Stav firewallu: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Není třeba kamaráda - TCP port je otevřený"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Není třeba kamaráda - UDP port je otevřený"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Žádný kamarád"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Připojuji se ke kamarádovi"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Připojen ke kamarádovi na %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indexované zdroje:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indexovaná klíčová slova:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Neběží"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6796,7 +6707,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6804,7 +6715,7 @@ msgstr[0] "Nalezeno %i známých a %i neznámých sdílených souborů"
 msgstr[1] "Nalezeno %i známých a %i neznámých sdílených souborů"
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6812,421 +6723,421 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Sdílený adresář nenalezen, přeskakuji: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Uživatelské jméno"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Rychlost stahování"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Rychlost odesílání"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Dostupné části"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Stav odesílání"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Průběh stahování"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Původ"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Název souboru"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Sdílené soubory"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Obdržené části"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Cesta"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Přidat komentář/hodnocení"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Upravit komentář/hodnocení"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Přejmenovat"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Zkopírovat magnet URI do schránky"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Zkopírovat eD2k odkaz do schránky (%zdroj)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Zkopírovat ED2K odkaz do schránky (AICH info)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "K vytvoření platného odkazu potřebujete HighID"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Název souboru"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Odeslaná data (sezení (celkem)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Celková režie (pakety): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Režie serveru (pakety): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Režie Kadu (pakety): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktivní odesílání: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Čekající odesílání: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Průměrný čas odesílání: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Stažená data (sezení (celkem)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Nalezené zdroje: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktivní stahování (části): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "UL:DL poměr sezení (celkem): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Průměrzná rychlost stahování (sezení): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Průměrzná rychlost odesílání (sezení): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Maximální rychlost stahování (sezení): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Maximální rychlost odesílání (sezení): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Znovupřipojení: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Doba od prvního přenosu: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Připojen k serveru od: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktivních připojení (odhad): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Limit připojení dosažen: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Průměrný počet připojení (odhad): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienti"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Neznámý: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrován: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Zabanován: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Celkem: %i Známých: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Fungující servery: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Nefungující servery: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Celkem: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Smazané servery: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtrované servery: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Uživatelů na fungujících serverech: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Souborů na fungujících serverech: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Celkem uživatelů: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Celkem souborů: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zaplnění serveru: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Počet sdílených souborů: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Celková velikost sdílených souborů: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Průměrná velikost souboru: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operační systém"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Neobdrženo"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktivní připojení (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nedostupný"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nikdy"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Spustí <str> a ukončí se."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Neplatný formát IP adresy. Použijte xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Zpracovávám podle hashe: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Zpracovávám podle názvu souboru: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Neplatné číslo\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7235,7 +7146,7 @@ msgstr "Pro nápovědu spusťte '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7244,89 +7155,87 @@ msgstr "Pro nápovědu spusťte '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Pro nápovědu spusťte '%s'.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Stahování (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Požadavek selhal kvůli neznámé chybě."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operace byla úspěšná."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "vypnuto"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "zapnuto"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Připojen k %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Připojování"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "za firewallem"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7335,7 +7244,7 @@ msgstr ""
 "\n"
 "Stahování:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7344,7 +7253,7 @@ msgstr ""
 "\n"
 "Odesílání:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7353,7 +7262,7 @@ msgstr ""
 "\n"
 "Klientů ve frontě:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7362,47 +7271,47 @@ msgstr ""
 "\n"
 "Celkem zdrojů:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartSoubor]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Počet výsledků vyhledávání: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "Zobrazit procenta průběhu"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Obdržena neznámá odpověď od serveru, kód operace = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Zobrazit celý strom statistik."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7411,46 +7320,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Ukončit aMuli"
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Připojit se k síti."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7458,35 +7367,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Připojit se pouze k eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Připojit se pouze ke Kademlia."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Odpojit se od sítě."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Odpojit se pouze od eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Odpojit se pouze od Kademlia."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Přidat eD2k nebo magnet odkaz do jádra."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7497,122 +7406,122 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Nastavit hodnotu nastavení."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Nastavit filtrování IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Povolit klientům i serverům filtrování IP."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Zakázat klientům i serverům filtrování IP."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Povolit/zakázat klientům filtrování IP."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Povolit klientům filtrování IP."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Zakázat klientům filtrování IP."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Povolit/zakázat klientům filtrování IP."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Povolit serverům filtrování IP."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Zakázat serverům filtrování IP."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Zvolte úroveň filtrování IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Nastavit limity šířky pásma."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Nastavit limit šířky pásma pro odesílání."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Nastavit limit šířky pásma pro stahování."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Spustí vyhledávání v síti Kad"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7631,124 +7540,124 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Spustí globální vyhledávání"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Spustí lokální vyhledávání"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Spustí vyhledávání v síti Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Zobrazí výsledky posledního vyhledávání."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Zobrazí průběh vyhledávání."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pozastavit stahování."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Pokračovat ve stahování."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Zrušit stahování."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Nastaví prioritu stahování."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Nastavte prioritu stahovaného souboru na nízkou, normální, vysokou, nebo automatickou.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Nastaví nízkou prioritu."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Nastaví normální prioritu."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Nastaví vysokou prioritu."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Nastaví automatickou prioritu."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Zobrazit fronty/seznamy."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Zobrazit frontu odesílání."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Zobrazit frontu stahování."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Zobrazit log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Zobrazit seznam serverů."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Znovu načte seznam sdílených souborů."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Vyčistit log."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7757,262 +7666,259 @@ msgstr ""
 "Toto je zastaralý příkaz, který může být v budoucnosti odstraněn.\n"
 "Použijte místo něj '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Textový klient aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Převádí se staré AICH hashsety v '%s' do 64b v '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "VAROVÁNÍ: Název souboru '%s' je neplatný a byl změněn na '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "VAROVÁNÍ: Soubor '%s' již existuje, nový soubor byl přejmenován na '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Opravdu si přejete zrušit a smazat všechny soubory v této kategorii?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Potvrzení je nutné"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Příliš mnoho připojení"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Vše ostatní"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Přidat kategorii"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Upravit kategorii"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Odstranit kategorii"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Obnovuji odesílání souboru %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Zastavuji odesílání souboru %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Stahování dokončeno"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Celá cesta k souboru."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "ED2k hash souboru."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Velikost souboru v bytech."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Zahájeno nové sezení v chatu"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Odesílač zpráv."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Došlo místo"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Diskový oddíl."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Chyba při dokončení"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Zpracovávám soubor č. %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Vyžádal jste si částečné hashe (používá se pouze pro soubory > 9,5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Neexistující soubor !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, tvůrce eD2k odkazů z aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Vítejte!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Vstupní parametry"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Soubor k hashování"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Přidat volitelné URL pro tento soubor"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Sem zadejte soubor pro který chcete vypočítat eD2k odkaz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Vytvořit odkaz s hashi částí"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Pomůže rozšířit nové a raritní soubory rychleji, za cenu zvýšené velikosti odkazu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 hash souboru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k hash souboru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k odkaz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Uložit"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Zkopírovat do schránky"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Otevřít"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Otevřít soubor pro vytvoření jeho eD2k odkazu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Zkopírovat vypočítaný eD2k odkaz do schránky"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Uložit jako"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Uložit vytvořený eD2k odkaz do souboru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "O aLinkCreatoru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Vyberte soubor jemuž chcete vytvořit eD2k odkaz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Nelze otevřít schránku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Zatím není co zkopírovat!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Zvolte soubor s vaším vytvořeným eD2k odkazem"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Nelze otevřít"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Zadejte prosím (neprázdný) název souboru"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Zatím není co ukládat!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8032,167 +7938,159 @@ msgstr ""
 "\n"
 "Šířeno pod GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hashování..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator pracuje"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Počítám MD4 hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Počítám eD2k hashe..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Přerušeno!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Hotovo za %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Tato URL je již přidána!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Zadejte prosím neprázdnou URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Nelze otevřít %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dní %i hodin %i min %i sek"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, online statistiky aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Maximální rychlost stahování během tohoto běhu wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Maximální rychlost stahování během všech běhů wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Reset"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Systém"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Přerušit automatické obnovování"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Uložit obrázek online statistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Vytisknout obrázek online statistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Nastavení"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "O wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Spustit automatické obnovování"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatické obnovování zastaveno"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automatické obnovování spuštěno"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Uložit obrázek statistiky"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Online statistiky aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8200,11 +8098,11 @@ msgstr ""
 "Nastal problém při tisku.\n"
 "Možná vaše tiskárna není správně nastavena."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Tisknu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8221,403 +8119,392 @@ msgstr ""
 "\n"
 "Distribuovaný pod GPL licencí"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMule neběží..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule běží"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule běží, ale je odpojená"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule se připojuje..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Stav aMule je neznámý..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " běží už "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " je zastavená!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " je nepřipojená!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " se připojuje..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " je asi vypnutá, zkontrolujte to!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " je připojena k "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "vypnuto"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr "běží"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " s"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Celkem staženo:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Odesláno:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Stahování: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, odesílání: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Sdílení:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " soubor(ů), klientů ve frontě: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Čas:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " na "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Průměrná zátěž systému (1-5-15 minut): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Běh systému: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Adresář obsahující soubor amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Zadejte cestu k adresáři, ve kterém je soubor amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Interval pro obnovování v sekundách"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Vygenerovat obrázek při každém obnovení"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Zadejte adresář, do kterého si přejete vygenerovat obrázek statistik"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Pravidelně nahrávat obrázek statistik na FTP server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP cesta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Zadejte URL vašeho FTP serveru"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Zadejte sem adresář, do kterého se na FTP budou ukládat obrázky statistik"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Uživatel"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Zadejte sem uživatelské jméno pro přihlášení k vašemu FTP serveru"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Zadejte sem heslo pro přihlášení k vašemu FTP serveru"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Interval aktualizace FTP v minutách"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Zkontrolovat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Adresář obsahující váš soubor s podpisem"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Adresář pro generování obrázků statistik"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Načte šablonu <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "HTTP port webserveru"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Použít UPnP port forwarding pro webserver"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Použít gzip kompresi"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Heslo pro plný přístup k webserveru"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Heslo pro omezený přístup k webserveru"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Povolit přístup hostům"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Zakázat přístup hostům"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Cesta ke konfiguráku aMule. NEPOUŽÍVEJTE PŘÍMO!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Zakázat PHP interpreter (zastaralé)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Překompilovat PHP stránky při každém požadavku"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Webový server aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "CHYBA: nelze přijmout připojení na webového klienta\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Požadavek selhal kvůli následující chybě: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Index nenalezen: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sezení vypršelo - vyžaduji přihlášení\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Relace je v pořádku, přihlášen\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Relace je v pořádku, nepřihlášen\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Není otevřené žádné sezení - vyžaduji přihlášení\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Relace zahájena - vyžadování přihlášení\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Zpracování požadavku [původní]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Heslo nezadáno, přihlášení nebude možné."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Kontrola hesla\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash hesla je neplatný\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Heslo v pořádku\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Špatné heslo\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Nezadal(a) jste heslo. Prázdné heslo není povoleno.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Bylo vyžádáno odhlášení\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Zpracování požadavku [přesměrovaný]:"
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Připojení selhalo "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -20,102 +20,102 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Omking wxCas"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ikke tilgængelig"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Tilføj en Ven"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Du skal indtaste en brugbar IP og port"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -124,47 +124,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -173,176 +172,169 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Kunne ikke åbne %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Fejlede"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Bekræft afslut"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule kører"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -352,271 +344,267 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "Vi giver ikke garanti for at det ikke vil ødelægge noget, brænde dit hus,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FEJL: Kan ikke åbne logfil"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FARE: logfilen er tom. Noget er galt"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Log nulstillet"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerBesked: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Fejl ved hentning af node listen"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Fejl ved åbning af den hentet version check filen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Korrupt version check fil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Du bruger en forældet version af aMule"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMule version er %i.%i.%i og den sisdte nye version er %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FARE: Din aMule version er forældet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Din kopi af aMule er op til dato"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Fejl ved hentning af version check filen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Forbundet til %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Forbundet til %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad startet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad stoppet."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Forbundet til Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad netværk kan ikke bruges hvis UDP port er fravalgt i instillinger, starter ikke."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad netværk fravalgt i instillinger, forbinder ikke."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -626,198 +614,191 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Fatal Fejl: Kunne ikke oprette timer"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Forbindelse afbrudt"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Spørg ved afslut"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -826,1215 +807,1188 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Fatal Fejl: Kunne ikke oprette timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Forbinder"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Ready"
 msgstr "Opdater"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Ikke tilgængelig"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Ingen part filer fundet"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "venter pÃ¥ forbindelse..."
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMule version-%#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " Falsk eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseret på eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Anmodede:"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Anmodet om ukendt fil"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Uventet fil fejl ved skrivning %s : %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Fejl ved forbindelse til %s (%s:%i): %d"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Vælg en mappe til indkommende filer"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Luk tab"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Luk alle tabs"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Luk andre tabs"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Tilføj til Venner"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] "Kredit udlÃžbet!"
 msgstr[1] "Kredit udlÃžbet!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Klient Detaljer"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Lavt ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøjtID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Forbundet"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Afbrudt"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Ikke færdig"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Fil Kommentarer"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Brugernavn"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fil Navn"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "venter pÃ¥ forbindelse..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ingen kommentarer"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "Ingen kommentarer"
 msgstr[1] "Ingen kommentarer"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Fejl ved indlÃŠsning af kreditfil"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [La]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Hø]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høj"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Meget Høj"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Udgiv"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Spørger"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Forbinder via Server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Kø Fuld"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I Kø"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Henter"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Modtaget Hashsæt"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Ingen brugbare dele"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Kan ikke forbinde LavID til LavID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "For mange forbindelser"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Banlyst"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Færdig"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighed"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Forløb"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kilder"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priotet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tid Tilbage"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Sidst Færdig"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Sidste Kontakt"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stop"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pause"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Genoptag"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Ryd færdige"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Udvidet Muligheder"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Smug Kig"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Vis fil &detaljer"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Vis alle kommentarer"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "fjern fra ketegori"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Flyt til kategori"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Åben filen"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Indtast nyt navn for denne fil:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Omdøb fil"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f MB"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Anmoder om delte filer fra '%s'"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Ingen part filer fundet"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Fandt %i part filer"
 msgstr[1] "Fandt %i part filer"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Downloader %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Index fil ikke fundet: "
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2042,23 +1996,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2066,59 +2020,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2127,2685 +2081,2643 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Velkommen"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Forbundet til %s"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Forbindelse"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Venner"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Vis &Detaljer"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Tilføj en ven"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Fjern Ven"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Send &Besked"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Se Filer"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "I Kø"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Spørger efter en anden fil"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Ventende Uploads: %i"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "I Kø"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Upload"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Downloader..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "Max download grÃŠnse"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Downloaded:"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Max download grÃŠnse"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Kunne ikke hente serverlist fra %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Kunne ikke hente serverlist fra %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: søgeord er for kort"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, fuzzy, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Læs %u Kad kontakter"
 msgstr[1] "Læs %u Kad kontakter"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad startet."
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Ukendt: %i"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hasher"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Færdiggør"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Færdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Beskadiget"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Venter"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Du skal specificere et ikke tomt kodeord"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Forkert kodeord, ikke it MD5 hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Forbindelsen fejlede"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "ExternalConn: Dårligt svar fra server. Forbindelse lukket"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Succes! Forbindelse oprettet til aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Succes! Forbindelse oprettet"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Luk"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ryd"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Forbundet"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Forbundet"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Forbundet til Kad (med firewall)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Afslut"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ubegrænset"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Download-Hastighed"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Upload-Hastighed"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Klient ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "ServerNavn: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Ingen Forbindelse"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Signatur: Aktiv"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Signatur: Inaktiv"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Tilføj til Venner"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Henter ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Antal brugere på den server du er forbundet til ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Brugere: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Op: 0.0 | Ned: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ikke Forbundet ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Søg"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arkiver"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Lyd"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Aftryk"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Billeder"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programer"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videoer"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Endelse"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min Størrelse"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Max Størrelse"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Fundne Kilder :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "General"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Navn :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-Fil :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Filstørrelse :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overfør"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Sidst færdig :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fundne Kilder :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Overfører Kilder :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Tilgængelig :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Overført :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Færdig Størrelse :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Fejl Håndtering"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Tabt pga beskadigelse :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Deling: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Anmodninger"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Godtaget Anmodninger"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Overført Data"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Delings Kvote"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Hele kilder"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Upload: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Ikke anslået"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Overtag"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Ryd Op"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Anvend"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Fil Kvalitet"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Ikke anslået"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Invalid / fejl / Falsk"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Dårlig"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Nogen Lunde"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "God"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Glimrende"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Afbrudt fra Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Henter, vent venligst"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Krævet Information"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP Adresse :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Aktuelle Adresse"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Brugernavn :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Tilføj"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload-Hastighed"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Navn:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Point:"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Kø Fuld"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Brugernavn"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Start minimeret"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Spørg ved afslut"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video Afspiller"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Slot Tildeling"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Genforbind ved fejl"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Fjern ikke tilgængelige servere, efter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "forsøg"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Brug prioterings system"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Brug smart LavID tjek ved forbindelse"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Sikker forbindelse"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoforbind kun til servere i statik liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Sæt manuelt tilføjede servere til Høj Priotet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Tilføj filer til download i pause tilstand"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Tilføj filer til download med auto priotet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Prøv at download første og sidste del først"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Tilføj nye delte filer med auto priotet"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafer"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Opdaterings interval : 5 sek"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gennemsnitlig graf: 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Baggrund"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Download nu"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Upload nu"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Vælg"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! Advarsel !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Max nye forbindelser / 5 sekunder"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fil Buffer Størrelse"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Vis overførsels hastighed i titel"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Flad"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Tillad bruger adgang"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4813,11 +4725,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4827,854 +4739,854 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Delte Filer"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Inaktiv [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "Bytes"
 msgstr[1] "Bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "kB/s"
 msgstr[1] "kB/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sek"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "alt"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "alt andet"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Mangelfuld"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "stoppet"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arkiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "Fejl: Kunne ikke oprette partfil"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Fejl: filen known.met er beskadiget, kunne ikke hente kendte filer"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Kunne ikke åbne %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "Fejl ved gemning af partfil: %s (%s => %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Kunne ikke hente serverlist fra %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Forbindelse"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mapper"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Fjern Kontrol"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5684,261 +5596,261 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Undersøger password\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Opdatering startet"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du prøver allerede at downloade denne fil %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Accepter ydre forbindelser"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Gennemse efter Video Afspiller"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "System standard"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5946,1225 +5858,1224 @@ msgstr ""
 "Tilføj URLer hvor der kan hentes server.met filer.\n"
 "Kun en URL på hver linje."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Hele kilder"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Opdaterings interval : 5 sek"
 msgstr[1] "Opdaterings interval : 5 sek"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gennemsnitlig graf: 100 min"
 msgstr[1] "Tid for gennemsnitlig graf: 100 min"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fil Buffer StÃžrrelse %i bytes"
 msgstr[1] "Fil Buffer StÃžrrelse %i bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server forbindelses opdaterings interval %i min"
 msgstr[1] "Server forbindelses opdaterings interval %i min"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server forbindelses opdaterings interval: Inaktiv"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "deaktiver"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte Filer"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Søg"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fil ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Ikke anslået"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Indtast nyt navn for denne fil:"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Afbryd"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Forbundet til %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Forbindelse oprettet til: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Kunne ikke forbinde. Internettet må være nede."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Mistede forbindelsen til %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) ser ud til at være død"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
 msgstr[1] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i Serverer fundet i server.met"
 msgstr[1] "%i Serverer fundet i server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "Servere tilfÃžjet: "
 msgstr[1] "Servere tilfÃžjet: "
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 #, fuzzy
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Fejl: filen server.met er beskadiget"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Uventet fil fejl ved skrivning %s : %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Fejl ved gemning af server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Invalid URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Kunne ikke hente serverlist fra %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernavn"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Brugere"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statistik"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servere (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Fjern server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
 msgstr "Fjern server"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Fjern Alle servere"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Ny Klient-ID er %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Modtog %d nye Servere"
 msgstr[1] "Modtog %d nye Servere"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server afviste sidste kommando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule Log"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Forbindelse"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Forbundet"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Peak Forbindelser (anslÃ¥et)"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Forbundet til %s"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Forbundet til %s %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Fundne Kilder :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "Index fil ikke fundet: "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Brugernavn"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Download-Hastighed"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Upload-Hastighed"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Tilgængelig :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Uploads"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Download Status"
 msgstr "Downloads"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Fil Navn"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Delte Filer"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Sendte Dele"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Mappe sti"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Tilføj kommentar/bedømmelse"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Rediger Kommentar/Bedømmelse"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Omdøb"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Tilføj filer i samling til overførelses liste"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopier magnet &URI til udklipsholder"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopier eD2k link til udklipsholder (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Du skal have et HighID for at lave et godkendt kildelink"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Fil Navn"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Gennemsnitlig upload tid: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Genforbindelser: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tid Siden Første Overførsel: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Forbundet Til Server Siden: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienter"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Ukendt: %i"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Filtreret: %i"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Banlyst"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Total Størrelse Af Delte Filer: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktive forbindelser (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Ikke tilgængelig"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Aldrig"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Processing by filename: "
 msgstr "Udfører anmodning [Original]: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7172,7 +7083,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7180,156 +7091,154 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Downloads (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Admodning fejlede med en ukendt fejl."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "firewalled"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[DeleAfFil]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "%s Ikke tilgÃŠngelig"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7338,46 +7247,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7385,35 +7294,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7424,121 +7333,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7557,387 +7466,384 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Viss statusbar"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Viss statusbar"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Delte Filer"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverter gamle AICH hashsæt i '%s' til 64b i '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ADVARSEL: Filnavnet '%s' er ikke understøttet og er blevet omdøbt til '%s'"
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ADVARSEL: Filen '%s' eksistere, ny fil omdøbt til '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Er du sikker på du vil annullere og slette alle filer i denne kategori?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Bekræftelse Krævet"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "For mange forbindelser"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Tilføj kategori"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Ændre kategori"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Fjern kategori"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Genoptager uploads af fil: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, fuzzy, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspender upload af fil: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Velkommen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Indput parametre"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7949,168 +7855,160 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 #, fuzzy
 msgid "Cancelled !"
 msgstr "Anulleret !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ikke muligt at åbne %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dag(e) %i time(r) %i Minut(ter) %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule Online Statistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Maksimum DL rate siden wxCas er startet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolute Maksimum DL rate gennem wxCas forrige kørsel"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Reset"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "System"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Stop Auto Genopfriskning"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Gem Online Statistisk billede"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Print Online Statistisk billede"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Omking wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Start Auto Opdatering"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Auto Opdatering stoppet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Auto Opdatering startet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Gem Statistisk Billede"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule Online Statistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8118,11 +8016,11 @@ msgstr ""
 "Der var et problem med udskrivningen.\n"
 "Måske printer instillingerne er forkerte."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Udskrivning"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8139,403 +8037,392 @@ msgstr ""
 "Baseret på CAS af Pedro de Oliveira <falso@rdk.homeip.net>\n"
 "Omdelt under GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule kører ikke..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule kører"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule kører men ikke forbundet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule forbinder"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, aMule status ukendt..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " har kørt i "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " er stoppet !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " er ikke forbundet !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " forbinder..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr "gør noget mærkeligt, undersøg det !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " er forbundet til "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "afbrudt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " er tændt "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 #, fuzzy
 msgid " with "
 msgstr "] med "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr " Total Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Sesion Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Deling: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fil(er), Klienter i kø: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tid: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " tændt "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "System Hentnings Gennemsnit (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Mappe indholdende amulesig.dat fil"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Skriv her i hvilken mappe amulesig.dat befinder sig"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Opdaterings rate interval i sekunder"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Generer et statistisk billede for hver opdaterings hændelse"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Skriv her mappen hvor du vil generere det statistiske billede"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Upload periodisk dit statistiske billede til en FTP server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP Sti"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Skriv her URL på din FTP server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Skriv her biblioteket hvor dit statistiske billede på FPT serveren skal ligge"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Bruger"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Skriv her brugernavnet for at logge på din FTP server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Skriv her bruger passworded for at logge på din FTP server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP opdaterings interval i minutter"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Valider"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Mapper der indeholder din signatur fil"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Mappe hvor det statistiske billede bliver genereret"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Henter template <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Brug gzip komprimering"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Tillad bruger adgang"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule configurations fil sti. BRUG IKKE DIREKTE"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Web Server"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Admoding fejlede med følgende fejl: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Index fil ikke fundet: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Session udløbet - admoder login\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Session ok, logget in\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Session ok, ikke logget in\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ingen session åbnet - vil admode om login\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Session oprettet - admoder login\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Udfører anmodning [Original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Undersøger password\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Password hash invalid\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Passwork ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Password forkert\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Intet password skrevet. Blank password er ikke gyldigt.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Logout anmodning\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Udfører forespørgsel [omledt]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -24,20 +24,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 26.04.0\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Zeige aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule-Fernbedienung "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Schnappschuss:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -45,7 +45,7 @@ msgstr ""
 "'All-Plattform' p2p Client basierend auf eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -53,79 +53,79 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Teile von aMule basieren auf \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer Weiterleitung basierend auf der XOR Funktion.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Probleme:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Beim Start auf neue Version prüfen"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Verbinde mit Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nicht verfügbar"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Einen Freund hinzufügen"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Du musst einen gültigen Port und eine gültige IP eingeben!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Information"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Die angegebene Benutzerprüfsumme ist nicht gültig!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
@@ -138,47 +138,46 @@ msgstr ""
 "\n"
 "Desktop-Integration jetzt installieren?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "aMule zum Anwendungsmenü hinzufügen?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Installieren"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Nicht erneut fragen"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Desktop-Integration konnte nicht installiert werden: die Umgebungsvariable APPDIR ist nicht gesetzt. Dies bedeutet in der Regel, dass das AppImage auf eine nicht standardmäßige Weise gestartet wurde."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "aMule-Integration fehlgeschlagen"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Desktop-Integration konnte nicht installiert werden: Erstellen von %s fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar ist."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Desktop-Integration konnte nicht installiert werden: Schreiben von %s fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar ist."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, fuzzy, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage-Integration: aMule wurde zu Ihrem Anwendungsmenü hinzugefügt."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -192,103 +191,100 @@ msgstr ""
 "\n"
 "aMule jetzt neu starten?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule installiert"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Jetzt neu starten"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Später"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Fehler beim Öffnen der ED2KLinks-Datei."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufügen während man eine niedrige ID hat."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Beende nun Hauptanwendung ..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Beende amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Erzwinge Beenden der amuleweb-Instanz mit pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Beende Programmkern."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule-Herunterfahren abgeschlossen."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Speicherfehlerbehebungsresultate für aMule-Beendung:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Deine Locale wurde wegen einer Konfigurationsänderung auf Systemstandard geändert. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +292,19 @@ msgstr ""
 "\n"
 "EC-Konfiguration"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,52 +312,49 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Webserver läuft mit pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kann Ports nicht mit der festgelegten Adresse verbinden: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ist nicht erreichbar. Du wirst eine niedrige ID erhalten\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -377,48 +369,48 @@ msgstr ""
 "\n"
 "Bitte überprüfe deine Netzwerkeinstellungen, um sicherzugehen, dass der Port für ein- und ausgehenden Traffic geöffnet ist."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Erstellen der OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erstellen der aMule OnlineSig-Datei gescheitert"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Die ausgewählte Locale scheint nicht auf dem System installiert zu sein.(INFO: Ich werde trotzdem versuchen, sie zu setzen)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dies ist das erste Mal, dass du aMule %s startest"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dies ist eine Testversion, täglich aktualisiert, und\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "wir garantieren nicht, dass sie keine Daten zerstört, dein Haus anzündet\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "oder deinen Hund tötet. Aber es *sollte* sicher sein, sie zu benutzen.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mehr Informationen und neue Releases können auf unserer Homepage gefunden werden\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "unter https://amule-org.github.io, oder in unserem IRC-Channel #amule auf irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bitte melde Fehler unter https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,223 +418,219 @@ msgstr ""
 "Das angegebene Verzeichnis für die Online-Signaturdateien ist UNGÜLTIG!\n"
 "Online-Signatur wird bis zur Fehlerbehebung in den Einstellungen DEAKTIVIERT."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Speicherplatzvorbelegung für Datei '%s' fehlgeschlagen: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FEHLER: kann Logdatei nicht öffnen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WARNUNG: Logdatei ist leer. Etwas ist falsch."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Das Log wurde zurückgesetzt"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servernachricht: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Lade %s nicht herunter, weil die angeforderte Datei nicht neuer ist."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Knotenliste kann nicht geholt werden."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Konnte heruntergeladene Datei zur Versionsprüfung nicht öffnen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Fehlerhafte Versionsprüfungsdatei"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Du benutzt eine veraltete aMule-Version!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Diese Version von aMule ist %i.%i.%i und die aktuelle Version ist %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WARNUNG: Diese Version von aMuled ist veraltet: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Deine Kopie von aMule ist aktuell."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Konnte die Versionsprüfungsdatei nicht herunterladen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Benutzer: %s | Dateien: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Benutzer: E: %s K: %s | Dateien: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Keine Netzwerke ausgewählt"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "mit niedriger ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "mit hoher ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbunden zu %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinde zu %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "eD2k getrennt"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad gestartet."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad beendet."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kad verbunden (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad verbunden (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Kad getrennt"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-Netzwerk kann mit deaktiviertem UDP-Port nicht benutzt werden, nicht gestartet."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-Netzwerk ist in den Voreinstellungen deaktiviert, kein Verbindungsversuch."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "FEHLER: aMule daemon kann nicht verwendet werden wenn externe Verbindungen deaktiviert sind. Zum aktivieren von externen Verbindungen entweder normales aMule benutzen, amuled mit der Option --ec-config starten oder in der Datei ~/.aMule/amule.conf die Einstellung \"AcceptExternalConnections\" auf 1 ändern."
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "FEHLER: Ein gültiges Password ist nötig um externe Verbindungen nutzen zu können und aMule daemon kann ohne externe Verbindungen nicht benutzt werden. Um aMule daemon zu starten muss das \"ECPassword\"-Feld in der Datei ~/.aMule/amule.conf mit einem richtigen Wert versehen sein. amuled kann mit dem Argument --ec-config gestartet werden um das Passwort zu setzen. Mehr Informationen können in der Wiki unter https://amule-org.github.io/docs gefunden werden."
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - Zeitmesser wird gestartet"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Kann keine Pid-Datei erstellen"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dies ist aMule %s, basierend auf eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,192 +640,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Kein Netzwerk"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule Fernsteuerung"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Schwerer Fehler: Der Kern-Zeitgeber konnte nicht erstellt werden."
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Verbinde mit entferntem aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Verbindung verloren"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Abfrage beim Beenden"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -846,41 +827,41 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Schwerer Fehler: Der Nachfrage-Zeitgeber konnte nicht erstellt werden."
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Gehe in Ereignisschleife..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Verbinde..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Verbindung fehlgeschlagen. Bitte Host, Port und Passwort prüfen."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "EC-Ereignissteuerung für entfernte Benutzeroberfläche"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Verbindung fehlgeschlagen. Konnte nicht zu %s:%d verbinden\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Beende..."
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Verbindungsversuch zu %s (%s:%i): Zeitüberschreitung."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -889,685 +870,662 @@ msgstr ""
 "Verbindungs-Timeout. %s:%d konnte innerhalb der vorgegebenen Zeit nicht erreicht werden.\n"
 "Prüfen Sie Host, Port und ob aMule mit aktivierten externen Verbindungen läuft."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Mit Netzwerk verbinden."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Verbindung fehlgeschlagen. Konnte nicht zu %s:%d verbinden\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Bereit"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Alle"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nicht verfügbar"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Datei nicht gefunden."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ungültiger Verweis oder schon auf der Liste"
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nutze weiter das Verzeichnis '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Suche Kumpel für Verbindung mit niedriger ID"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fake eMule version %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Fake eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Fake eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basiert auf eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Spitzname: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Angefordert: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Dateistatistik dieser Sitzung: %d von %d Anfrage akzeptiert, %s übertragen\n"
 msgstr[1] "Dateistatistik dieser Sitzung: %d von %d Anfragen akzeptiert, %s übertragen\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Dateistatistik aller Sitzungen: %d von %d Anfrage akzeptiert, %s übertragen\n"
 msgstr[1] "Dateistatistik aller Sitzungen: %d von %d Anfragen akzeptiert, %s übertragen\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Unbekannte Datei angefordert"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Nachricht gefiltert von '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Neue Nachricht von '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Benutzer %s (%u) hat die Liste freigegebener Dateien für das nicht vorhandene Verzeichnis '%s' angefordert -> Ignoriert"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "WARNUNG: Datei '%s' kann nicht geöffnet werden."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "WARNUNG: Liste der abgebrochenen Dateien korrumpiert, enthält ungültigen Header."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO-Fehler während des Lesens der Datei '%s': %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Fehler während des Speicherns der Datei '%s': %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Neue Kategorie"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Wähle einen Ordner für eingehende Dateien"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Du musst einen Namen für diese Kategorie festlegen!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Du musst einen Pfad für diese Kategorie festlegen!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Anlegen des Verzeichnisses für eingehende Dateien der Kategorie fehlgeschlagen. Bitte einen gültigen Pfad angeben!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Beginn der Chat-Sitzung: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Verbunden mit Client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Verbinde mit Client ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Verbindung zum Client fehlgeschlagen / Verbindung verloren ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Captcha-Überprüfung bestanden, Nachricht wurde vom Benutzer empfangen. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Falsche Antwort zum Captcha, Nachricht wurde ignoriert. Bitte eine neue Nachricht senden um ein neues Captcha anzufordern. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Reiter schließen"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Alle Reiter schließen"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Andere Reiter schließen"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Zu Freunden hinzufügen"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Credit-Datei geladen, %u Client ist bekannt"
 msgstr[1] "Credit-Datei geladen, %u Clients sind bekannt"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Credits für %u Client abgelaufen!"
 msgstr[1] " - Credits für %u Clients abgelaufen!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Keine 'cryptkey.dat' gefunden, erzeuge eine neue."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Client-Details"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Niedrige ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hohe ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Unterstützt"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nicht Unterstützt"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Verbindung getrennt"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nicht vollständig"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Böser Bube"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verifiziert - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nicht verfügbar"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Benutzer %s (%u) hat Deine Liste der freigegebenen Dateien angefordert -> akzeptiert"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Benutzer %s (%u) hat Deine Liste der freigegebenen Dateien angefordert -> abgelehnt"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Benutzer %s (%u) hat die Liste Deiner freigegebenen Verzeichnisse angefragt -> akzeptiert"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Benutzer %s (%u) hat die Liste Deiner freigegebenen Dateien angefragt -> abgelehnt"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Benutzer %s (%u) hat deine Liste freigegebener Dateien für das Verzeichnis '%s' angefordert -> akzeptiert"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Benutzer %s (%u) hat deine Liste freigegebener Dateien für das Verzeichnis '%s' angefordert -> abgelehnt"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Benutzer %s (%u) hat das Verzeichnis '%s' freigegeben"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Benutzer %s (%u) hat ungefragt seine freigegebenen Verzeichnisse gesendet."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Benutzer %s (%u) hat die Liste freigegebener Dateien für das Verzeichnis '%s' gesendet"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Benutzer %s (%u) hat das Senden der Liste freigegebener Dateien abgeschlossen"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Benutzer %s (%u) hat ungefragt die Liste seiner freigegebenen Dateien gesendet"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Benutzer %s (%u) verweigert den Zugriff auf die Liste freigegebener Verzeichnisse/Dateien."
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Dateikommentare"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Benutzername"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dateiname"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Bewertung"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad-Suche kann nicht ausgeführt werden, wenn Kad nicht läuft"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Suche Kumpel für Verbindung mit niedriger ID"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Keine Kommentare"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u Kommentar"
 msgstr[1] "%u Kommentare"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Client %s wurde gebannt, weil er %s korrupte Daten für %s gesamt für die Datei '%s' gesendet hat."
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Herunterladen der Länderdaten für '%s' fehlgeschlagen."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ni]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Ho]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoch"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Sehr hoch"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Release"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Anfragen"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Verbunden über Server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Warteschlange voll"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "in Warteschlange"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Herunterladen"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Empfange Prüfsummensatz"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Keine benötigten Teile"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Verbindung niedriger ID zu niedriger ID nicht möglich"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Zu viele Verbindungen"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Verbinde über Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Zu viele Kad-Verbindungen"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Gebannt"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Verbindungsfehler"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Entfernte Warteschlange voll"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Alter MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Neuer MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule-kompatibel"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Lokaler Server"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Quellenaustausch"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiv"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Verweis"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Einstiegsquellen"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Suchresultate:"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Fertiggestellt"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "In Arbeit"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "FEHLER: Ungenügender Festplattenplatz"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "FEHLER: part.met nicht gefunden"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "FEHLER: IO-Fehler!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "FEHLER: Fehlgeschlagen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "In Warteschlange"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Wird bereits heruntergeladen"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Unbekanntes oder fehlerhaftes Format der Temp-Datei."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Teil"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Übertragen"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Quellen"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorität"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Verbleibende Zeit"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Zuletzt vollständig gesehen"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Letzter Empfang"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Wirklich die ausgewählte Datei löschen?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Wirklich die ausgewählten Dateien löschen?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1576,109 +1534,106 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatisch"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stopp"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausieren"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "Fo&rtsetzen"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Liste um fertige Dateien bereinigen"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "[A4AF] Weise alle Quellen dieser Datei zu"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "[A4AF] Automatisches Zuweisen von Quellen zu dieser Datei"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "[A4AF] Weise alle Quellen einer anderen Datei zu"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Erweiterte Optionen"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Vorschau"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Zeige &Dateieigenschaften"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Zeige alle Kommentare"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopiere Magnet-URI in Zwischenablage"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopiere eD2k &Link in die Zwischenablage"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Feedback in die Zwischenablage kopieren"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "Zuweisung rückgängig machen"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Einer Kategorie hinzufügen"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Oeffne diese Datei"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Einen neuen Namen für diese Datei eingeben:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Datei umbenennen"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1687,346 +1642,345 @@ msgstr ""
 "Bitte trage deinen bevorzugten Videoplayer in den Einstellungen ein.\n"
 "Bis dahin wird aMule versuchen, %s zu starten, und bei jeder Vorschau wird diese Warnung angezeigt werden."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Dateivorschau"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEHLER: Konnte externen Mediaplayer nicht starten!Befehl: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Speichere unfertige Datei %u von %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Alle unfertigen Dateien gespeichert."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Lade temporäre Dateien von %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Lade unfertige Datei %u von %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "FEHLER: Konnte Sicherungsdatei nicht laden. Suche auf https://github.com/amule-org/amule/discussions nach .part.met Wiederherstellungslösungen."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Alle unfertigen Dateien geladen."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Keine Part-Dateien gefunden"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u part-Datei gefunden"
 msgstr[1] "%u part-Dateien gefunden"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Das Dateisystem für temporäre Dateien unterstützt keine großen Dateien."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Das Dateisystem für fertige Dateien unterstützt keine großen Dateien."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Herunterladen von %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Du versuchst bereits, die Datei '%s' herunterzuladen"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Die Datei '%s' ist bereits vorhanden"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Die Datei '%s' ist bereits vorhanden"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Die Datei %s wird bereits heruntergeladen"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Kann Magnet-Verweis nicht in eD2k umwandeln: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Unbekanntes Protokoll von Verweis: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "Konnte %u Link nicht hinzufügen (Details: siehe Log)"
 msgstr[1] "Konnte %u Links nicht hinzufügen (Details: siehe Log)"
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ungültiger eD2k-Link! Fehler: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Client sendete Paket nach fehlgeschlagener Authentifizierung."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Externe Verbindung getrennt."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Externe Verbindungen deaktiviert. Leeres Passwort!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Externe Verbindungen in der Konfigurationsdatei deaktiviert"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Neue externe Verbindung akzeptiert"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEHLER: Konnte keine neue externe Verbindung akzeptieren"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe Verbindung verweigert. Kein Passwort in den Einstellungen angegeben!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Verbinde mit Client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Unbekannte Version"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Unkorrekte EC-Versions-ID; es könnte eine binär-Inkompatibilität vorliegen. Benutze Kern und Fernsteuerung desselben Schnappschusses."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kannst nicht zu einer Release-Version von einer beliebigen Entwicklungs-Version verbinden! *seufz* möglicher Absturz verhindert"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Ungültige Protokollversion."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Fehlende Protokollversionsmarke."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentifizierung fehlgeschlagen: ungültiger Hash als EC-Passwort angegeben."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Authentifizierung fehlgeschlagen: falsches Passwort."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Authentifizierung fehlgeschlagen: fehlendes Passwort."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Ungültige Anfrage, bitte zuerst authentifizieren."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Zugang gewährt."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Fehlermeldung \"%s\" zu Client gesendet."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Unerlaubter Verbindungsversuch von %s. Verbindung getrennt."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fernsteuerungs-Part-Datei-Kommando gescheitert: Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dateiprüfsumme nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode-Verarbeitungsfehler!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Server nicht hinzugefügt"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "Server nicht gefunden: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "Der zu entfernende Server muss angegeben sein"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Freund nicht gefunden."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Client nicht gefunden."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED erfordert EC_TAG_FRIEND oder EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websuche mit der Fernsteuerungsschnittstelle macht keinen Sinn."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Suche läuft gerade. Aktualisiere gleich die Ergebnisse!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Keine Punkte für Graphen."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Der Client ist nicht nicht für diese Detailstufe eingestellt."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Externe Verbindungen: Herunterfahren gefordert"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Wird bereits heruntergefahren."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Externe Verbindungen: Füge hinzu Verweis '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d von %d Links fehlgeschlagen. Ungültiger Verweis oder schon auf der Liste"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Datei nicht gefunden."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Ungültiger Dateiname."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Datei kann nicht umbenannt werden."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad ist in den Einstellungen deaktiviert."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Bereits mit eD2k verbunden."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Verbinde mit eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Bereits mit Kad verbunden."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Verbinde mit Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Alle Netzwerke sind deaktiviert."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Von eD2k getrennt."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Von Kad getrennt."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe Verbindungen: ungültigen Opcode empfangen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ungültiger OpCode (falsche Protokollversion?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Unbekannte Erweiterung '%s' für Befehl '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Unbekannter Befehl '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2034,7 +1988,7 @@ msgstr ""
 "\n"
 "Dieser Befehl kann kein Argument haben.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2042,7 +1996,7 @@ msgstr ""
 "\n"
 "Dieser Befehl muss ein Argument haben.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2050,7 +2004,7 @@ msgstr ""
 "\n"
 "Befehl unvollständig, eine der folgenden Erweiterungen muss verwendet werden:\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2058,11 +2012,11 @@ msgstr ""
 "\n"
 "Verfügbare Erweiterungen:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Verfügbare Befehle:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2073,17 +2027,17 @@ msgstr ""
 "Alle Befehle sind unabhängig von Groß- und Kleinschreibung.\n"
 "Eingabe von '%s <Befehl>' für weitere Informationen zu <Befehl>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Programm verlassen."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Hilfe anzeigen."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2091,7 +2045,7 @@ msgstr ""
 "Um Hilfe zu einem Befehl zu bekommen, gib 'help <Befehl>' ein.\n"
 "Eine vollständige Befehlsübersicht erhält man mit 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2102,46 +2056,46 @@ msgstr ""
 "'%s' zeigt die Befehlsübersicht.\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Syntax Fehler!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Fehler beim Ausführen des Befehls - sollte niemals passieren! Bitte den Fehler melden.\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Dieser Befehl sollte keine Parameter haben."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Dieser Befehl muss einen Parameter haben."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Ungültiges Argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Unvollständiger Befehl."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Gib '%s' ein, um mehr Hilfe zu bekommen.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Dies ist %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Dies ist %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2149,7 +2103,7 @@ msgstr ""
 "\n"
 "Erstelle Client...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2158,7 +2112,7 @@ msgstr ""
 "\n"
 "Ok, beende %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2172,331 +2126,326 @@ msgstr ""
 "\n"
 "Beende...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Zeige diese Hilfe."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host, auf dem aMule läuft. (Standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules Port für externe Verbindungen. (Standard: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Passwort für externe Verbindungen."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Lese Konfiguration aus Datei."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Schreibe keinerlei Ausgabe auf stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Sei ausführlich - Zeige auch Debug-Nachrichten."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Setze Programm-Locale (Sprache)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Schreibe Kommandozeilen-Optionen in Konfigurationsdatei."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Erstelle Konfigurationsdatei basierend auf aMules Konfigurationsdatei."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Drucke Programmversion."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "ZLIB Kompression unabhängig der Ziel-IP erzwingen (nützlich wenn der Server per VPN über eine LAN-IP aufgelöst wird)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Dateieinzelheiten"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% erledigt"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Willkommen!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Verbinde zu Kumpel"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Verbindungstyp:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Netzwerke"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standard-TCP-Port"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Erweiterter UDP-Port (Kad / globale Suche)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktiviere UPnP für Router-Port-Weiterleitung"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Die Datei %s wird bereits heruntergeladen"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Serverliste beim Programmstart aktualisieren"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatisch starten wenn ich mich einlogge"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Verzeichnis für temporäre Downloaddateien"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Konnte Freundes-Liste 'emfriends.met' nicht lesen!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Freunde"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Zeige &Details"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Freund hinzufügen"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Freund entfernen"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "&Message senden"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Dateien ansehen"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Friendslot erstellen"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Den markierten Freund wirklich löschen?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Die markierten Freunde wirklich löschen?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2504,11 +2453,11 @@ msgstr ""
 "Du darfst nicht mehr als einen Friendslot vergeben.\n"
 " Nur ein Slot wurde vergeben."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Mehrfachauswahl"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2516,206 +2465,205 @@ msgstr ""
 "Du darfst nicht mehr als einen Friendslot vergeben.\n"
 " Nur ein Slot wurde vergeben."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Sende Nachricht an Benutzer"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Zu sendende Nachricht:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Entferne von Freundesliste"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Sende Nachricht"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zu dieser Datei verschieben"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In Warteschlange: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Andere Datei angefordert"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Warte auf Uploadslot"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "In Warteschlange: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Hochladen"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Keine"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nein"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Lädt herunter..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP-Download abgebrochen"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Die Download-URL kann nicht leer sein."
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Konnte HTTP-Anfrage für %s nicht erstellen"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP-Download: leerer Antworttext für %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Konnte heruntergeladene Datei nicht nach %s verschieben"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s heruntergeladen (%llu Bytes)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "Die URL %s antwortet mit: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-Download für %s fehlgeschlagen: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Nicht autorisiert für %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Lade neues %s von %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Herunterladen der Datei %s fehlgeschlagen, breche Aktualisierung ab."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Das Entfernen der %s-Datei ist fehlgeschlagen, breche Aktualisierung ab."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Das Umbenennen der neuen %s-Datei ist fehlgeschlagen, breche Aktualisierung ab."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s erfolgreich aktualisiert."
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Fehler beim Aktualisieren von %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Herunterladen der Datei %s von %s fehlgeschlagen."
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Lade IP-Filter 'ipfilter.dat'·und·'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Laden der ipfilter.dat '%s' fehlgeschlagen, unbekanntes Format aufgetreten."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Fehler beim Laden der ipfilter.dat '%s', Datei konnte nicht geöffnet werden."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u IP-Bereich von '%s' geladen."
 msgstr[1] "%u IP-Bereiche von '%s' geladen."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u fehlerhafte Zeile wurde ignoriert."
 msgstr[1] "%u fehlerhafte Zeilen wurden ignoriert."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Das Umbenennen der neuen %s-Datei ist fehlgeschlagen, breche Aktualisierung ab."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP-Filter ist bereit"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2723,869 +2671,837 @@ msgstr ""
 "Bootstrap von \n"
 "bekannten Clients"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Knoten (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ungültige Bootstrap-IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Ungültiger Bootstrap-Port"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Bitte alle erforderlichen Felder ausfüllen"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Wirklich neue nodes.dat herunterladen?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Dies wird alle momentanen Knoten entfernen und die Kademlia-Verbindung neu starten."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Fortsetzen?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: Suchbegriff zu kurz"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Das Suchwort ist bereits auf der Suchliste."
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Lesen der nodes.dat Datei fehlgeschlagen - zu alt. Diese Version (0) wird nicht mehr unterstützt."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Lese %u Kad-Kontakt"
 msgstr[1] "Lese %u Kad-Kontakte"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Keine Kontakte gefunden, bitte von einem anderen Client bootstrappen oder eine nodes.dat-Datei herunterladen."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Nur %d Kad-Kontakt verfügbar, nodes.dat wurde nicht geschrieben."
 msgstr[1] "Nur %d Kad-Kontakte verfügbar, nodes.dat wurde nicht geschrieben."
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d Kad-Kontakt geschrieben."
 msgstr[1] "%d Kad-Kontakte geschrieben."
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad-Netzwerk"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Dateiname"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Dateigröße"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Tauschverhältnis"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Angefordert"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Akzeptiert"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "vollständige Quellen"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "WARNUNG: Liste der bekannten Dateien korrumpiert, enthält ungültigen Header."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Laden eines Eintrags aus der Liste bekannter Dateien fehlgeschlagen, Datei möglicherweise beschädigt"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ungültiger Eintrag in der Liste bekannter Dateien, Datei möglicherweise beschädigt: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Unbekannter Fehler %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Kann Fehlerbeschreibung für Fehler %d nicht erhalten"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Prüfsumme erstellen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Wird abgeschlossen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Vollständig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Fehlerhaft"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Warten"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Das angegebene Passwort darf nicht leer sein."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Ungültiges Passwort, keine MD5-Prüfsumme!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Verbindungsfehler"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Externe Verbindung getrennt — Beende."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC-Verbindung fehlgeschlagen. Leere Antwort."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Externe Verbindungen: Falsche Antwort, Verhandlung fehlgeschlagen. Verbindung beendet."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Gelungen! Verbindung aufgebaut zu aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Verbindung hergestellt."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: OK"
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "FEHLER: Kann nicht auf TCP-Port lauschen."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "FEHLER: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "WARNUNG: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Schließen"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Leeren"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Verbunden (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Verbunden (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Verbunden (firewalled)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Server: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "Server-IP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP-Port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP-Port: Nicht bereit"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP-Port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP-Port: Nicht bereit"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Client-Information"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Upload-Einstellung"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Download-Einstellung"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Zeige aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Verstecke aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Schließen"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Unbegrenzt"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule-Traymenü"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Geschwindigkeitsbegrenzungen:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Keine"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Keine"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Download-Geschwindigkeit: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Upload-Geschwindigkeit: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Spitzname: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Kein Spitzname ausgewählt!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Client-ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Servername: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Nicht verbunden"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online-Signatur: An"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online-Signatur: Aus"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Laufzeit: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Freigegebene Dateien: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clients in Warteschlange: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Gesamt-DL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Gesamt-UL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Sendet einen eD2k- oder Magnet-Verweis an den Kern."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Zu Freunden hinzufügen"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Hier klicken, um den eD2k-Verweis im Texteingabefeld zur Download-Liste hinzuzufügen. "
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Hier werden Ereignisse angezeigt. Eine komplette Ereignisliste kann im Log unter dem Server-Reiter eingesehen werden."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Lade ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Anzahl Benutzer auf dem Server, mit dem du verbunden bist ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Benutzer: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Zum aktuellen Server verbundene Benutzer und ungefähre Anzahl der Benutzer insgesamt im Netz."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Hoch: 0.0 | Herunter: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Derzeitige Upload- und Download-Raten im Schnitt. Wenn aktiviert, dann auch noch in Klammern der Overhead durch Client-Kommunikation."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Zeigt den aktuellen Verbindungsstatus an: rote Pfeile bedeuten, dass du im Moment nicht verbunden bist, gelb bedeutet, du hast eine niedrige ID (firewalled), und grün bedeutet, dass du eine hohe ID hast (die beste Verbindung)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Nicht verbunden..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Momentan verbundener Server."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Suche"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Name:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Suchtyp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokal"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Erweiterte Parameter"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtere"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Dateityp"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archive"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Abbilder"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Bilder"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programme"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Texte"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Dateiendung"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Mindestgröße"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Höchstgröße"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filterergebnisse"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Ergebnisse umkehren"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Bekannte Dateien ausblenden"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Mehr"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern. Jeder Klick fragt den nächstgelegenen Peer nach weiteren Kontakten ab (KADEMLIA_FIND_VALUE_MORE) und macht zusätzliche Dateitreffer sichtbar, die die anfängliche Alpha-Grenze der Suche verfehlt hat."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Setze Felder zurück."
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Vollständige Downloads entfernen"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dateiquellen:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Allgemein"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Name:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-Datei:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Prüfsumme:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Dateigröße:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Übertragungen"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Status der Part-Datei:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Zuletzt vollständig gesehen:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Gefundene Quellen:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Übertragende Quellen:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Anzahl der Part-Dateien:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Verfügbar:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Dauer aktiven Herunterladens: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Übertragen:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Fertiggestellt:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligente Fehlerkorrektur"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Durch Fehler verloren:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Durch Kompression gewonnen:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Durch I.C.H. gesparte Pakete:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Freigegeben: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Anfragen"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Akzeptierte Anfragen"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Übertragene Datenmenge"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Verteilungsfaktor"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Vollständige Quellen"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Freigegebene Dateien"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Upload: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nicht bewertet"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titel:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Dateinamen"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Übernehmen"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Aufräumen"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Kommentiere/bewerte Datei (der Text wird für alle Benutzer sichtbar sein)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3593,574 +3509,572 @@ msgstr ""
 "Für einen Film kann man die Länge, die Handlung, die Sprache,... angeben\n"
 "und wenn es eine Fälschung ist, kann man andere aMule-Benutzer davor warnen."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Dateiqualität"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nicht bewertet"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Ungültig / fehlerhaft / Fälschung"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Schlecht"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Ordentlich"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Gut"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Hervorragend"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Bewerte diese Datei oder gib anderen Benutzern einen Hinweis, wenn sie ungültig ist..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Kad getrennt"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Wird geladen, bitte warten ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Unbekannte Größe"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Benötigte Information"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-Adresse:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Zusätzliche Information"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistikbaum"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Client-Software:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Client-Version:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-Adresse:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Benutzer-ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Server-IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Servername:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Verschleierung:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Übertragungen zum Client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Momentane Anfrage:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Durchschnittliche Uploadrate:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Durchschnittliche Downloadrate:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Hochgeladen (Sitzung):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Heruntergeladen (Sitzung):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Hochgeladen (Gesamt):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Heruntergeladen (Gesamt):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punkte"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DL/UP-Modifikator:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Sichere Erkennung:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Warteschlangenposition:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Wartepunkte:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Spitzname"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - der multiplattform Muli"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Dies ist der Name, den andere Benutzer sehen, wenn sie mit dir verbunden sind."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Sprache:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Verzögerung vor dem Anzeigen der Tooltips. "
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Verwendete Sprache für die Einstellungen festlegen."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Beim Start auf neue Version prüfen"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Wenn dies aktiviert ist, wird aMule beim Start überprüfen, ob eine neue Version vorliegt"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registriert einen Autostart pro Nutzer. Wenn du das Programm verschiebst musst du aMule manuell starten um den Eintrag zu aktualisieren."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "minimiert starten"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Wenn dies aktiviert ist, wird aMule sofort nach dem Start minimiert. "
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Abfrage beim Beenden"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Sicherheitsabfrage vorm Beenden."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Tray-Icon aktivieren"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Dies aktiviert/deaktiviert das Symbol im Infobereich (oder Taskleiste)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Anwendungsfenster bei Klick auf \"Schließen\" verbergen"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimiere zu Symbol im Infobereich"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Wird dies aktiviert, minimiert sich aMule in den Infobereich, anstatt in die Taskleiste."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Benachrichtigungen anzeigen, wenn Downloads abgeschlossen sind"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wenn aktiviert, zeigt aMule Benachrichtigungen an, sobald Downloads abgeschlossen sind."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Tooltip-Verzögerungszeit:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "Sekunden"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Browser-Wahl"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Öffne in neuem Reiter, wenn möglich"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öffne die Webseite in einem neuen Reiter, statt einem neuen Fenster, wenn möglich"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videoplayer"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Bandbreitenbegrenzungen"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Slotzuteilung"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dies ist der Standard-eD2k-Port. Er kann nicht deaktiviert werden."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-Port für Serveranfragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Dieser UDP-Port wird für erweiterte ED2k-Anfragen und das Kad-Netzwerk benutzt."
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP-TCP-Port (optional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automatisches Verbinden beim Start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Wiederverbinden nach Trennung"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Lösche tote Server nach"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "Versuchen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Serverliste von verbundenem Server beziehen"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Serverliste beim Verbinden zu einem Client beziehen"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Benutze Prioritätssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Benutze intelligente Prüfung für niedrige ID beim Verbinden"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Sicheres/langsames Verbinden zu Servern"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisches Verbinden nur zu Servern aus der statischen Liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Setze manuell hinzugefügte Server auf hohe Priorität"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Neue Dateien dem Download pausiert hinzufügen"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Neu hinzugefügte Dateien im Download auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Versuche, zuerst die ersten und letzten Dateiteile herunterzuladen"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Starte nächste pausierte Datei, wenn eine Datei fertiggestellt wird"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Aus der selben Kategorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "In alphabetischer Reihenfolge"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Reserviere Speicherplatz für neue Dateien"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserviert für neue Dateien Speicherplatz für die ganze Datei und reduziert so Fragmentierung."
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe Downloads wenn freier Speicherplatz folgenden Wert erreicht:"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Wähle dies aus, wenn aMule deinen Festplattenplatz prüfen soll"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Hier den minimalen erwünschten Festplattenplatz angeben."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bei seltenen (< 20 Quellen) Dateien zehn Quellen speichern"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Neue freigegebene Dateien auf Autopriorität stellen"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente Korruptionsverarbeitung (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Aktiviere"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Advanced I.C.H vertraut jeder Prüfsumme (nicht empfohlen)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4168,693 +4082,691 @@ msgstr ""
 "Vollständige Downloads werden hier gespeichert. Alle Dateien in diesem Ordner werden automatisch geteilt\n"
 ". Falls dieser Ordner Dateien enthält die du nicht teilen willst, wähle einen eigenen Ordner nur für aMule aus."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Freigegebene Ordner"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Entferne"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtsklick auf das Symbol des rekursiv freizugebenden Verzeichnisses)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Versteckte Dateien freigeben"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ornder automatisch auf Änderungen überwachen"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Symbolischen Links in geteilten Ordnern folgen"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graphen"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Aktualisierungsverzögerung: 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Durchschnittsgraphen in Minuten berechnen: 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Verbindungsgraphenskalierung: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Downloadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Farben: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Hintergrund"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Gitter"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Aktueller Download"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Download: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Download: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Aktueller Upload"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Upload: Durchschnitt"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Momentane Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Laufende Kad-Knoten"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Auswahl"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Baum"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Anzahl angezeigter Client-Versionen (0=unbegrenzt)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! WARNUNG !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maximale neue Verbindungen pro 5 Sekunden"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dateipuffergröße: 240000 Bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Upload-Warteschlangengröße: 5000 Clients"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Zeitgesteuerten Bereitschaftsmodus des Computers deaktivieren"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "benutztes Aussehen:"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Zeige \"schnelle eD2k-Linkverarbeitung\" in jedem Fenster"
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Zeige erweiterte Informationen auf Kategorie-Reitern"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Zeige Programmversion im Titel"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Zeige Transferraten im Titel"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Vor dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Nach dem Anwendungsnamen"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Zeige Overhead-Bandbreite"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Toolbar senkrecht ausrichten"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Downloadwarteschlangendateien"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Zeige Prozent des Fortschritts"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Flach"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Verweigere Gastzugriff"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Gast-Passwort für den Webserver"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4862,11 +4774,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4876,517 +4788,517 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Freigaben"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Ausgeschaltet [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "Byte"
 msgstr[1] "Bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "Byte/Sek"
 msgstr[1] "Bytes/Sek"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "Sekunden"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "Minuten"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "Stunden"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "tage"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "alle"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "alle anderen"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Unvollständig"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Angehalten"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Text"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Verwende Konfigurationsverzeichnis: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Warte auf Ende des Umwandlungsthreads für unfertige Dateien..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importiere %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lese Temp-Verzeichnis"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Hole Basis-Informationen aus der Download-Info-Datei"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Erzeuge Zieldatei"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Lade Daten aus der alten Download-Datei (%u von %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Speichere Datenblock in die neue, einzelne Download-Datei (%u von %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Hole Quellen-Download-Datei-Informationen"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Füge Download hinzu und speichere neue Part-Datei"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importiere Part-Dateien"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Status"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Dateiprüfsumme"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Platte: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Bitte wähle einen Ordner, um nach temporären Downloads zu suchen! (Unterordner werden mit eingeschlossen!)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Quelldateien der erfolgreich importierten Downloads löschen?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Quellen entfernen?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "FEHLER: Erstellen der Part-Datei fehlgeschlagen"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Versuche, Sicherung der met-Datei von %s zu laden"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "FEHLER: Konnte part.met-Datei nicht öffnen: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "FEHLER: part.met-Datei hat die Größe 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "FEHLER: ungültige part.met-Dateiversion: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Fehler: %s (%s) ist defekt (falsche Tags: %s), kann Datei nicht laden."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "Fehler: %s (%s) ist defekt (falscher Tagcount), kann Datei nicht öffnen)."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Versuche, Dateiinformation wiederherzustellen..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Unbenannte Datei wird versucht wiederherzustellen - Es wird versucht, sie als RecoveredFile.dat zu speichern"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Alle verfügbaren Dateiinformationen wiederhergestellt :D - Versuche, sie zu benutzen..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Konnte Dateiinfo nicht wiederherstellen :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Fehler beim Öffnen von %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "WARNUNG: %s könnte defekt sein (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "FEHLER beim Speichern der Part-Datei: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Eingabe/Ausgabe-Fehler beim Speicher der unfertigen Dateien:"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "0/unbekannt Bytes nach '%s' geschrieben -- erhalte existierende .part.met."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Speichern der Datei 'part.met.seeds' für %s fehlgeschlagen"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i Einstiegsquelle für Part-Datei %s (%s) gespeichert."
 msgstr[1] "%i Einstiegsquellen für Part-Datei %s (%s) gespeichert."
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Konnte Seed-Datei für Part-Datei %s (%s) nicht lesen"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fehler beim Lesen der Partfile-Einstiegsquellendatei (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "korrumpierter Teil (%d) in %d-teiliger Datei %s gefunden - Dateiergebnishash |%s| Dateihash |%s|"
 msgstr[1] "korrumpierter Teil (%d) in %d-teiliger Datei %s gefunden - Dateiergebnishash |%s| Dateihash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Vollständigen Teil (%i) in %s gefunden"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Prüfsumme für %s neu erstellt"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Unerwarteter Fehler beim Abschließen des Herunterladens von %s. Datei pausiert."
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Herunterladen abgeschlossen: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5395,307 +5307,307 @@ msgstr ""
 "Herunterladen abgeschlossen:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Lösche Datei: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "WARNUNG: Konnte für heruntergeladenen Teil die Prüfsumme nicht berechnen - Prüfsummensatz unvollständig für '%s'."
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEHLER: Prüfsumme für einen Teil konnte nicht erstellt werden - Prüfsumme unvollständig (%s). Dies dürfte eigentlich nie passieren."
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Teil %u von '%s' als vollständig markiert aber das Partfile ist kürzer als erwartet (%llu Bytes statt %llu); öffne Lücke für wiederholten Download."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF beim Hashen des %u. heruntergeladenen Teils, mit der Länge %u (max %u), für die Part-Datei '%s', mit der Länge %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "WARNUNG: Nicht genügend freier Festplattenplatz! Pausiere Datei: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Heruntergeladener Teil %i in Datei '%s' ist defekt"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Defekter Teil %i in %s wiederhergestellt -> Gesparte Bytes: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Reserviere"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Zu wenig Festplattenplatz"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Verbindung"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Sicherheit"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Aussehen"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Fernsteuerung"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Fortgeschritten"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Ereignisse"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Fehlersuche (Debugging)"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5705,15 +5617,15 @@ msgstr ""
 "    %PARTFILE - ganzer Pfad zur Datei\n"
 "    %PARTNAME - nur der Dateiname"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Tray-Icon unterstützung benötigt libayatana-appindicator3 beim kompilieren."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Auf Wayland nicht verfügbar: Das Protokoll meldet nicht wenn ein Fenster minimiert is, sodass diese Option nicht auf die Minimieren Schaltfläche des System reagieren kann. Workaround: aMule mit `GDK_BACKEND=x11 starten um XWayland zu verwenden."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5729,35 +5641,35 @@ msgstr ""
 "aMule funktioniert auch hervorragend, ohne\n"
 "dass diese Einstellungen verändert werden."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Verbindung von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datentransfer von Einstellung zu Steuerelement mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Der Typ des Proxy, zu dem du verbindest"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datentransfer von Steuerelement zu Einstellung mit ID %d und Schlüssel %s fehlgeschlagen."
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Prüfe Passwort\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5765,41 +5677,41 @@ msgstr ""
 "aMule muss neu gestartet werden, um diese Änderungen zu übernehmen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP-Port geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Port externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Akzeptanz externer Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Unterstützung für Protokollverschleierung geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5807,7 +5719,7 @@ msgstr ""
 "Die Auto-Update-Serverliste ist leer.\n"
 "'Serverliste beim Programmstart aktualisieren' wird deaktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5815,33 +5727,33 @@ msgstr ""
 "Du hast die externen Verbindungen aktiviert, aber kein Passwort angegeben.\n"
 "Externe Verbindungen können nur aktiviert werden, wenn ein gültiges Passwort angegeben wird."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Sprache geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Temp-Verzeichnis geändert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2k-Netzwerk aktiviert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ungültige Protokollversion."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5849,7 +5761,7 @@ msgstr ""
 "Beide Netzwerke, eD2k und Kad, sind deaktiviert.\n"
 "Mindestens eins davon muss aktiviert sein, um sich verbinden zu können."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5857,7 +5769,7 @@ msgstr ""
 "Kad wird nicht starten, solange der UDP-Port deaktiviert ist.\n"
 "Bitte UDP-Port aktivieren, oder Kad ausschalten."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5867,71 +5779,71 @@ msgstr ""
 "aMule MUSS jetzt neu gestartet werden.\n"
 "Wenn du jetzt nicht neu startest, beklage dich nicht, wenn irgendwas übles passiert.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Autostart"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Konnte aMule nicht für Autostart registrieren. Der Ort dafür könnte nicht beschreibbar sein."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Konnte den Autostart-Bei-Login Eintrag nicht entfernen."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5941,66 +5853,66 @@ msgstr ""
 "Bitte gib mindestens eine URL zu einer gültigen server.met ein.\n"
 "Drücke dazu den Knopf \"Liste\" neben diesem Kontrollkästchen."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Temporäre Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Fertige Dateien"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online-Signaturen"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wähle einen Ordner für %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Suche nach einem Videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Browser-Wahl"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Ausführbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemvorgabe"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Serverliste bearbeiten"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6008,115 +5920,115 @@ msgstr ""
 "Hier URL's für server.met-Dateien eintragen.\n"
 "Nur eine URL pro Zeile!"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "vollständige Quellen"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Aktualisierungsverzögerung: %d Sekunde"
 msgstr[1] "Aktualisierungsverzögerung: %d Sekunden"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Zeit für Durchschnittslinie: %d Minute"
 msgstr[1] "Zeit für Durchschnittslinie: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Verbindungsgraphenskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dateipuffergröße: %d Byte"
 msgstr[1] "Dateipuffergröße: %d Bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Upload-Warteschlangengröße: %d Client"
 msgstr[1] "Upload-Warteschlangengröße: %d Clients"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-Wiederverbindungsintervall: %d Minute"
 msgstr[1] "Server-Wiederverbindungsintervall: %d Minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server-Wiederverbindungsintervall: Aus"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "deaktiviert"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Führe Kommando beim '%s' Ereignis aus"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Aktiviere Befehlsausführung im Kern"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Kern-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Aktiviere Befehlsausführung in GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI-Befehl:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6124,1088 +6036,1087 @@ msgstr ""
 "Die folgenden Ordner sehen nach System oder Sensiblen Daten aus.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar machen. Willst du das wirklich?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Suche nach Unterverzeichnissen..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Freigegebene Ordner werden aktualisiert"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u Verzeichnisse durchsucht..."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Suchfehler"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße ignoriert."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Suchwarnung"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Hauptkategorie"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k-Suche kann nicht ausgeführt werden, wenn eD2k nicht verbunden ist"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Kein Schlüsselwort für Kad-Suche – abgebrochen"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Unerwarteter Fehler bei der Kad-Suche:"
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Kad-Suche: weitere Ergebnisse von einem zusätzlichen Peer angefordert."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad-Suche: kein Peer mehr verfügbar, um weitere Ergebnisse abzufragen (Limit erreicht oder noch keine Antworten)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Datei-ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nicht bewertet"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Herunterladen in Kategorie"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s für diese Datei erhalten"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Suche verwandte Dateien (eD2k, lokale Server)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Als bekannte Datei kennzeichnen"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du bist zu einem Server verbunden, den du zu löschen versuchst. Bitte zuerst trennen."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Abgebrochen"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Neu"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Verbindung zu allen gelisteten verschleierten Servern misslungen. Versuche erneut, ohne Verschleierung."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Verbindung zu allen gelisteten verschleierten Servern misslungen. Versuche erneut, ohne Verschleierung."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Fehler beim Verbinden zu allen Servern in der Liste. Ein neuer Durchgang wird gestartet."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Fehler beim Verbinden zu allen Servern in der Liste. Ein neuer Durchgang wird gestartet."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-Netzwerk ist in den Einstellungen deaktiviert - verbinde nicht."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Keine gültigen Server zum Verbinden in der Serverliste gefunden"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Verbunden mit %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Verbindung hergestellt mit %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Schwerer Fehler beim Verbinden. Möglicherweise ist die Internetverbindung getrennt"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Verbindung verloren zu %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) scheint tot zu sein."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) scheint voll zu sein."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatische Verbindungsherstellung zum Server wird in %d Sekunde wiederholt"
 msgstr[1] "Automatische Verbindungsherstellung zum Server wird in %d Sekunden wiederholt"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Verbindung zu %s (%s:%i) fehlgeschlagen."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "FEHLER: Ungültiger Socket bei Prüfung auf Zeitüberschreitung"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Verbindungsversuch zu %s (%s:%i): Zeitüberschreitung."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Verspätetes Ergebnis für DNS-Nachschlag erhalten, wird verworfen."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Lade Datei server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Datei server.met nicht gefunden!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Laden der server.met '%s' fehlgeschlagen, unbekanntes Format aufgetreten."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Konnte Datei server.met nicht öffnen!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met unbrauchbar, unzulässige Versionsmarke gefunden: 0x%x, Größe %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i Server in server.met gefunden"
 msgstr[1] "%i Server in server.met gefunden"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d Server hinzugefügt"
 msgstr[1] "%d Server hinzugefügt"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Fehler: die 'server.met' Datei ist defekt: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "IO-Fehler beim Lesen der 'server.met' Datei: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Server nicht hinzugefügt: [%s:%d] Gibt keinen gültigen Port an."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Server nicht hinzugefügt: Die IP-Adresse [%s:%d] ist gefiltert oder ungültig."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Server nicht hinzugefügt: Server mit gleicher IP:Port [%s:%d] bereits vorhanden."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Server hinzugefügt: Server bei [%s:%d] mit Namen '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Du bist zu einem Server verbunden, den du zu löschen versuchst. Bitte zuerst trennen."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Konnte '%s' nicht öffnen"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Speichern der server.met fehlgeschlagen!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Ungültige URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Download der Serverliste von %s beendet"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Keine Serverlistenadresse in 'addresses.dat' gefunden. Bitte dort zum automatischen Aktualisieren eine gültige Serverlistenadresse eintragen."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Beginne Download der Serverliste von %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "WARNUNG: ungültige URL für das automatische Aktualisieren der Serverliste angegeben: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Keine gültige server.met Auto-Download URL in addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Konnte Serverliste von %s nicht herunterladen"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Lokaler Server ist gefiltert durch IPFilters, verbinde neu zu einem anderen Server!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servername"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresse"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Benutzer"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statisch"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Du möchtest einen Server löschen, mit dem Du verbunden bist. Bitte trenne Dich zuerst. Der Server wurde NICHT gelöscht."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Unbekannter Name)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Wirklich den statischen Server '%s' löschen?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Server (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Verbinde mit Server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Markiere den Server als statisch"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Markiere den Server als nicht statisch"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markiere die Server als statisch"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markiere die Server als nicht statisch"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Entferne Server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Entferne die Server"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Alle Server entfernen"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopiere eD2k-Verweise in die Zwischenablage"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Wiederverbinden mit Server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Wirklich alle Server löschen?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Wirklich den markierten Server löschen?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Wirklich die markierten Server löschen?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "Fehler: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "WARNUNG: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "Server %s (%s) hat den Login abgelehnt (keine ClientID zugewiesen). Trenne."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Neue Benutzer-ID ist %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "WARNUNG: Du hast eine Low-ID zugeordnet bekommen!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tDies rührt vermutlich daher, dass Du Dich hinter einem Router oder einer Firewall befindest."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tMehr Informationen dazu gibt es hier: https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Unbekannte Serverinfo empfangen! - Zu kurz"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d neuen Server empfangen"
 msgstr[1] "%d neue Server empfangen"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Speichern der Serverliste abgeschlossen."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server hat letzten Befehl abgelehnt"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Seltsames Paket vom Server empfangen: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Unbearbeiteter Fehler beim Verarbeiten eines Paketes vom Server: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Kann DNS-Auflöse-Thread nicht erstellen, um zu %s zu verbinden"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Server-IP %s (%s) ist gefiltert. Verbinde nicht."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "verwende Protokollverschleierung."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Verbinde mit·%s·(%s·-·%s:%i)·%s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Konnte DNS-Namen von Server %s nicht auflösen: Kann nicht verbinden!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule-Log"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Server nicht hinzugefügt: Keine IP-Adresse oder Hostname angegeben."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Server nicht hinzugefügt: Ungültiger Server-Port angegeben."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k-Status:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Verbindungstyp:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Verbunden"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia-Status:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Läuft im LAN Modus"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Läuft"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia-Client-ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Verbindungszustand:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - bitte TCP-Port %d in Router oder Firewall öffnen."
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP-Verbindungszustand:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - bitte UDP-Port %d in Router oder Firewall öffnen."
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Firewalled-Status: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Kein Kumpel notwendig - TCP-Port ist geöffnet."
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Kein Kumpel notwendig - UDP-Port ist geöffnet."
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Kein Kumpel"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Verbinde zu Kumpel"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Verbunden mit Kumpel an %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indizierte Quellen:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indizierte Schlüsselwörter:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indizierte Anmerkungen:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indizes geladen:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Benutzer im Schnitt:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Dateien im Schnitt:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Läuft nicht"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Füge Datei %s zu freigegebenen Dateien hinzu"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i bekannte Datei gefunden, %i unbekannt"
 msgstr[1] "%i bekannte Dateien gefunden, %i unbekannt"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "FEHLER: Versuchte %s freizugeben"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Freigegebenes Verzeichnis nicht gefunden, überspringe: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Benutzername"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Upload-Geschwindigkeit"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Verfügbare Teile"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Upload-Status"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Download-Status"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Lokaler Dateiname"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Liste der Freigaben"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Erhaltene Teile"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Verzeichnispfad"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Kommentar/Bewertung abgeben"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Kommentar/Bewertung ändern"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Füge Dateien aus Sammlung zur Übertragungsliste"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopiere Magnet-URL &URI in Zwischenablage"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage (&Source)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopiere eD2k-Verweis in Zwischenablage (Source) (&With Crypt options)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "eD2k-Link in Zwischenablage kopieren (&Hostname)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopiere eD2k-Verweis in Zwischenablage (Hostname) (With &Crypt options)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage (&AICH Info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "eD2k-Verweis in die Zwischenablage kopieren (&AICH-Info + Quelle)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Du brauchst eine hohe ID, um einen gültigen Quellenverweis zu erstellen"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Ferndateiname"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Hochgeladene Daten (Sitzung (Gesamt)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Gesamt-Overhead (Pakete): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Dateianfragen-Overhead (Pakete): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Quellenaustausch-Overhead (Pakete): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Server-Overhead (Pakete): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad-Overhead (Pakete): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "zusätzlicher Datenverkehr durch Verschlüsselung (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Laufende Uploads: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Wartende Uploads: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Erfolgreiche Upload-Sitzungen insgesamt: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Fehlgeschlagene Upload-Sitzungen insgesamt: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Gesamte Upload-Zeit: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Heruntergeladene Daten (Sitzung (Gesamt)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Gefundene Quellen: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Laufende Downloads (Chunks): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Sitzung UL:DL-Rate (Gesamt): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Durchschnittliche Download-Rate (Sitzung): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Durchschnittliche Upload-Rate (Sitzung): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Max. Download-Rate (Sitzung): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Max. Upload-Rate (Sitzung): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Server-Wiederverbindungen: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Zeit seit erster Übertragung: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Verbunden mit Server seit: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktive Verbindungen (geschätzt): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Verbindungslimit erreicht: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Durchschnittliche Verbindungen (geschätzt): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Höchste Verbindungsanzahl (geschätzt): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clients"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Unbekannt: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Gefiltert: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Gebannt: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Gesamt: %i Bekannt: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Funktionierende Server: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Ausgefallene Server: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Gesamt: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Gelöschte Server: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Gefilterte Server: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Benutzer auf funktionierenden Servern: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Dateien auf funktionierenden Servern: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Benutzer insgesamt: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Dateien insgesamt: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Server-Auslastung: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Anzahl freigegebener Dateien: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Durchschnittliche Dateigröße: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Betriebssystem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Nicht empfangen"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktive Verbindungen (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nicht verfügbar"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Niemals"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Befehl '%s' mit pid '%d' wurde mit Status-Code '%d' abgeschlossen."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Führe <str> aus und beende."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Ungültiges IP-Format. Benutze xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Dieser Befehl benötigt ein Argument. Mögliche Argumente sind 'all', ein Dateiname oder eine Zahl.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Verarbeite Datei nach Hash:"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Verarbeite Datei nach Namen:"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Dieser Befehl benötigt ein Argument. Mögliche Argumente: ein Datei-Hash\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Keine gültige Nummer\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Keine gültige Prüfsumme (sollte genau 32 Zeichen lang sein)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7215,7 +7126,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7225,7 +7136,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7233,82 +7144,80 @@ msgstr ""
 "Kein Suchtyp angegeben.\n"
 "Geben Sie 'help search' ein, um mehr Hilfe zu erhalten.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Datei herunterladen: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Anfrage ist mit unbekanntem Fehler gescheitert."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Vorgang erfolgreich."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Anfrage mit folgendem Fehler gescheitert: %s."
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP-Filterung für Clients ist %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "AUS"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "AN"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP-Filterung für Server ist %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Momentane IP-Filterstufe ist %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Bandbreiteneinstellungen: Hoch: %u kB/s, Herunter: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Verbunden mit %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Verbinde"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "firewalled"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7317,7 +7226,7 @@ msgstr ""
 "\n"
 "Download:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7326,7 +7235,7 @@ msgstr ""
 "\n"
 "Upload:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7335,7 +7244,7 @@ msgstr ""
 "\n"
 "Clients in Warteschlange:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7344,46 +7253,46 @@ msgstr ""
 "\n"
 "Quellen insgesamt:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartFile]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Anzahl der Suchergebnisse: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Vergleichsfortschritt: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Fortschritt der Suche nicht verfügbar"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Unbekannte Antwort vom Server empfangen, OpCode = %#x"
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Zeige kurze Statusinformation."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Verbindungszustand, momentane Geschwindigkeit des Hoch-/Herunterladens, usw. zeigen\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Zeige vollständigen Statistikbaum."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7397,11 +7306,11 @@ msgstr ""
 "\n"
 "Beispiel: 'statistics 5' zeigt nur die ersten 5 Versionen für jeden Clienttyp.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "aMule beenden."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7411,35 +7320,35 @@ msgstr ""
 "Dadurch wird auch der Textclient beendet, weil er\n"
 "ohne laufenden Kern (core) nicht verwendbar ist.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Neu laden des angegebenen Objekts."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Liste freigegebener Dateien neu laden."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "IP-Filtertabelle neu laden."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Aktuelle IP-Filtertabelle neu laden."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "IP-Filtertabelle von URL aktualisieren."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Wenn keine URL eingetragen wird, wird die URL aus den Einstellungen benutzt."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Mit Netzwerk verbinden."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7451,35 +7360,35 @@ msgstr ""
 "werden, um nur zu diesem Server zu verbinden. Die IP muss eine dezimale,\n"
 "punktgetrennte IPv4-Adresse, oder ein auflösbarer DNS-Name sein."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Nur mit eD2k verbinden."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Nur mit Kad verbinden."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Vom Netzwerk trennen."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Dies wird von allen momentan verbundenen Netzwerken trennen.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Nur von eD2k trennen."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Nur von Kad trennen."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Sendet einen eD2k- oder Magnet-Verweis an den Kern."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7497,51 +7406,51 @@ msgstr ""
 "\n"
 "Der Magnet-Verweis muss die eD2k-Prüfsumme(\"Hash\") und die Dateigröße beinhalten.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Einstellwert festlegen."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "IP-Filter-Einstellungen festlegen."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Aktiviere IP-Filterung sowohl für Clients als auch für Server."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Deaktiviere IP-Filterung sowohl für Clients als auch für Server."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Ein-/Ausschalten von IP-Filterung für Clients."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Einschalten der IP-Filterung für Clients."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Ausschalten der IP-Filterung für Clients."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Ein-/Ausschalten der IP-Filterung für Server."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Einschalten der IP-Filterung für Server."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Ausschalten der IP-Filterung für Server."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "IP-Filterstufe auswählen."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7549,73 +7458,73 @@ msgstr ""
 "Gültige Filterlevel liegen im Bereich zwischen 0-255, und die\n"
 "Standardeinstellung (Ausgangswert) ist 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Bandbreiteneinstellungen festlegen."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Der Wert für diese Befehle muss in Kilobytes/Sek. angegeben werden.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Upload-Bandbreitenbegrenzung festlegen."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Der Wert für diese Befehle muss in Kilobytes/Sek. angegeben werden.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Download-Bandbreitenbegrenzung festlegen."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Der Wert für diese Befehle muss in Kilobytes/Sek. angegeben werden.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Einstellungswert holen und anzeigen."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "IP-Filter-Einstellungen holen."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hole IP-Filter-Status für Clients und Server."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Hole IP-Filter-Status nur für Clients."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Hole IP-Filter-Status nur für Server."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "IP-Filterstufe holen."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Bandbreiteneinstellungen holen."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Suche ausführen."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7649,44 +7558,44 @@ msgstr ""
 "Beispiel: 'search global linux iso --type Iso --min-size 100M' ergibt\n"
 "Ergebnisse für \"linux iso\" vom Datei-Typ Iso mit mindestens 100 MiB.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Globale Suche ausführen."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Lokale Suche ausführen."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Kad-Suche ausführen."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Zeige die Ergebnisse der letzten Suche an."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Zeige den Fortschritt einer Suche."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Beginne, eine Datei herunterzuladen."
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7694,80 +7603,80 @@ msgstr ""
 "Die Nummer einer Datei aus der letzten Suche muss angegeben sein.\n"
 "Beispiel: 'download 12' beginnt das Herunterladen der Datei Nr. 12 der letzten Suche.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Download anhalten."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Download weiterführen."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Download löschen."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Setze Herunterlade-Priorität."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Setze die Priorität einer herunterladenden Datei auf niedrig, normal, hoch oder Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Setze niedrige Priorität."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Setze normale Priorität."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Setze hohe Priorität."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Setze automatische Priorität."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Warteschlangen/Listen zeigen."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Upload-/Download-Warteschlange, Serverliste, oder Liste freigegebener Dateien zeigen.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Upload-Warteschlange zeigen."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Download-Warteschlange zeigen."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Zeige Log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Serverliste zeigen."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Liste freigegebener Dateien anzeigen."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Setze Log zurück."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Veralteter Befehl, bitte '%s' nutzen."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7776,261 +7685,258 @@ msgstr ""
 "Das ist ein veralteter Befehl und könnte in der Zukunft enfernt werden.\n"
 "Nutze stattdessen '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule Textclient"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Wandle alte AICH-Prüfsummensätze von '%s' um in 64b in '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "WARNUNG: Der Dateiname '%s' ist ungültig und wurde in '%s' umbenannt."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "WARNUNG: Die Datei '%s' gibt es schon, neue Datei in '%s' umbenannt."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Wirklich das Herunterladen aller Dateien in dieser Kategorie abbrechen und alle Dateien darin löschen??"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Bestätigung erforderlich"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Es werden nur 99 Kategorien unterstützt."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Zu viele Kategorien!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Alle anderen"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Ansichtenfilter wählen"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Kategorie bearbeiten"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Kategorie entfernen"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Prüfsummensatz angefordert für unbekannte Datei '%s'"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Wiederaufnahme des Hochladens der Datei '%s'."
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Aussetzen des Hochladens der Datei '%s'."
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Befehlsausführung fehlgeschlagen: Befehl `%s' aufgrund Ereignis `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Download fertiggestellt"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Der vollständige Pfad zur Datei."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Der Name der Datei ohne den Pfadanteil."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Die eD2k-Prüfsumme der Datei."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Die Dateigröße in Byte."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Die Gesamtzeit aktiven Herunterladens."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Neue Chat-Sitzung gestartet."
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Nachrichtensender."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Kein Speicherplatz mehr vorhanden."
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Festplattenpartition."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Fehler beim Fertigstellen der Datei."
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Verarbeite Datei Nummer %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Du willst Part-Prüfsummen erstellen (nur bei Dateien > 9,5 MiB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Datei existiert nicht!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, der aMule-eD2k-Verweis-Ersteller"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Willkommen!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Eingabeparameter"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Datei für Prüfsummenberechnung"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Dieser Datei optionale URLs hinzufügen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Hier die Datei zum Erzeugen des eD2k-Verweises eingeben."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Hier die URL eingeben, die zum eD2k-Verweis hinzugefügt werden soll. Füge am Ende einen / ein, damit aLinkCreator den momentanen Dateinamen übernimmt."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Erstelle Verweis mit Part-Prüfsummen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Hilft, neue und seltene Dateien schneller zu verteilen auf Kosten einer erhöhten Verweisgröße"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4-Dateiprüfsumme"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k-Dateiprüfsumme"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k-Verweis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Speichern"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Öffnen..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Eine Datei zum Erstellen ihres eD2k-Verweises öffnen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopiere erstellten eD2k-Verweis in die Zwischenablage"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Speichern unter..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Speichere erstellten eD2k-Verweis in Datei"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Über aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Datei zum Erstellen des eD2k-Verweises auswählen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Kann die Zwischenablage nicht öffnen."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Derzeit nichts zu Kopieren!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Datei zu dem errechneten eD2k-Verweis auswählen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Konnte Datei nicht öffnen "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Bitte keinen leeren Dateinamen eingeben"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Momentan nichts zu speichern!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8051,167 +7957,159 @@ msgstr ""
 "\n"
 "Vertrieben unter der GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Prüfsummenberechnung..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator arbeitet gerade für dich"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Berechne MD4-Hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Berechne eD2k-Hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Abgebrochen !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Fertig in %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Du hast diese URL bereits eingegeben!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Bitte keine leere URL eingeben"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Konnte '%s' nicht öffnen"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Nicht genügend Speicher zum Berechnen des eD2k-Hashes!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i Tag(e) %i Std. %i Min. %i Sek."
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uT %02uStd %02uMin %02uSek"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uStd %02uMin %02uSek"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02uMin %02uSek"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02uSek"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, die aMule-Onlinestatistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Höchste Downloadrate seit wxCas läuft"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Höchste Downloadrate während wxCas jemals lief"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "System"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Automatische Aktualisierung beenden"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Speichere Onlinestatistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Drucke Onlinestatistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Einstellungen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Über wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Beginne automatische Aktualisierung"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatische Aktualisierung angehalten"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automatische Aktualisierung begonnen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Speichere Statistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule-Onlinestatistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8219,11 +8117,11 @@ msgstr ""
 "Es gab ein Problem beim Drucken.\n"
 "Vielleicht ist der aktuelle Drucker nicht richtig eingestellt?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Drucke"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8241,376 +8139,365 @@ msgstr ""
 "\n"
 "Vertrieben unter der GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh-oh, aMule läuft nicht..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule läuft"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule läuft, aber nicht verbunden"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule verbindet gerade...."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh-oh, aMule-Status ist unbekannt..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " läuft seit "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " ist angehalten!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ist nicht verbunden!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " verbindet sich..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " macht irgendetwas Merkwürdiges, bitte überprüfen!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " ist verbunden mit "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "aus"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " ist auf "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " mit "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Gesamtdownload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Sitzung Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Freigegeben: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " Datei(en), Clients in Warteschlange: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Zeit: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " auf "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Durchschnittliche Systemlast (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Systemlaufzeit: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Verzeichnis mit der Datei amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Hier das Verzeichnis zur Datei amulesig.dat angeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Erzeuge bei jeder Aktualisierung ein Statistikbild"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Hier das Zielverzeichnis zum Erstellen des Statistikbildes angeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Statistikbild periodisch auf einen FTP-Server hochladen"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP-URL"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP-Pfad"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Hier die URL deines FTP-Servers eingeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Hier das Zielverzeichnis für das Statistikbild auf dem FTP-Server angeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Benutzer"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Hier den Benutzernamen zur Anmeldung auf deinem FTP-Server eingeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Hier das Benutzerpasswort zur Anmeldung auf dem FTP-Server eingeben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP-Aktualisierungsintervall in Minuten"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Bestätigen"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Verzeichnis mit deiner Signaturdatei"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Verzeichnis zum Erzeugen des Statistikbildes"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Lädt Vorlage <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Webserver-HTTP-Port"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Benutze UPnP-Port-Weiterleitung für Webserver-Port"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP-Port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Benutze gzip-Kompression"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Vollzugriff-Passwort für den Webserver"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Gast-Passwort für den Webserver"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Erlaube Gastzugriff"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Verweigere Gastzugriff"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Lade/Speichere Webserver-Einstellungen von/zu entferntem aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule-Konfigurationsdateipfad. NICHT DIREKT BENUTZEN!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP-Interpreter deaktivieren (überholt)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Rekompiliere PHP-Seiten bei jeder Anfrage"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Webserver"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "Webclient-Verbindung akzeptiert.\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "FEHLER: Kann Webclientverbindung nicht akzeptieren.\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Anfrage mit folgendem Fehler gescheitert: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Index-Datei nicht gefunden: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sitzung abgelaufen - fordere Anmeldung\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sitzung ok, angemeldet\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sitzung ok, nicht angemeldet\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Keine Sitzung geöffnet - fordere Anmeldung\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sitzung eröffnet - fordere Anmeldung\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Anfrage verarbeiten [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "Verweigere,  `pass`vom Parameterteil der URL zu lesen\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Kein Passwort angegeben, Anmeldung wird nicht erlaubt."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Prüfe Passwort\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Passwort-Prüfsumme ungültig\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Passwort ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Falsches Passwort\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Du hast kein Passwort angegeben. Leeres Passwort ist nicht erlaubt.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Fordere Abmeldung\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Anfrage verarbeiten [umgeleitet]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (benötigt)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Desktopverknüpfung"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "aMule beim Login automatisch starten"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Deinstallieren"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Entferne Benutzerdaten (ED2K Server, Kad Nodes, Part-Dateien)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "aMule Programmdateien (benötigt)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Lege eine aMule Verknüpfung auf den Desktop an."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Starte aMule automatisch wenn sich der aktuelle Benutzer einloggt (benutzerspezifische Einstellung)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Entferne aMule Programmdateien, Startmenü / Desktopverknüpfungen, Autostarteintrag, und Programm Hinzufügen/Entfernen  Eintrag (benötigt)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "%APPDATA%\\aMule für den aktuellen Benutzer endgültig  löschen (aMule.conf, ED2K Serverliste, Kad Nodes, Part-Dateien, IP Filter, Freundeliste). Unmarkiert lassen, um die Einstellungen zu behalten."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8618,7 +8505,7 @@ msgstr ""
 "aMule scheint von $INSTDIR zu laufen.\r\n"
 "Bitte aMule (und aMuleD / aMulgeGUI) schließen und erneut versuchen."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8626,11 +8513,11 @@ msgstr ""
 "Der aMule Service (amuled.exe) scheint von $INSTDIR zu laufen.\r\n"
 "Bitte stoppen und erneut versuchen."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Entferne vorherige aMule installation von $0..."
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8638,11 +8525,11 @@ msgstr ""
 "Konnte die vorherige aMule Installation von $0 nicht entfernen.\r\n"
 "Bitte beende alle laufenden aMule Prozesse und versuche es noch einmal, oder entferne die vorherige Version manuell."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut ausführen."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Εμφάνιση aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Τηλεχειρισμός aMule"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Στιγμιότυπο"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "Πελάτης P2P για όλες τις πλατφόρμες βασισμένος στο eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,79 +50,79 @@ msgstr ""
 "Πνευματικά Δικαιώματα (c) 2003-2019 η ομάδα του aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Μέρος του aMule είναι βασισμένο στο  \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Δρομολόγηση Peer-to-peer βασισμένη στην μετρική XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Ιστοσελίδα:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Συζητήσεις:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνηση"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Διαδικασία σύνδεσης στο Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Προσθήκη φίλου"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Πρέπει να βάλετε σωστή IP και θύρα!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Ο προσδιορισμένος κατακερματισμός χρήστη δεν είναι έγκυρος!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -131,49 +131,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Αποτυχία σύνδεσης"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,183 +181,176 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Αποτυχία ανοίγματος %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσετε τον εαυτό σας σαν πηγή για έναν σύνδεσμο eD2k ενώ έχετε χαμηλή προτεραιότητα."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Απέτυχε"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Το κατέβασμα ολοκληρώθηκε"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Οι τοπικές ρυθμίσεις άλλαξαν στις προεπιλεγμένες του συστήματος λόγο μιας αλλαγής παραμέτρων. Sorry!"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "διακομιστής ιστού τρέχει με αριθμό διεργασίας %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Δεν μπόρεσε να προσδέσει τις θύρες στην προσδιορισμένη διεύθυνση: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Η θύρα %u δεν είναι διαθέσιμη. Θα σας αποδωθεί LOWID (χαμηλή προτεραιότητα)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +365,48 @@ msgstr ""
 "\n"
 "Ελέξτε το δίκτυο σας για να βεβαιωθήτε ότι η θύρα είναι ανοιχτή για είσοδο και έξοδο."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Αποτυχία δημιουργίας αρχείου Συνδεδεμένων Υπογραφών του aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Οι επιλεγμένες τοπικές ρυθμίσεις δεν φαίνεται να είναι εγκατεστημένες στο σύστημά σας. (Σημ. Θα προσπαθήσω να τις θέσω ούτως ή άλλως)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Αυτή είναι η πρώτη φορά που τρέχετε το aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Αυτή η έκδοση είναι δοκιμαστική, και αναβαθμίζεται καθημερινά, και\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "δεν δίνουμε εγγύηση ότι δεν θα χαλάσει κάτι, δεν θα κάψει το σπίτι σας,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ή δεν θα σκοτώσει το σκύλο σας. Αλλά πρέπει να είναι ασφαλές στη χρήση\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Περισσότερες πληροφορίες, υποστήριξη και νέες εκδόσεις μπορούν να βρεθούν στην ιστοσελίδα μας,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "στο https://amule-org.github.io, ή στο κανάλι #aMule του IRC στο irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Παρακαλούμε αναφέρετε σφάλματα του προγράμματος στο https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,225 +414,221 @@ msgstr ""
 "Ο δικτυακός κατάλογος των ηλεκτρονικών αρχείων υπογραφών που προσδιορίσατε είναι ΑΚΥΡΟΣ!\n"
 "Οι ηλεκτρονικές υπογραφές θα ΑΠΕΝΕΡΓΟΠΟΙΗΘΟΥΝ μέχρι να το φτιάξετε στις προτιμήσεις."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Η εκχώρηση χώρου για το αρχείο '%s' απέτυχε: '%s'"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ΣΦΑΛΜΑ: το αρχείο καταγραφής δεν μπορεί να ανοίξει"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο καταγραφών είναι άδειο. Κάτι δεν πάει καλά."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Το αρχείο καταγραφών επαναφέρθηκε στην αρχική κατάσταση"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Μήνυμα Διακομιστή: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Αποτυχία κατεβάσματος της λίστας κόμβων."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Αποτυχία ανοίγματος του κατεβασμένου αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Φθαρμένο αρχείο ελέγχου έκδοσης"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Χρησιμοποιείται μία ξεπερασμένη έκδοση του aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Η παρούσα έκδοση του aMule είναι %i.%i.%i και η τελευταία %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Η έκδοση του aMuled είναι ξεπερασμένη: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Αυτό το αντίγραφο του aMule είναι σύγχρονο. "
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Αποτυχία κατεβάσματος του αρχείου ελέγχου έκδοσης"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Χρήστες: %s | Αρχεία: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Χρήστες: E: %s K: %s | Αρχεία: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Δεν έχουν επιλεχθεί δίκτυα"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "με Χαμηλή Προτεραιότητα"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "με Υψηλή Προτεραιότητα"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Σύνδεση με το %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Διαδικασία σύνδεσης με %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Αποσυνδεδεμένο από το eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Το Kad ξεκίνησε."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Το Kad είναι σταματημένο."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Συνδεδεμένο στο Kad (ΟΚ)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Το δίκτυο Kad δεν μπορεί να χρησιμοποιηθεί αν η θύρα UDP είναι απενεργοποιημένη στις προτιμήσεις. Δεν έγινε εκκίνηση."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Το δίκτυο Kad είναι απενεργοποιημένο από τις προτιμήσεις. Δεν έγινε σύνδεση."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ΣΦΑΛΜΑ: ο δαίμονας του aMule δεν μπορεί να χρησιμοποιηθεί όταν οι εξωτερικές συνδέσεις είναι απενεργοποιημένες. Για να ενεργοποιήσετε τις εξωτερικές συνδέσεις, χρησιμοποιήστε είτε ένα κανονικό aMule, ξεκινήστε το amuled με την παράμετρο --ec-config ή θέστε το κλειδί \"AcceptExternalConnections\" στην τιμή 1 στο αρχείο ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ΣΦΑΛΜΑ: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -650,195 +638,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Έλεγχος του aMule εξ' αποστασεως"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Μοιραίο σφάλμα: Αποτυχία δημιουργίας χρονομέτρου"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Η σύνδεση χάθηκε"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Επιβεβαίωση κατά την έξοδο"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -847,730 +828,707 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Μοιραίο σφάλμα: Αποτυχία δημιουργίας χρονομέτρου"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "Προσπάθεια ανάκτηση πληροφοριών αρχείου..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Συνδέοντας"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Η απόπειρα σύνδεσης στο %s (%s:%i) ξεπέρασε το χρονικό όριο."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Σύνδεση στο δίκτυο."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Όλα"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Δεν υπάρχει"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Πλασματική έκδοση eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Πλασματικό eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Πλασματικό eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (βασισμένο στο eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Παρατσούκλι: %s Ταυτότητα: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Ζητήθηκε: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Στατιστικές αρχείων για αυτή τη συνεδρία: Δεκτό %d από %d αίτηση, %s μεταφέρθηκε\n"
 msgstr[1] "Στατιστικές αρχείων για αυτή τη συνεδρία: Δεκτά %d από %d αίτησεις, %s μεταφέρθηκαν\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Στατιστικές αρχείων για όλες τις συνεδρίες: Δεκτό %d από %d αίτηση, %s μεταφέρθηκε\n"
 msgstr[1] "Στατιστικές αρχείων για όλες τις συνεδρίες: Δεκτά %d από %d αίτησεις, %s μεταφέρθηκαν\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Αναζητήθηκε άγνωστο αρχείο"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Φιλτραρίστηκε το μήνυμα από τον '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Καινούριο μήνυμα από τον '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Ο χρήστης %s (%u) ζήτησε λίστα κοινόχρηστων αρχείων του κατάλογου %s -> Απορρίφθηκε"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: το αρχείο known.met δεν μπορεί να ανοιχτεί."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: η λίστα των γνωστών αρχείων είναι φθαρμένη, περιέχει άκυρη επικεφαλίδα."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Σφάλμα εισόδου εξόδου κατά την ανάγνωση του αρχείου known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Σφάλμα κατά το αποθήκευση του αρχείου known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Κατηγορία"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Καινούρια κατηγορία"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Επιλέξτε έναν κατάλογο για τα εισερχόμενα αρχεία"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Πρέπει να προσδιορίσετε ένα όνομα για την κατηγορία!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Πρέπει να προσδιορίσετε μία διαδρομή για την κατηγορία!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Αποτυχία δημιουργίας καταλόγου εισερχομένων για την κατηγορία. Παρακαλώ προσδιορίστε μία έγκυρη διαδρομή!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Ξεκίνησε συνεδρία συνομιλίας: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Συνδεδεμένος σε πελάτη ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Συνδέεται σε πελάτη ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Αποτυχία σύνδεσης σε πελάτη/η σύνδεση χάθηκε ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Κλείσιμο καρτέλας"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Κλείσιμο όλων των καρτελών"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Κλείσιμο των άλλων καρτελών"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Προσθήκη στους φίλους"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Φορτώθηκε το αρχείο πιστώσεων, %u πελάτη είναι γνωστός"
 msgstr[1] "Φορτώθηκε το αρχείο πιστώσεων, %u πελάτες είναι γνωστοί"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] "- Εξέπνευσε η προθεσμία πιστώσεων για %u πελάτη!"
 msgstr[1] "- Εξέπνευσε η προθεσμία πιστώσεων για %u πελάτες!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Δεν βρέθηκε το αρχείο 'cryptkey.dat' και γι αυτό το δημιουργώ"
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Πληροφορίες πελάτη"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Κακή ποιότητα σύνδεσης (LowID)"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Καλή ποιότητα σύνδεσης (HighID)"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Ενεργό"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Υποστηρίζεται"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Δεν υποστηρίζεται"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Απενεργοποιημένο"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Συνδεδεμένο"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Αποσυνδεδεμένο"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Δεν ολοκληρώθηκε"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Κακό παιδί"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Επιβεβαιώθηκε - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Δεν υπάρχει"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Ο χρήστης %s (%u) ζήτησε τη λίστα με τα κοινόχρηστα αρχεία -> Έγινε δεκτό"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Ο χρήστης %s (%u) ζήτησε τη λίστα με τα κοινόχρηστα αρχεία -> Απορρίφθηκε"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Ο χρήστης %s (%u) ζήτησε τη λίστα με τους κοινόχρηστους καταλόγους -> Έγινε δεκτό"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Ο χρήστης %s (%u) ζήτησε τη λίστα με τους κοινόχρηστους καταλόγους -> Απορρίφθηκε"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Ο χρήστης %s (%u) ζήτησε λίστα κοινόχρηστων αρχεία του κατάλογου %s -> Έγινε δεκτό"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Ο χρήστης %s (%u) ζήτησε λίστα κοινόχρηστων αρχείων του κατάλογου %s -> Απορρίφθηκε"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Ο χρήστης %s (%u) μοιράζεται τον κατάλογο %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Ο χρήστης %s (%u) έστειλε κοινόχρηστους καταλόγους χωρίς να ζητηθούν."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Ο χρήσης %s (%u) έστειλε λίστα κοινόχρηστων αρχείων για κατάλογο %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Ο χρήστης %s (%u) τελείωσε την αποστολή της λίστας κοινόχρηστων αρχείων"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Ο χρήστης %s (%u) έστειλε αχρείαστη λίστα κοινόχρηστων αρχείων"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Ο χρήστης %s (%u) αρνήθηκε πρόσβαση στη λίστα κοινόχρηστψων καταλόγων/αρχείων"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Σχόλια αρχείου"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Όνομα αρχείου"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Σχόλιο"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Δεν μπορεί να γίνει αναζήτηση στο Kad αν το Kad δεν τρέχει"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Κανένα σχόλιο"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u σχόλιο"
 msgstr[1] "%u σχόλια"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Αποτυχία κατεβάσματος της λίστας διακομιστών από το %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Αυτόματη [Χαμηλή]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Αυτόματη [Κανονική]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Αυτόματη [Υψηλή]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Υψηλή"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Πολύ υψηλή"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Επίσημη έκδοση"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Ζητώντας"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Σύνδεση μέσω διακομιστή"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Ουρά γεμάτη"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Εν αναμονή"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Κατεβαίνει"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Λαμβάνοντας το σύνολο των τεμαχίων"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Δεν υπάρχουν χρειαζούμενα κομμάτια"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Δεν μπορεί να γίνει σύνδεση από LowID σε LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Υπερβολικά πολλές συνδέσεις"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Σύνδεση μέσω Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Υπερβολικά πολλές συνδέσεις Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Απαγορευμένοι"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Σφάλμα σύνδεσης"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Η απομακρυσμένη ουρά είναι γεμάτη"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Παλιό MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Νέο MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Συμβατό με eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Τοπικός διακομιστής"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Ανταλλαγή πηγών"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Παθητικό"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Σύνδεσμος"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Πηγαίος σπόρος"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Αποτέλεσμα Αναζήτησης"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ολοκληρώθηκαν"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Σε εξέλιξη"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ΣΦΑΛΜΑ: Δεν υπάρχει χώρος στο δίσκο"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ΣΦΑΛΜΑ: Δεν βρέθηκε το Partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ΣΦΑΛΜΑ: σφάλμα εισόδου/εξόδου!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ΣΦΑΛΜΑ: Απέτυχε!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Εν αναμονή"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Ήδη κατεβαίνει"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Άγνωστος ή κακός τύπος προσωρινού αρχείου."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Μέρος"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Ταχύτητα"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Πρόοδος"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Αρ. πηγών"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Κατάσταση"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Υπόλοιπος Χρόνος"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Τελευταία φορά που εμφανίστηκε ολοκληρωμένο"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Τελευταία λήψη"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το συγκεκριμένο αρχείο;"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τα συγκεκριμένα αρχεία;"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1579,109 +1537,106 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Αυτόματη"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Σταμάτημα"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Παύση"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Συνέχιση"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Κ&αθάρισμα των ολοκληρωμένων"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Εναλλαγή κάθε A4AF μέχρι αυτό το αρχείο τώρα"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Εναλλαγή κάθε A4AF μέχρι αυτό το αρχείο (αυτόματα)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Εναλλαγή κάθε A4AF μέχρι κάθε άλλο αρχείο (αυτόματα)"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Εκτεταμένες Προτιμήσεις"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Προεπισκόπιση"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Εμφάνιση &λεπτομερειών για το αρχείο"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Εμφάνιση όλων των σχολίων"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Αντιγραφή μαγνητικής URI στο πρόχειρο"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Αντιγραφή των συμβουλών στην πρόχειρη μνήμη"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "μη ανάθεση"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Ανάθεση σε κατηγορία"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Δώστε νέο όνομα γι αυτό το αρχείο:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Μετονομασία αρχείου"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Κατεβασμένα (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1690,353 +1645,352 @@ msgstr ""
 "Για να μην εμφανίζεται αυτή η προειδοποίηση σε κάθε προεπισκόπιση,\n"
 "θέστε το προτιμητέο πρόγραμμα βίντεο στις ρυθμίσεις (ο %s είναι προεπιλεγμένος)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Προεπισκόπηση αρχείου"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία εκτέλεσης του εξωτερικού προγράμματος εμφάνισης πολυμέσων! Εντολή: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Φόρτωση του αρχείου διακομιστών: %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Φόρτωση δεδομένων από το παλιό αρχείο κατεβάσματος (%u από %u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ΣΦΑΛΜΑ: Αποτυχία φορτώματος του αντιγράφου ασφαλείας. Ψάξτε στο https://github.com/amule-org/amule/discussions για λύσεις ανάκτησης αρχείων .part.met"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Δεν βρέθηκαν ημιτελή αρχεία"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Βρέθηκε %u ημιτελές αρχείο"
 msgstr[1] "Βρέθηκαν %u ημιτελή αρχεία"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Το σύστημα αρχείων του προσωρινού καταλόγου δεν μπορεί να διαχειριστεί μεγάλα αρχεία."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Το σύστημα αρχείων του καταλόγου εισερχομένων δεν μπορεί να διαχειριστεί μεγάλα αρχεία."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Κατεβάζοντας %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Προσπαθείτε ήδη να κατεβάσετε αυτό το αρχείο '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Το αρχείο '%s' υπάρχει ήδη"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Το αρχείο '%s' υπάρχει ήδη"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Δεν γίνεται η μετατροπή του μαγνητικού συνδέσμου σε σύνδεσμο eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Άγνωστο πρωτόκολλο του συνδέσμου: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Άκυρος σύνδεσμος eD2k! ΣΦΑΛΜΑ: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν στο αρχείο ρυθμίσεων"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ΣΦΑΛΜΑ: δεν μπόρεσα να αποδεχτώ νέα εξωτερική σύνδεση"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Οι εξωτερικές συνδέσεις απενεργοποιήθηκαν λόγω καινού κωδικού στις προτιμήσεις!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Συνδεόμενος πελάτης: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Άγνωστη έκδοση"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Λανθασμένη ταυτότητα έκδοσης EC, ίσως υπάρχει δυαδική ασυμβατότητα. Χρησιμοποιήστε πυρήνα και απομακρυσμένο μέρος από το ίδιο στιγμιότυπο."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Δεν μπορείτε να συνδεθείτε σε μια επίσημη έκδοση από μια αναπτυσσόμενη (SVN) έκδοση! *ουφ* αποφευχθεί πιθανό κρέμασμα"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Λείπει η ετικέτα με την έκδοση του πρωτοκόλλου."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Η πιστοποίηση απέτυχε."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Άκυρη αίτηση, πρέπει πρώτα να πιστοποιηθήτε."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Η πρόσβαση επικυρώθηκε."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Απόπειρα μη εξουσιοδοτημένης πρόσβασης. Η σύνδεση έκλεισε."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Η απομακρυσμένη εντολή ημιτελούς αρχείου απέτυχε: Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ο κατακερματισμός αρχείου δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Όπα! Σφάλμα επεξεργασίας OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Ο διακομιστής δεν προστέθηκε"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "χρειάζεται να οριστεί ο διακομιστής που να διαγραφεί"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "Το eD2k είναι απενεργοποιημένο στις ρυθμίσεις."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Η αναζήτηση από τον ιστό από απομακρυσμένο περιβάλλον δεν έχει κανένα νόημα."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Αναζήτηση δια εξέλιξη. Επανάκτηση αποτελεσμάτων σε λίγο!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Δεν υπάρχουν σημεία για γράφημα."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Ο πελάτης σας δεν έχει ρυθμιστεί με τόση λεπτομέρεια"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Εξωτερική σύνδεση: ζητήθηκε κλείσιμο"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Ήδη η λειτουργία είναι σε φάση διακοπής"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Εξωτερική Σύνδεση: προστίθεται ο σύνδεσμος '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Το αρχείο δεν βρέθηκε."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Άκυρο όνομα αρχείου."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Αποτυχία μετονομασίας αρχείου."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Το Kad έχει απενεργοποιηθεί στις προτιμήσεις."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Ήδη συνδεδεμένο στο eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Συνδέεται στο eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Ήδη συνδεδεμένο στο Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Διαδικασία σύνδεσης στο Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Αποσυνδεδεμένο από το eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Αποσυνδεδεμένο από το Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Εξωτερική σύνδεση: λήφθηκε άκυρος opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Εσφαλμένος κωδικός (λάθος έκδοση πρωτοκόλλου;)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Άγνωστη επέκταση  '%s' για την εντολή '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Άγνωστη εντολή '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Αυτή η εντολή δεν μπορεί να έχει όρισμα.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2052,7 +2006,7 @@ msgstr ""
 "\n"
 "Αυτή η εντολή πρέπει να έχει όρισμα.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2060,7 +2014,7 @@ msgstr ""
 "\n"
 "Αυτή η εντολή είναι ημιτελής, πρέπει να χρησιμοποιήσετε μία από τις παρακάτω επεκτάσεις.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2068,11 +2022,11 @@ msgstr ""
 "\n"
 "Διαθέσιμες επεκτάσεις:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Διαθέσιμες εντολές:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2083,17 +2037,17 @@ msgstr ""
 "Όλες οι εντολές δεν διακρίνουν πεζά από κεφαλαία.\n"
 "Γράψτε '%s <command>' για να πάρετε λεπτομερείς πληροφορίες πάνω στην <εντολή>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Κλείσιμο της εφαρμογής."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Εμφάνιση βοήθειας."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2101,7 +2055,7 @@ msgstr ""
 "Για βοήθεια πάνω σε μία εντολή, γράψτε 'help <εντολή>'.\n"
 "Για την πλήρη λίστα εντολών γράψτε 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2112,46 +2066,46 @@ msgstr ""
 "Χρησιμοποιήστε '%s' για την λίστα εντολών\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Συντακτικό λάθος!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Σφάλμα κατά την επεξεργασία της εντολής - δεν έπρεπε να συμβεί ποτέ! Παρακαλείστε να αναφέρετε σφάλμα προγράμματος\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Αυτή η εντολή πρέπει να έχει παράμετρο."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Άκυρο όρισμα."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Αυτή είναι ημιτελής εντολή."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Για περισσότερη βοήθεια, γράψτε '%s'.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Αυτό είναι %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Αυτό είναι %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2159,7 +2113,7 @@ msgstr ""
 "\n"
 " Δημιουργία πελάτη...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2168,7 +2122,7 @@ msgstr ""
 "\n"
 "Όλα μια χαρά, έξοδος %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2181,331 +2135,326 @@ msgstr ""
 "είτε στην γραμμή εντολών είτε προσδιορίζοντας κάποιο όταν ζητηθεί.\n"
 "Έξοδος...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Δείξε αυτό το αρχείο βοήθειας."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Υπολογιστής όπου το aMule τρέχει (προεπιλεγμένος: ο τοπικός υπολογιστής)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Η Θύρα του aMule για Εξωτερική σύνδεση. (προεπιλεγμένη: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Κωδικός εξωτερικής σύνδεσης"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Διάβασε το αρχείο διευθετήσεων"
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Μην στέλνεις μηνύματα στην stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Να είσαι αναλυτικός - δείξε και να μηνύματα αποσφαλμάτωσης"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Θέσε τις τοπικές ρυθμίσεις"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Εγγραφή των παραμέτρων της γραμμής εντολών σε αρχείο."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Δημιουργεί ένα αρχείο παραμέτρων βασισμένο στο αρχείο παραμέτρων του aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Τύπωσε την έκδοση του προγράμματος."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Λεπτομέρειες αρχείου"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% ολοκληρώθηκαν"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Καλώς ήρθατε (Καλώς σας βρήκαμε)"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Συνδεδεμένος στον φιλαράκο"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Κατάσταση σύνδεσης:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Δίκτυα"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Πρότυπη θύρα TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Εκτεταμένη θύρα UDP (Kad / καθολική αναζήτηση)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ενεργοποίηση UPnP για προώθηση της θύρας του δρομολογητή"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Εκκινητήρας"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Επιλογή"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Αποτυχία ανάγνωσης του αρχείου της λίστας φίλων 'emfriends.met' "
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Αποτυχία γραψίματος στο αρχείο της λίστας φίλων 'emfriends.met' "
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Φίλοι"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Εμφάνιση &Λεπτομερειών"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Πρόσθεσε έναν φίλο"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Αφαίρεσε έναν φίλο"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Στείλε &Μήνυμα"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Παρουσίαση αρχείων"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Εγκαθίδρυσε φιλική θυρίδα"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Σίγουρα θέλετε να διαγράψετε τον επιλεγμένο φίλο;"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Σίγουρα θέλετε να διαγράψετε τους επιλεγμένους φίλους;"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2513,11 +2462,11 @@ msgstr ""
 "Δεν επιτρέπεται να θέσεις μόνο πανω από μία φιλική θυρίδα. \n"
 " Γι αυτό μόνο μία ανατέθηκε."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Πολλαπλή επιλογή"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2526,210 +2475,209 @@ msgstr ""
 "Δεν επιτρέπεται να θέσεις μόνο πανω από μία φιλική θυρίδα. \n"
 " Γι αυτό μόνο μία ανατέθηκε."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Αποστολή μηνύματος στον χρήστη"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Μήνυμα προς αποστολή:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Αφαίρεση από του φίλους"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Αποστολή μηνύματος"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Εναλλαγή σε αυτό το αρχείο"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Αίτηση ενός άλλου αρχείου"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Ανεβάσματα σε αναμονή: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "Εν αναμονή"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Ανέβασμα"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Κανείς"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Όχι"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ναι"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Μεταφόρτωση..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Έχει κατεβεί"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Κατεβασμένα (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Αποτυχία κατεβάσματος της λίστας διακομιστών από το %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Αποτυχία κατεβάσματος της λίστας διακομιστών από το %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Φόρτωση των φίλτρων IP 'ipfilter.dat' και 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Αποτυχία φόρτωσης του αρχείου ipfilter.dat '%s', εκδηλώθηκε άγνωστο σφάλμα."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Αποτυχία φόρτωσης του αρχείου ipfilter.dat '%s', δεν μπόρεσε να ανοίξει το αρχείο."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Φορτώθηκε διάστημα IP %u από '%s'."
 msgstr[1] "Φορτώθηκαν διαστήματα IP %u από '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u παραμορφωμένη γραμμή απορρίφθηκε."
 msgstr[1] "%u παραμορφωμένες γραμμές απορρίφθηκαν."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2737,879 +2685,847 @@ msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Κόμβοι (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Άκυρη διεύθυνση ip για εκκινητήρα"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Άκυρη θύρα για εκκινητήρα"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Παρακαλώ συμπληρώστε όλα τα απαιτούμενα πεδία"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Μήνυμα"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Είστε σίγουροι ότι θέλετε να κατεβάσετε ένα καινούριο αρχείο nodes.dat;\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Κάτι τέτοιο θα αφαιρέσει του τρέχοντες κόμβους και θα ξαναξεκινήσει την σύνδεση Kademlia"
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Συνέχιση;"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: O κωδικός αναζήτησης είναι πολύ μικρός"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Ο κωδικός αναζήτησης υπάρχει ήδη στη λίστα αναζητήσεων: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Ανάγνωση %u επαφής Kad"
 msgstr[1] "Ανάγνωση %u επαφών Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Μόνο %d γνωριμία Kad είναι διαθέσιμο. το αρχείο nodes.dat δεν γράφτηκε"
 msgstr[1] "Μόνο %d γνωριμίες Kad είναι διαθέσιμες. το αρχείο nodes.dat δεν γράφτηκε"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Γράψιμο %d επαφής Kad"
 msgstr[1] "Γράψιμο %d επαφών Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Δίκτυο Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Όνομα αρχείου"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Μέγεθος αρχείου"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Λόγος μοιράσματος"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Έγινε δεκτό"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: η λίστα των γνωστών αρχείων είναι φθαρμένη, περιέχει άκυρη επικεφαλίδα."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Άγνωστη έκδοση"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Κατακερματισμός"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Ολοκληρώνεται"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Ολοκληρωμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Σταματημένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Εσφαλμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Εν αναμονή"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Πρέπει να προσδιορίσετε ένα μη κενό κωδικό."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Άκυρο κωδικό, δεν είναι κατακερματισμός τύπου MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Αποτυχία σύνδεσης"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Η εξωτερική σύνδεση απέτυχε. Κενή ανταπόκριση."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Εξωτερική Σύνδεση: Κακή ανταπόκριση από τον διακομιστή. Η σύνδεση τερματίστηκε."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Επιτυχία! Έγινε σύνδεση με το aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Επιτυχία! Έγινε σύνδεση"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Εξωτερική Σύνδεση: Η πρόσβαση απορρίφθηκε επειδή"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ΣΦΑΛΜΑ: Δεν μπορώ να ακούσω την θύρα TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ΣΦΑΛΜΑ:"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Αποκοπή"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Καθαρισμός"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Συνδεδεμένο"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Συνδεδεμένο"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Συνδεδεμένο στο Kad (με προστατευτικό τοίχο)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "Διεύθυνση διακομιστή:"
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Διεύθυνση διακομιστή:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Συνδεδεμένο τώρα"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Θύρα TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Θύρα TCP: Δεν είναι έτοιμη"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Θύρα UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Θύρα UDP: Δεν είναι έτοιμη"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Πληροφορίες πελάτη"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Όριο ανεβάσματος"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Όριο κατεβάσματος"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Εμφάνιση aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Κρύψιμο aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Έξοδος"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Απεριόριστο"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Μενού για το Tray του aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Όρια ταχύτητας:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Όριο Ανεβάσματος: Κανένα"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Όριο Ανεβάσματος: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Όριο Κατεβάσματος: Κανένα"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Όριο Κατεβάσματος: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Ταχύτητα κατεβάσματος: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Ταχύτητα ανεβάσματος: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Παρατσούκλι: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Δεν επιλέχτηκε παρατσούκλι!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Ταυτότητα πελάτη:"
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Όνομα διακομιστή:"
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Διεύθυνση διακομιστή:"
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Δεν είναι συνδεδεμένο"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Συνδεδεμένη Υπογραφή: Ενεργοποιημένη"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Συνδεδεμένη Υπογραφή: Απενεργοποιημένη"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Χρόνος λειτουργίας: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Κοινόχρηστα αρχεία: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Πελάτες στην αναμονή: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Συνολικό Κατέβασμα: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Συνολικό Ανέβασμα: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Προσθήκη ενός μαγνητικού συνδέσμου ή συνδέσμου eD2k στον πυρήνα."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Προσθήκη στους φίλους"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Πατήστε εδώ για να προσθέσετε τον σύνδεσμο eD2k στον διαχειριστή κειμένου της λίστας αναμονής κατεβασμάτων."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Τα γεγονότα εμφανίζονται εδώ. Για μια πλήρη λίστα γεγονότων, αναφερθείτε στο αρχείο καταγραφής στην καρτέλα διακομιστών. "
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Φόρτωμα σε εξέλιξη ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Αριθμός χρηστών στον διακομιστή στον οποίο είστε συνδεδεμένος ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Χρήστες: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Χρήστες συνδεδεμένοι στην τρέχων διακομιστή και μία εκτίμηση του συνολικού αριθμού χρηστών."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Πάνω: 0.0 | Κάτω: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Τρέχωντες μέσοι ρυθμοί ανεβάσματος και κατεβάσματος. Όταν ενεργοποιηθεί, οι αριθμοί σε αγκύλες δείχνουν την επιβάρυνση λόγω της επικοινωνίας των πελατών."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Εμφανίζει το καθεστώς σύνδεσης καθώς και τις ενεργές μεταφορές. Τα κόκκινα βέλη δείχνουν ότι είστε συνδεδεμένοι, τα κίτρινα ότι έχετε χαμηλή ποιότητα (LowID, firewalled) και τα πράσινα ότι έχετε υψηλή ποιότητα (HighID, ο ιδανικός τύπος σύνδεσης)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Δεν είναι συνδεδεμένο ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Διακομιστές συνδεδεμένοι αυτή τη στιγμή."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Όνομα:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Τοπικό"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Καθολικό"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Εκτεταμένες παράμετροι"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Διήθηση"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Τύπος αρχείου"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Οτιδήποτε"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Αρχεία"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Ήχος"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Είδωλα CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Φωτογραφίες"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Προγράμματα"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Κείμενα"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Βίντεο"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Κατάληξη"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Ελάχιστο μέγεθος"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Μέγιστο αρχείο"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Φίλτρο:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Αποτελέσματα φιλτραρίσματος"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Αντιστροφή αποτελεσμάτων"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Απόκρυψη γνωστών τύπων"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Εκκίνηση"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Περισσότερα"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Σταμάτημα"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Κατέβασμα"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Επαναφορά πεδίων"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Αποτελέσματα"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Καθάρισμα των ολοκληρωμένων κατεβασμάτων"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Γενικά"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Πλήρες Όνομα :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Αρχείο met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Κατακερματισμός :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Μέγεθος αρχείου :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Μεταφορά"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Κατάσταση ημιτελούς αρχείου:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Τελευταία φορά που εμφανίστηκε ολόκληρο :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Βρέθηκαν πηγές :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Ενεργές πηγές :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Απαρίθμηση τμημάτων αρχείου:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Διαθέσιμα:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Ενεργός χρόνος κατεβάσματος:"
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Μεταφέρθηκαν :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Ολοκληρωμένος όγκος :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.):"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Χάθηκε λόγο φθοράς :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Κέρδος σε μέγεθος λόγω συμπίεσης :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Πακέτα που σώθηκαν από την Ε.Δ.Φ. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Κοινοκτημοσύνη"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Αιτήσεις"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Δεκτές αιτήσεις"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Όγκος δεδομένων που μεταφέρθηκαν"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Λόγος συμμετοχής"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Ολοκληρωμένες πηγές"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Ανέβασμα: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Μη αποτιμημένο"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Τίτλος:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Ονόματα αρχείων"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Ανάληψη ελέγχου"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Καθάρισμα"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Εφαρμογή"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Αρχείο σχολίων/Αξιολόγησης (το κείμενο θα είναι ορατό σε όλους του χρήστες)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3617,1275 +3533,1271 @@ msgstr ""
 "Για ταινίες μπορείτε να πείτε το μέγεθος, το σενάριο, τη γλωσσα ...\n"
 "και αν είναι ψεύτικη, μπορείτε να το πείτε στους άλλους χρήστες του aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Ποιότητα αρχείου"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Μη αποτιμημένο"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Άκυρο / Φθαρμένο / Πλαστό"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Φτωχή"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Ανεκτή"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Καλή"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Εξαιρετική"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Βαθμολογήστε την αξία του αρχείου ή ενημερώστε τους χρήστες αν το αρχείο είναι έγκυρο ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Αποσυνδεδεμένο από το Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Κατεβαίνει, παρακαλώ περιμένετε ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Άγνωστο μέγεθος"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Απαιτούμενες πληροφορίες"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Διεύθυνση IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Θύρα :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Πρόσθετες πληροφορίες"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Όνομα χρήστη :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Ταχύτητα ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Δέντρο στατιστικών"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Τεμάχιο χρήστη:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Λογισμικό πελάτη:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Αριθμός έκδοσης πελάτη:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Διεύθυνση IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Αριθμός Χρήστη:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Διεύθυνση διακομιστή:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Όνομα διακομιστή:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Συσκότιση:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Μεταφορές προς τον πελάτη"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Τρέχουσα αίτηση:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Μέσος ρυθμός ανεβάσματος:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Μέσος ρυθμός κατεβάσματος:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Ανέβηκαν (συνεδρία):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Κατέβηκαν (συνεδρία):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Ανέβηκαν (συνολικά):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Κατέβηκαν (συνολικά):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Σκορ"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Τροποποιητής Ανεβοκατεβάσματος:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Ασφαλής ταυτότητα:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Εν αναμονή"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Βαθμολογία αναμονής:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Παρατσούκλι"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - το μουλάρι όλων των πλατφόρμων"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Αυτό είναι το όνομα που οι άλλοι χρήστες θα βλέπουν όταν είναι συνδεδεμένοι με εσάς."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Γλώσσα:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Ο χρόνος πριν εμφανιστεί το επεξηγηματικό κείμενο."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Αυτό ορίζει την γλώσσα που χρησιμοποιείται στο γραφικό περιβάλλον."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Αν ενεργοποιηθεί, το aMule θα ελέγχει αν υπάρχει νέα έκδοση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Εκκίνηση σαν ελαχιστοποιημένο"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Αν ενεργοποιηθεί, το aMule θα ξεκινήσει ελαχιστοποιημένο."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Επιβεβαίωση κατά την έξοδο"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Κάνει το aMule να επιβεβαιώνει πριν την έξοδο."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Ενεργοποιεί την εικόνα της μπάρας"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Αυτό ενεργοποιεί/απενεργοποιεί την εικόνα της μπάρας του συστήματος."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Ελαχιστοποίηση στην μπάρα"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Αν ενεργοποιηθεί το aMule θα ελαχιστοποιηθεί στην μπάρα του συστήματος αντί για την μπάρα εφαρμογών"
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Χρόνος καθυστέρησης επεξηγήσεων:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "δεπτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Επιλογή περιηγητή ιστοσελίδων"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Αν είναι δυνατόν, άνοιξε τη σελίδα σε καινούρια καρτέλα"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Άνοιξε την ιστοσελίδα σε καινούρια καρτέλα αντί σε καινούριο παράθυρο αν αυτό είναι εφικτό"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Πρόγραμμα προβολής βίντεο"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Ευρυζωνικά όρια"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Ανέβασμα"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Ανάθεση θυρίδας"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Θύρες"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Αυτή είναι η βασική θύρα eD2k και δεν μπορεί να απενεργοποιηθεί."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Θύρα UDP για αιτήσεις εξυπηρετητή (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Αυτή η θύρα UDP χρησιμοποιήται για εκτεταμένες αιτήσεις eD2k και για το δίκτυο Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Θύρα UPnP TCP (Προαιρετική):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο αρχείο:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Αυτόματη σύνδεση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Επανασύνδεση σε περίπτωση διακοπής"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Αφαίρεση του νεκρού διακομιστή ύστερα από"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "προσπάθειες"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Λίστα"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε διακομιστή"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Ενημέρωση της λίστας διακομιστών κατά τη σύνδεση σε πελάτη"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Χρήση συστήματος προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Χρήση έξυπνου ελέγχου LowID κατά τη σύνδεση"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Ασφαλής σύνδεση"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Αυτόματη σύνδεση μόνο με τους διακομιστές της στατικής λίστας"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Υψηλή προτεραιότητα στους διακομιστές που προστέθηκαν με το χέρι"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Προσθήκη αρχείων προς κατέβασμα κατά τη διάρκεια παύσης"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Προσθήκη αρχείων προς κατέβασμα με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Προσπάθησε να κατεβάσεις πρώτα τα αρχικά και τελικά κομμάτια"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Εκκίνηση του επόμενου σταματημένου αρχείου όταν ένα αρχείο ολοκληρωθεί"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Από την ίδια κατηγορία"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Δέσμευση χώρου στο δίσκο για καινούρια αρχεία"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Δεσμεύει χώρο στο δίσκο για καινούρια αρχεία και έτσι μειώνει τον κατακερματισμό"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Σταμάτημα του κατεβάσματος όταν ο ελεύθερος δίσκος φτάσει τα"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Επιλέξτε αυτό αν θέλετε το aMule να ελέγξει τον χώρο στον δίσκο σας"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Γράψτε εδώ των ελάχιστο επιθυμητό χώρο στον δίσκο."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Αποθήκευση 10 πηγών σε σπάνια αρχεία (<20 πηγές)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Ανεβασμένα"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Προσθήκη νέων κοινόχρηστων αρχείων με αυτόματη προτεραιότητα"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Ενεργοποιήση"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Προχωρημένη Ε.Δ.Φ. εμπιστεύεται κάθε κατακερματισμό (δεν συνιστάται)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Δεξί κλικ στην εικόνα του καταλόγου για να γίνουν κοινόχρηστοι οι υποκατάλογοι)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Κάνε τα κρυφά αρχεία κοινόχρηστα"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Χρόνος καθυστέρηση ενημέρωσης : 5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Χρόνος μέσου γραφήματος: 100 λεπτά"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Κλίμακα διαγράμματος συνδέσεων: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Κλιματα του γραφήματος εισερχομένων:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Κλιμακα του γραφήματος εξερχομένων"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Χρώματα:"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Υπόβαθρο"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Πλέγμα"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Κατέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Μέσο τρέξιμο κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Μέσο συνεδρίας κατεβάσματος"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Ανέβασμα του τρέχοντος"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Μέσο τρέξιμο ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Εικόνα για την μπάρα ταχείας πρόσβασης του Systray"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Σύνδεσμοι-Kad παρόντες"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Σύνδεσμοι-Kad τρέχοντες"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Επέλεξε"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Δέντρο"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Αριθμός των εμφανιζόμενων εκδόσεων πελάτη (0=απεριόριστος)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! Προειδοποίηση !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Μέγιστος αρ. νέων συνδέσεων /5 δευτερόλεπτα"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Χώρος προσωρινής αποθήκευσης αρχείου: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Λίστα αναμονής ανεβάσματος: 5000 πελάτες"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποίηση"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Θέμα:"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Εμφάνιση \"Γρήγορου διαχειριστή συνδέσμων eD2k\" σε όλα τα παράθυρα."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Εμφάνιση εκτεταμένων πληροφοριών στην καρτέλα κατηγοριών"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Εμφάνιση των ταχυτήτων μεταφοράς στον τίτλο"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Πριν απο το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Μετά το όνομα της εφαρμογής"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Εμφάνιση επιβάρυνσης στο εύρος ζώνης"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Κατακόρυφος προσανατολισμός της γραμμής εντολών"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Ουρά εισερχομένων αρχείων"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Εμφάνιση μπάρας προόδου"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Επίπεδη"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Να απαγορεύεται η πρόσβαση σε επισκέπτες"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Κωδικός επισκέπτη για τον διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4893,11 +4805,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4907,854 +4819,854 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Απενεργοποιημένο [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/δευτερόλεπτο"
 msgstr[1] "bytes/δευτερόλεπτο"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "δευτερόλεπτα"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "λεπτά"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ώρες"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "μέρες"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "όλα"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "όλα τα άλλα"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Ημιτελές"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Σταματημένο"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Βίντεο"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Αρχείο"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Κείμενο "
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Ενεργό"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Εισαγωγή %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Ανάγνωση του προσωρινού καταλόγου"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Ανάκτηση στοιχειωδών πληροφοριών από το αρχείο πληροφοριών κατεβάσματος"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Δημιουργία αρχείου προορισμού"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Φόρτωση δεδομένων από το παλιό αρχείο κατεβάσματος (%u από %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Αποθήκευση του τεμαχίου δεδομένων σε ένα καινούριο μοναδικό αρχείο κατεβάσματος (%u από %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Διαδικασία ανάκτησης πηγαίων πληροφοριών αρχείου κατεβασμάτων"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Προσθήκη κατεβάσματος και αποθήκευση του καινούριου ημιτελούς αρχείου"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Εισαγωγή ημιτελών αρχείων"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Κατάσταση"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Αρχείο κατακερματισμού"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Δίσκος: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Παρακαλώ διαλέξτε έναν κατάλογο για αναζήτηση προσωρινών κατεβασμάτων! (θα συμπεριληφθούν και οι υποκατάλογοι)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Θέλετε να σβηστούν τα πηγαία αρχεία των επιτυχών εισαγόμενων κατεβασμάτων;"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Αφαίρεση πηγών;"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία δημιουργίας ημιτελούς αρχείου"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Προσπάθεια φόρτωσης του αντιγράφου ασφαλείας του αρχείου met από το %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του αρχείου part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ΣΦΑΛΜΑ: το αρχείο έχει μηδενικό μέγεθος: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ΣΦΑΛΜΑ: άκυρη έκδοση του αρχείου part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Σφάλμα: το %s (%s) είναι φθαρμένο (εσφαλμένη απαρίθμηση ετικέτας), δεν είναι δυνατή η φόρτωση του αρχείου."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ΣΦΑΛΜΑ: %s (%s) είναι φθαρμένο (εσφαλμένη απαρρίθμηση ετικέτας), δεν είναι δύνατο το φόρτωμα του αρχείου."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Προσπάθεια ανάκτηση πληροφοριών αρχείου..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Ανάκτηση αρχείου χωρίς όνομα -  θα γίνει προσπάθεια ανάκτησης ως RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Ανακτήθηκαν όλες οι διαθέσιμες πληροφορίες αρχείου :D - Τώρα προσπαθώ να τις χρησιμοποιήσω..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Δεν είναι δυνατή η ανάκτηση πληροφοριών αρχείου :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Αποτυχία ανοίγματος %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: %s μπορεί να είναι φθαρμένο (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ΣΦΑΛΜΑ κατά το αποθήκευση του ημιτελούς αρχείου: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "ΣΦΑΛΜΑ κατά το αποθήκευση του ημιτελούς αρχείου: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Απέτυχε να σωθεί το αρχείο part.met.seeds για %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Σώθηκε %i σπόρος πηγής για το ημιτελές αρχείο: %s (%s) "
 msgstr[1] "Σώθηκαν %i σπόροι πηγής για το ημιτελές αρχείο: %s (%s) "
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Σώθηκε %i σπόρος πηγής για το ημιτελές αρχείο: %s (%s) "
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου σπόρου του ημιτελούς αρχείου (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Βρέθηκε φθαρμένο τμήμα (%d) στο %d μέρος αρχείου %s -  FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Βρέθηκε φθαρμένο τμήμα (%d) στα %d μέρη αρχείου %s -  FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Βρέθηκε ολοκληρωμένο μέρος (%i) στο %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Τελείωσε ο επανακατακερματισμός του %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Απρόσμενο σφάλμα κατά την ολοκλήρωση του %s. Το αρχεί έπαψε"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Ολοκλήρωση του κατεβάσματος: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Ολοκλήρωση του κατεβάσματος: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Σβήσιμο αρχείου: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατός ο κατακερματισμός του κατεβασμένου τμήματος - του σύνολο κατακερματισμού για το '%s' είναι ημιτελές"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ΣΦΑΛΜΑ: Δεν είναι δυνατός ο κατακερματισμός του κατεβασμένου τμήματος - του σύνολο κατακερματισμού για το '%s' είναι ημιτελές. Αυτό δεν πρέπει να ξανασυμβεί ποτέ"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Μη αρκετός χώρος στο δίσκο! Παύση αρχείου: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Το κατεβασμένο τμήμα υπ. αρ. %i είναι φθαρμένο στο αρχείο: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Ανακτήθηκε φθαρμένο τεμάχιο %i για το %s -> Σωσμένα bytes: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Κατανέμει"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Ανεπαρκής χώρος στο δίσκο"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Σύνδεση"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Διακομιστές"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Ασφάλεια"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Διακομιστής διαμεσολάβησης"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Φίλτρα"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Τηλεχειρισμός"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Διασυνδεδεμένη υπογραφή"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Προχωρημένες"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Γεγονότα"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Έλεγχος σφαλμάτων προγράμματος"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5769,35 +5681,35 @@ msgstr ""
 "Το aMule θα τρέχει μια χαρά χωρίς την αλλαγή καμιάς από αυτές\n"
 " τις ρυθμίσεις."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Ο τύπος του διακομιστή μεσολάβησης στον οποίον συνδέεστε"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5805,45 +5717,45 @@ msgstr ""
 "το aMule πρέπει να επανεκινηθεί για να ενεργοποιηθούν αυτές οι αλλαγές: \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Άλλαξε η θύρα TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Άλλαξε η θύρα UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Η εξωτερική σύνδεση έκλεισε."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5851,7 +5763,7 @@ msgstr ""
 "Η λίστα αυτόματης ενημέρωσης διακομιστών είναι κενή.\n"
 "Θα απενεργοποιηθεί η επιλογή: 'Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση' "
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5859,34 +5771,34 @@ msgstr ""
 "Έχετε ενεργοποιήσει τις εξωτερικές συνδέσεις αλλά δεν έχετε προσδιορίσει κωδικό.\n"
 "Οι εξωτερικές συνδέσεις δεν μπορούν να ενεργοποιηθούν μέχρι να προσδιοριστεί ένας έγκυρος κωδικός."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Η γλώσσα άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Ο προσωρινός κατάλογος άλλαξε.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Όλα τα δίκτυα είναι απενεργοποιημένα."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Άκυρη έκδοση πρωτοκόλλου."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5894,7 +5806,7 @@ msgstr ""
 "Και το δίκτυο eD2k και το Kad είναι απενεργοποιημένα.\n"
 "Δεν θα μπορέσετε να συνδεθείτε μέχρι να ενεργοποιήσετε τουλάχιστον ένα από αυτα."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5902,7 +5814,7 @@ msgstr ""
 "Το δίκτυο Kad δεν θα ξεκινήσει αν η θύρα UDP είναι απενεργοποιημένη.\n"
 "Ενεργοποιήστε τη θύρα UDP ή απενεργοποιήστε το Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5912,69 +5824,69 @@ msgstr ""
 "Τώρα πρέπει να επανεκινήσετε το aMule.\n"
 "Διαφορετικά μην διαμαρτυρηθείτε αν συμβεί κάτι κακό.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Νέα εξωτερική σύνδεση έγινε δεκτή"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5984,66 +5896,66 @@ msgstr ""
 "Παρακαλώ βάλτε τουλάχιστον μία URL που να δείχνει σε ένα έγκυρο αρχείο sever.met.\n"
 "Πατήστε το διπλανό κουμπί \"List\" για να βάλετε ένα URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Προσωρινά αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Εισερχόμενα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Συνδεδεμένες υπογραφές"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Επιλέξτε κατάλογο για %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Αναζήτηση του προγράμματος για βίντεο"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Επιλογή περιηγητή"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Εκτελέσιμο%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Επεξεργασία λίστας διακομιστών"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6051,1225 +5963,1224 @@ msgstr ""
 "Βάλτε εδώ τη διεύθυνση για το κατέβασμα των αρχείων server.met. \n"
 "Μία διεύθυνση σε κάθε γραμμή"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Ολοκλήρωση πηγών"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Κατάσταση:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτο"
 msgstr[1] "Καθυστέρηση ενημέρωσης: %d δευτερόλεπτα"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Χρόνος για μέσο γράφημα: %d λεπτό"
 msgstr[1] "Χρόνος για μέσο γράφημα: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Κλίμακα γραφήματος συνδέσεων: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byte"
 msgstr[1] "Μέγεθος χώρου ενδιάμεσης αποθήκευση αρχείου: %d byteς"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Μέγεθος λίστας αναμονής αποστελλόμενων: %d πελάτης"
 msgstr[1] "Μέγεθος λίστας αναμονής ανεβασμάτων: %d πελάτες"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτό"
 msgstr[1] "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: %d λεπτά"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Διάστημα ανανέωσης της σύνδεσης σε διακομιστή: Απενεργοποιημένο"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "απενεργοποίηση"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Εκτέλεση εντολής κατά το γεγονός `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στον πυρήνα"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Εντολή πυρήνα:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Ενεργοποίηση εκτέλεσης εντολών στο γραφικό περιβάλλον"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Εντολή γραφικού περιβάλλοντος:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Οι παρακάτω μεταβλητές θα αντικατασταθούν:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικρότερο από το μέγιστο. Το μέγιστο μέγεθος θα αγνοηθεί."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Προειδοποίηση ψαξίματος"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Κύρια"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Δεν μπορεί να γίνει αναζήτηση στο eD2k αν το eD2k δεν είναι συνδεδεμένο"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Άγνωστο σφάλμα όταν έγινε απόπειρα αναζήτησης στο Kad:"
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Τιμή ταυτότητας αρχείου"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Μη αποτιμημένο"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Κατέβασμα στην κατηγορία"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Αναζήτηση παρόμοιων αρχείων (στο eD2k, τοπικός διακομιστής)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Σημείωση αρχείου ως γνωστού"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Είστε συνδεδεμένος στον διακομιστή που προσπαθείτε να σβήσετε. Παρακαλείστε να αποσυνδεθείτε πρώτα"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Ακύρωση"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Αποτυχία σύνδεσης σε όλους τους συσκοτισμένους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα χωρίς συσκότιση."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Αποτυχία σύνδεσης σε όλους τους συσκοτισμένους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα χωρίς συσκότιση."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Αποτυχία σύνδεσης σε όλους τους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Αποτυχία σύνδεσης σε όλους τους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Το δίκτυο eD2k απενεργοποιήθηκε στις επιλογές, δεν γίνεται σύνδεση."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Δεν βρέθηκαν διακομιστές στη λίστα διακομιστών στους οποίους να γίνει σύνδεση"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Συνδεδεμένο στο %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Σύνδεση παγιώθηκε στο: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Μοιραίο Σφάλμα κατά την προσπάθεια σύνδεσης. Η σύνδεση στο διαδίκτυο πρέπει να έχει διακοπεί"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Χάθηκε η σύνδεση στο %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) φαίνεται να είναι νεκρό"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) φαίνεται να είναι γεμάτο."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτο"
 msgstr[1] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτα"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Η σύνδεση στο %s (%s:%i) απέτυχε."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ΣΦΑΛΜΑ: Η υποδοχή κρίθηκε άκυρη κατά τον έλεγχο χρονικού ορίου"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Η απόπειρα σύνδεσης στο %s (%s:%i) ξεπέρασε το χρονικό όριο."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Φόρτωση του αρχείου διακομιστών: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Το αρχείο server.met δεν βρέθηκε"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Σφάλμα φόρτωσης του αρχείου server.met '%s', βρέθηκε άγνωστη μορφοποίηση."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Αποτυχία ανοίγματος του αρχείου server.met"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Το αρχείο server.met είναι φθαρμένο. βρέθηκε λανθασμένη ετικέτα έκδοσης: 0x%x, μεγεθος %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "βρέθηκε %i διακομιστής στο server.met"
 msgstr[1] "βρέθηκαν %i διακομιστές στο server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "Προστέθηκε %d διακομιστής"
 msgstr[1] "Προστέθηκαν %d διακομιστές"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Σφάλμα εισόδου εξόδου κατά την ανάγνωση του αρχείου known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Ο διακομιστής δεν προστέθηκε: [%s:%d] δεν προσδιορίζει έγκυρη θύρα."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Ο διακομιστής δεν προστέθηκε: Το IP του [%s:%d] είναι φιλτραρισμένο ή άκυρο."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Ο διακομιστής δεν προστέθηκε: Διακομιστής με το ίδιο IP:Θύρα [%s:%d] βρέθηκε στη λίστα."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Ο διακομιστής προστέθηκε: Διακομιστής στην [%s:%d] με όνομα '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Είστε συνδεδεμένος στον διακομιστή που προσπαθείτε να σβήσετε. Παρακαλείστε να αποσυνδεθείτε πρώτα"
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Αποτυχημένη προσπάθεια να ανοίξει '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Αποτυχία σβησίματος του server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Άκυρη URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Ολοκληρώθηκε το κατέβασμα της λίστας διακομιστών από το %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Δεν βρέθηκε πεδίο λίστας διακομιστών το αρχείο 'addresses.dat'. Παρακαλώ επικολλήστε μια έγκυρη λίστα σε αυτό το αρχείο έτσι ώστε να ενημερωθεί αυτόματα η λίστα διακομιστών σας"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Εκκίνηση του κατεβάσματος της λίστας διακομιστών από το %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Προσδιορίστηκε άκυρη διεύθυνση για την αυτόματη ενημέρωση των διακομιστών: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Άκυρη URL αυτόματο κατέβασμα του server.met στο αρχείο addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Αποτυχία κατεβάσματος της λίστας διακομιστών από το %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Ο τοπικός διακομιστής είναι φιλτραρισμένος από τα IPFilters, επανασύνδεση σε διαφορετικό διακομιστή!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Όνομα διακομιστή"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Διεύθυνση"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Θύρα"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ηχοβόλιση πακέτων"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Χρήστες"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Στατικό"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Έκδοση"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Είστε συνδεδεμένος σε έναν διακομιστή που προσπαθείτε να διαγράψετε. Παρακαλώ αποσυνδεθείτε πρώτα. Ο διακομιστής δεν διαγράφηκε."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Άγνωστο όνομα)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Είστε σίγουρος/η ότι θέλετε να διαγράψετε τον στατικό διακομιστή %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Διακομιστές (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Διακομιστής"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Σύνδεση σε διακομιστή"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Σημαδέψτε τον διακομιστή σαν στατικό"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Σημαδέψτε τον διακομιστή σαν μη στατικό"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Σημαδέψτε τους διακομιστές σαν στατικούς"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Σημαδέψτε τους διακομιστές σαν μη στατικούς"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Αφαίρεση διακομιστή"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Αφαίρεση διακομιστών"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Διαγράψτε όλους τους διακομιστές"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Αντιγραφή συνδέσμων eD2k στο πρόχειρο"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Επανασύνδεση στον διακομιστή"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Σίγουρα να σβηστούν όλοι οι διακομιστές;"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τον επιλεγμένο διακομιστή;"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τους επιλεγμένους διακομιστές;"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ΣΦΑΛΜΑ: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Ο νέος πελάτης είναι %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: σας έχει αποδοθεί Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tΠιθανότατα αυτό είναι γιατί είστε πίσω από τοίχο προστασίας ή δρομολογητή."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tΓια περισσότερες πληροφορίες, παρακαλώ αναφερθείτε στο https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Ελήφθησαν άγνωστες πληροφορίες διακομιστή! - υπερβολικά σύντομες"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Λήφθηκε %d καινούριος διακομιστής"
 msgstr[1] "Λήφθηκαν %d καινούριοι διακομιστές"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Το αποθήκευση τις λίστας διακομιστών ολοκληρώθηκε."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Ο διακομιστής απέρριψε την τελευταία εντολή"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Κάλπικο πακέτο ελήφθει από τον διακομιστή: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Αδιαχείριστο σφάλμα κατά την επεξεργασία πακέτου από τον διακομιστή: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Δεν μπορεί να δημιουργηθεί νήμα επίλυσης DNS για τη σύνδεση στο %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Η διεύθυνση IP %s (%s) του διακομιστή είναι φιλτραρισμένη. Δεν γίνεται σύνδεση."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "χρήση πρωτοκόλλου συσκότισης."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Σύνδεση σε %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Δεν μπόρεσε να γίνει επίλυση dns για τον διακομιστή %s: Δεν είναι δυνατή ή σύνδεση!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Ο διακομιστής δεν προστέθηκε: Δεν προσδιορίστηκε διεύθυνση."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Ο διακομιστής δεν προστέθηκε: Προσδιορίστηκε άκυρη θύρα διακομιστή."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Κατάσταση eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "Ταυτότητα"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Κατάσταση σύνδεσης:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Συνδεδεμένο"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Κατάσταση Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Τρέχει στο %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Τρέχει"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Κατάσταση Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Κατάσταση:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Κατάσταση σύνδεσης:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Κατάσταση σύνδεσης:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Κατάσταση τοίχου προστασίας:"
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Όχι φιλαράκος"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Συνδεδεμένος στον φιλαράκο"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Συνδεδεμένος στον φιλαράκο"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Βρέθηκαν πηγές :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "Το αρχείο δεικτών δεν βρέθηκε (ψάχνω ψάχνω και τίποτα δεν βρίσκω)"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Μέσοι χρήστες:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Μέσα αρχεία:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Δεν τρέχει"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο και %i άγνωστο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία και %i άγνωστα"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ΣΦΑΛΜΑ: Αποπειράθηκε να μοιραστεί το %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Όνομα χρήστη"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Ταχύτητα ανεβάσματος"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Διαθέσιμα:"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Κατάσταση ανεβάσματος"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Κατάσταση κατεβάσματος"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Όνομα αρχείου"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Κεκτημένα τμήματα"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Μονοπάτι καταλόγου"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Προσθήκη σχολίου/Αξιολόγησης"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Επεξεργασία σχολίου/Αξιολόγησης"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Μετονομασία"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Προσθήκη των αρχείων της συλλογής στην λίστα με τα μεταφερόμενα"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Αντιγραφή μαγνήτη &URI στην πρόχειρη μνήμη"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο (&Πηγή)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο (Πηγή) (& Με κρυπτογραφικές επιλογές)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο (&Όνομα υπολογιστή)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο (Όνομα υπολογιστή) (&Με κρυπτογραφικές επιλογές)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο) (Πληροφορίες AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο) (Πληροφορίες AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Χρειάζεται Υψηλή Προτεραιότητα για τη δημιουργία έγκυρου πηγαίου συνδέσμου"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Όνομα αρχείου"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Ανεβασμένα Δεδομένα (Συνεδρία (Συνολικά)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Συνολική επιβάρυνση (Πακέτα): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Επιβάρυνση αίτησης αρχείου (Πακέτα): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Επιβάρυνση ανταλλαγής πηγών (Πακέτα): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Επιβάρυνση διακομιστή (Πακέτα): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Επιβάρυνση Kad (Πακέτα): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Κρυπτογραφική επιβάρυνση (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Ενεργά ανεβάσματα: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Ανεβάσματα σε αναμονή: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Συνολικός αρ. επιτυχών συνεδριών ανεβάσματος: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Συνολικός αριθμός αποτυχημένων συνεδριών ανεβάσματος: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Μέσος χρόνος ανεβάσματος: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Κατέβηκαν δεδομένα (Συνεδρία (Συνολικά)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Βρέθηκαν πηγές: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Ενεργά κατεβάσματα (κομμάτια): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Συνεδρία λόγος Άνω:Κάτω (Σύνολο): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Μέσος ρυθμός κατεβάσματος (Συνεδρία): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Μέσος ρυθμός ανεβάσματος (Συνεδρία): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Μέγιστος ρυθμός κατεβάσματος (Συνεδρία): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Ελάχιστος ρυθμός κατεβάσματος (Συνεδρία): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Επανασυνδέσεις: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Χρόνος μετά από την πρώτη μεταφορά: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Σύνδεση με τον διακομιστή από: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Ενεργές συνδέσεις (εκτίμηση): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Έφτασε στο μέγιστο αρ. συνδέσεων: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Μέσες συνδέσεις (εκτίμηση): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Κορυφαίες συνδέσεις (εκτίμηση): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Πελάτες"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Άγνωστο μέγεθος"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Φιλτραρισμένοι"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Απαγορευμένοι"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Συνολικοί: %i Γνωστοί: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Εργαζόμενοι διακομιστές: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Αποτυχημένοι διακομιστές: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Σύνολο: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Διαγραμμένοι διακομιστές: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Φιλτραρισμένοι διακομιστές: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Χρήστες στους εργαζόμενους διακομιστές: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Αρχεία στους εργαζόμενους διακομιστές: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Σύνολο χρηστών: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Σύνολο αρχείων: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Κατοχή διακομιστών: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Αριθμός κοινόχρηστων αρχείων: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Μέσο μέγεθος αρχείου: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Λειτουργικό σύστημα"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Δεν ελήφθει"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Ενεργές συνδέσεις (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Ποτέ"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Η εντολή `%s' με pid `%d' τελείωση με κωδικό κατάστασης `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Εκτέλεση <str> και έξοδος."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Άκυρη μορφή διεύθυνσης IP. Χρησιμοποιήστε xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Αυτή η εντολή χρειάζεται ένα όρισμα. Έγκυρα ορίσματα: 'all', όνομα αρχείου ή έναν αριθμό.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Επεξεργασία κατά κατακερματιστή:"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Επεξεργασία κατά όνομα αρχείου:"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Αυτή η εντολή χρειάζεται ένα όρισμα. Έγκυρα ορίσματα: ένας κατακερματιστής αρχείου.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Άκυρος αριθμός\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Δεν είναι έγκυρος κατακερματισμός (το μήκος πρέπει να είναι ακριβώς 32 χαρακτήρες)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7278,7 +7189,7 @@ msgstr "Για περισσότερη βοήθεια, γράψτε '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7287,89 +7198,87 @@ msgstr "Για περισσότερη βοήθεια, γράψτε '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Για περισσότερη βοήθεια, γράψτε '%s'.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Κατεβασμένα (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Η αίτηση απέτυχε για άγνωστο λόγο"
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Η διαδικασία ολοκληρώθηκε επιτυχώς."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Η αίτηση απέτυχε με το ακόλουθο σφάλμα: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Το φίλτρο IP για πελάτες είναι %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Εκτός"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Σε λειτουργία"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Το φιλτράρισμα διευθύνσεων για διακομιστές είναι %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Το τρέχον επίπεδο IPFilter είναι %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Ευρυζωνικά όρια: Πάνω: %u kB/s, Κάτω: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Συνδεδεμένο στο %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Συνδέεται τώρα"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "βρίσκεται πίσω από τοίχο προστασίας"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "Εντάξει"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7378,7 +7287,7 @@ msgstr ""
 "\n"
 "Κατέβασμα:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7387,7 +7296,7 @@ msgstr ""
 "\n"
 "Ανέβασμα:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7396,7 +7305,7 @@ msgstr ""
 "\n"
 "Πελάτες σε αναμονή:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7405,47 +7314,47 @@ msgstr ""
 "\n"
 "Συνολικές πηγές:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Μέρος αρχείου]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Αριθμός αποτελεσμάτων αναζήτησης: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "Εμφάνιση ποσοστού προόδου"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Ελήφθη άγνωστη απάντηση από τον διακομιστή, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Εμφάνιση σύντομων πληροφοριών κατάστασης."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Εμφάνιση κατάστασης σύνδεσης, τρέχουσες ταχύτητες ανεβοκατεβάσματος, κτλ.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Εμφάνιση πλήρους δέντρου στατιστικών."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7459,11 +7368,11 @@ msgstr ""
 "\n"
 "Παράδειγμα: 'statistics 5' θα δείξει μόνο τις 5 πρώτες εκδόσεις του κάθε τύπου πελάτη.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Κλείσιμο του aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7473,40 +7382,40 @@ msgstr ""
 "Αυτό θα κλείσει και τον πελάτη κειμένου, γιατί είναι άχρηστος χωρίς έναν\n"
 "τρέχοντα πυρήνα.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Επαναφορτώνει το δεδομένο αντικείμενο"
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Επαναφορτώνει τον πίνακα φίλτρων IP από αρχείο"
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Επιλογή επιπέδου φιλτραρίσματος IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Επαναφορτώνει τον πίνακα φίλτρων IP από αρχείο"
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Σύνδεση στο δίκτυο."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7518,36 +7427,36 @@ msgstr ""
 "μόνο σε αυτόν τον διακομιστή. Η διεύθυνση IP πρέπει να είναι μια διάστικτη δεκαδική διεύθυνση IPv4\n"
 "ή ένα επιλύσιμο όνομα DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Σύνδεση μόνο στο eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Σύνδεση μόνο στο Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Αποσύνδεση από το δίκτυο."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Αυτό θα προκαλέσει αποσύνδεση από όλα τα συνδεδεμένα δίκτυα.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Αποσύνδεση μόνο από το eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Αποσύνδεση μόνο από το Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Προσθήκη ενός μαγνητικού συνδέσμου ή συνδέσμου eD2k στον πυρήνα."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7566,52 +7475,52 @@ msgstr ""
 "Ο μαγνητικός σύνδεσμος πρέπει να περιέχει τον κατακερματισμό \n"
 " και το μέγεθος αρχείου.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Θέτει την τιμή μίας προτίμησης."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Θέτει τις προτιμήσεις του φίλτρου IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Άνοιγμα του φίλτρου IP τόσο για πελάτες όσο και για διακομιστές."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Κλείσιμο του φίλτρου IP τόσο για πελάτες όσο και για διακομιστές."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Ενεργοποίηση/Απενεργοποίηση του φίλτρου IP για πελάτες."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Άνοιγμα του φίλτρου IP τόσο για πελάτες."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Κλείσιμο του φίλτρου IP τόσο για πελάτες."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Ενεργοποίηση/Απενεργοποίηση του φίλτρου IP για διακομιστές."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Άνοιγμα του φιλτραρίσματος IP για τους διακομιστές."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Κλείσιμο του φιλτραρίσματος IP για τους διακομιστές."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Επιλογή επιπέδου φιλτραρίσματος IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7619,80 +7528,80 @@ msgstr ""
 "Έγκυρα επίπερα φιλτραρίσματος είναι στο διάστημα 0-255, και η προεπιλεγμένη (αρχική)\n"
 "τιμή είναι 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Ρύθμιση ορίων εύρους ζώνης."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Η τιμή που δίνεται σε αυτές τις εντολές πρέπει να είναι σε kilobytes/δευτερόλεπτο.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Θέσε το όριο εύρους ζώνης για ανέβασμα."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Η τιμή που δίνεται σε αυτές τις εντολές πρέπει να είναι σε kilobytes/δευτερόλεπτο.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Θέσε το όριο εύρους ζώνης για κατέβασμα."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Η τιμή που δίνεται σε αυτές τις εντολές πρέπει να είναι σε kilobytes/δευτερόλεπτο.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Λήψη και εμφάνιση της τιμής μίας προτίμησης."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Λήψη προτιμήσεων φίλτρου IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Λήψη κατάστασης φίλτρου IP για πελάτες και διακομιστές."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Λήψη κατάστασης φίλτρου IP μόνο για πελάτες."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Λήψη κατάστασης φίλτρου IP μόνο για διακομιστές."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Επιλογή επιπέδου φιλτραρίσματος IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Λήψη τον ορίων εύρους ζώνης."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Εκτελεί αναζήτηση στο Kad"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7711,48 +7620,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Εκτελεί συνολική αναζήτηση."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Εκτελεί τοπική αναζήτηση"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Εκτελεί αναζήτηση στο Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Δείχνει τα αποτελέσματα της τελευταίας αναζήτησης."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Δείχνει την πρόοδο της αναζήτησης."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Ξεκινά να κατεβάζει ένα αρχείο"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7760,82 +7669,82 @@ msgstr ""
 "Πρέπει να δωθεί αριθμός του αρχείου από την τελευταί αναζήτηση.\n"
 " Για παράδειγμα \"download 12\" θα ξεκινήσει να κατεβάζει το αρχείο υπ' αριθμό 12 της προηγούμενης αναζήτησης.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Παύση κατεβάσματος."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Συνέχιση κατεβάσματος."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Ακύρωση κατεβάσματος."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Θέσε την προτεραιότητα κατεβάσματος."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Βάλτε την προτεραιότητα κατεβάσματος σε χαμηλή, κανονική, ηψηλή ή αυτόματη.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Θέστε χαμηλή προτεραιότητα."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Θέστε κανονική προτεραιότητα."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Θέστε υψηλή προτεραιότητα."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Θέστε αυτόματη προτεραιότητα."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Δείξε τις ουρές/λίστες."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Δείχνει την ουρά ανεβάσματος/κατεβάσματος, τη λίστα διακομιστών ή κοινόχρηστων αρχείων.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Δείξε την ουρά ανεβάσματος."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Δείξε την ουρά κατεβάσματος."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Δείξε τον αρχείο καταγραφής."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Δείξε τη λίστα των διακομιστών."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Καθάρισμα αρχείου καταγραφής."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Δεν συνίσταται αυτή η εντολή, αντ' αυτής χρησιμοποιήστε την '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7844,262 +7753,259 @@ msgstr ""
 "Αυτή είναι μη συνιστώμενη εντολή και μπορεί να αφαιρεθεί στο μέλλον. \n"
 "Χρησιμοποιήστε '%s' καλύτερα.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Διακομιστής κειμένου του aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Μετατροπή των παλιών συνόλων κατακερματισμού AICH στο '%s' σε 64b στο '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "Ειδοποίηση: Το όνομα αρχείου '%s' είναι άκυρο και μετονομάστηκε σε '%s' "
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "Ειδοποίηση: Το αρχείο '%s' υπάρχει ήδη, το νέο αρχείο μετονομάστηκε σε '%s'"
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Είστε σίγουροι ότι θέλετε να ακυρώσετε και να σβήσετε όλα τα αρχεία σε αυτήν την κατηγορία;"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Χρειάζεται επιβεβαίωση"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Υπερβολικά πολλές συνδέσεις"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Όλα τα άλλα"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Προσθήκη κατηγορίας"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Επεξεργασία κατηγορίας"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Διαγραφή κατηγορίας"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Σύνολο κατακερματισμού για άγνωστο αρχείο: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Συνέχεια του ανεβάσματος του αρχείου: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Αναστολή ανεβάσματος του αρχείου: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Αποτυχία εκτέλεσης εντολής `%s' στο συμβάν `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Το κατέβασμα ολοκληρώθηκε"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Η πλήρης διαδρομή του αρχείου"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Το όνομα του αρχείου χωρίς τη διαδρομή."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Ο κατακερματισμός eD2k του αρχείου."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Το μέγεθος του αρχείου σε byte."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Συνολική διάρκεια κατεβάσματος"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Ξεκίνησε καινούρια περίοδος συνομιλίας"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Αποστολέας μηνύματος"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Δεν υπάρχει χώρος"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Κατάτμηση δίσκου"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Σφάλμα κατά την ολοκλήρωση"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Επεξεργασία του αρχείου υπ' αριθμόν %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ζητήσατε μερικά τεμάχια (Χρησιμοποιείται μόνο για αρχεία > 9.5ΜΒ)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Ανύπαρκτο αρχείο !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, ο δημιουργός συνδέσμων eD2k του aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Καλώς ήρθατε (Καλώς σας βρήκαμε)"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Παράμετρος εισόδου"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Αρχείο προς κατακερματισμό"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Εδώ εισάγετε το αρχείο για το οποίο θέλετε να υπολογίσετε τον σύνδεσμο eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Εδώ εισάγετε την διεύθυνση που θέλετε να προσθέσετε στον σύνδεσμο eD2k: Προσθέστε / στο τέλος για να ενημερώσετε τον δημιουργό συνδέσμων να επισυνάψει το τρέχων όνομα αρχείου"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Δημιουργία συνδέσμου με μερικό κατακερματισμό"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Βοηθήστε στην διανομή καινούριων και σπάνιων αρχείων  ταχύτερα, με αντίτιμο ένα μεγαλύτερο μέγεθος συνδέσμου"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Κατακερματισμός αρχείου MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Αρχείο κατακερματισμού eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "σύνδεσμος eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Άνοιγμα αρχείου για τον υπολογισμού του συνδέσμου eD2k του"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Αντιγραφή υπολογισμένου συνδέσμου eD2k στο πρόχειρο"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Αποθήκευση υπολογισμένου συνδέσμου eD2k σε αρχείο"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Σχετικά με τον aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Επιλέξτε το αρχείο για το οποίο θέλετε να υπολογίσετε τον σύνδεσμο eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Δεν υπάρχει τίποτα για να αντιγραφεί σε αυτή τη φάση !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Επιλέξτε το αρχείο για τον υπολογισμένο σύνδεσμο eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Αδύνατο το άνοιγμα"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Παρακαλώ δώστε ένα μη κενό όνομα αρχείου"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Δεν υπάρχει τίποτα για να σωθεί σε αυτή τη φάση !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8119,167 +8025,159 @@ msgstr ""
 "\n"
 "Διανέμεται υπό την GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Κατακερματίζεται..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Ακυρώθηκε!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Ολοκληρώθηκε σε %.2f δεύτερα"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Έχετε ήδη προσθέσει αυτήν την URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Παρακαλώ εισάγετε μια μη κενή URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Αποτυχία ανοίγματος του %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i Ημέρες %i Ώρες %i λεπτά %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Στατιστικές σύνδεσης aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Μέγιστη ταχύτητα κατεβάσματος στη διάρκεια που το wxCas τρέχει"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Απόλυτα ελάχιστη ταχύτητα κατεβάσματος στις προηγούμενες εκτελέσεις του wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Καθαρισμός"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Σύστημα"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Διακοπή της αυτόματης ανανέωσης"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Αποθήκευση της απεικόνισης στατιστικών σύνδεσης"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Εκτύπωση της απεικόνισης στατιστικών σύνδεσης"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Ρυθμίσεις προτιμήσεων"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Σχετικά με το wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Εκκίνηση της αυτόματης ανανέωσης"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Η αυτόματη ανανέωση σταμάτησε"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Αποθήκευση της στατιστικής απεικόνισης"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Στατιστικές σύνδεσης του aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8287,11 +8185,11 @@ msgstr ""
 "Υπήρξε πρόβλημα κατά την εκτύπωση.\n"
 "Μήπως ο τρέχων εκτυπωτής δεν έχει ρυθμιστεί σωστά;"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Εκτύπωση"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8309,403 +8207,392 @@ msgstr ""
 "\n"
 "Διανέμετε υπό την GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Να πάρει! Το amule δεν τρέχει.."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "Το aMule τρέχει"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "Το aMule τρέχει, αλλά δεν είναι συνδεδεμένο"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "Το aMule συνδέεται..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Στο καλό! Η κατάσταση του aMule είναι άγνωστη..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr "τρέχει επί"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr "έχει διακοπεί !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr "δεν είναι συνδεδεμένο !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr "συνδέεται.."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr "κάνει κάτι περίεργο, τσεκάρει το!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr "είναι συνδεδεμένο με"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "κλειστό"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr "είναι ανοιχτό"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr "με"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Συνολική μεταφόρτωση:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Ανέβασμα: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Περίοδος κατεβάσματος:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Μεταφόρτωση"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Ανέβασμα: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Κοινοκτημοσύνη"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr "Αρχείο(α), Πελάτες στην αναμονή: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Χρόνος"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " ανοιχτό"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Μέσο φορτίο συστήματος (1-5-15 λεπτά): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Χρόνος λειτουργικότητας συστήματος:"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Ο κατάλογος που περιέχει το αρχείο amulesig.dat."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Γράψτε εδώ το όνομα του καταλόγου που περιέχει το αρχείο amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Περίοδος ανανέωσης σε δευτερόλεπτα"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Παραγωγή στατιστικής απεικόνισης σε κάθε συμβάν ανανέωσης"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Γράψτε εδώ τον κατάλογο όπου θέλετε να παραχθεί η στατιστική απεικόνιση"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Περιοδικό ανέβασμα του ειδώλου στατιστικών στον διακομιστή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Διεύθυνση FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Διαδρομή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Εδώ εισάγετε τη διεύθυνση του διακομιστή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Εισάγετε εδώ τον κατάλογο που θα μπει το είδωλο στατιστικών στον διακομιστή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Χρήστης"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Γράψτε εδώ το όνομα χρήστη για να συνδεθείτε στον διακομιστή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Γράψτε εδώ τον κωδικό χρήστη για να συνδεθείτε στον διακομιστή FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Περίοδος ενημέρωσης του FTP σε λεπτά"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Τεκμηρίωση"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Κατάλογος που περιέχει το αρχείο υπογραφής"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Κατάλογος όπου να δημιουργηθεί η στατιστική απεικόνιση"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Φορτώνει προτύπου <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Θύρα HTTP του διακομιστή ιστού"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Χρήση της προώθησης της θύρας UPnP στη θύρα διακομιστή ιστού"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Θύρα UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Κωδικός πλήρους πρόσβασης για τον διακομιστή ιστού"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Κωδικός επισκέπτη για τον διακομιστή ιστού"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Να επιτρέπεται η πρόσβαση σε επισκέπτες"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Να απαγορεύεται η πρόσβαση σε επισκέπτες"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Φόρτωση/Αποθήκευση των ρυθμίσεων του διακομιστή ιστού από/προς απομακρυσμένο aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Η διαδρομή στα αρχεία ρυθμίσεων του aMule. ΜΗΝ ΑΛΛΑΖΕΤΕ ΑΠΕΥΘΕΙΑΣ"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Απενεργοποίηση του διερμηνέα PHP (απαρχαιωμένο)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Μεταγλώττιση των σελίδων PHP σε κάθε αίτηση"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Ο διακομιστής δικτύου του aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "η σύνδεση πελάτη ιστού έγινε αποδεκτή\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ΣΦΑΛΜΑ: δεν μπορεί να γίνει δεκτή η σύνδεση πελάτη ιστού\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Η αίτηση απέτυχε με το εξής σφάλμα: %s"
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Το αρχείο δεικτών δεν βρέθηκε (ψάχνω ψάχνω και τίποτα δεν βρίσκω)"
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Η περίοδος εργασίας έληξε - αίτηση επανασύνδεσης\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Η Περίοδος εργασίας είναι εντάξει, συνδεδεμένο\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Η περίοδος εργασίας είναι εντάξει, μη συνδεδεμένο\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Δεν έχει ξεκινήσει περίοδος εργασίας - θα ζητήσει σύνδεση\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Δημιουργία περιόδου εργασίας - ζήτηση σύνδεσης\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "H αίτηση διεκπεραιώνεται [αρχικό]:"
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Ο κωδικός κατακερματισμού είναι άκυρος\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Ο κωδικός είναι εντάξει\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Κακός κωδικός\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Δεν βάλατε κανέναν κωδικό. Δεν επιτρέπεται κενός κωδικός.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Ζητήθηκε αποσύνδεση\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Επεξεργασία αιτήματος [ανακατεύθυνση]"
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Αποτυχία σύνδεσης"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -18,100 +18,100 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr ""
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr ""
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -120,47 +120,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -169,172 +168,165 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -344,269 +336,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -616,191 +604,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -809,1204 +790,1177 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr ""
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr ""
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr ""
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr ""
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2014,23 +1968,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2038,59 +1992,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2099,2647 +2053,2605 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 msgid "Connection & bandwidth"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 msgid "Connection speed:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr ""
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr ""
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr ""
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr ""
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr ""
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr ""
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr ""
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr ""
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr ""
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4747,11 +4659,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4761,836 +4673,836 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr ""
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr ""
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5600,1444 +5512,1443 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr ""
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 msgid "Connected since:"
 msgstr ""
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr ""
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr ""
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7045,7 +6956,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7053,155 +6964,153 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7210,46 +7119,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7257,35 +7166,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7296,121 +7205,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7429,383 +7338,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr ""
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr ""
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr ""
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7817,177 +7723,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -7998,400 +7896,389 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -28,19 +28,19 @@ msgstr ""
 "X-Language: es_ES\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "Acerca de aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Control remoto de aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Versión:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,7 +48,7 @@ msgstr ""
 "Cliente p2p multiplataforma basado en eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -56,77 +56,77 @@ msgstr ""
 "Copyright (c) 2003-2026 El equipo de aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte de aMule está basada en \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: direccionamiento P2P basado en la métrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foro:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Documentación:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Problemas:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Haz clic para comprobar si hay una versión más nueva."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Conectando a Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "Estás utilizando la última versión."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Una nueva versión (%s) está disponible:"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "No se pudo comprobar si hay actualizaciones. Por favor, inténtelo de nuevo más tarde."
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Añadir un amigo"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "¡Debe introducir una IP y puerto válidos!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Información"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash de usuario especificado no es válido!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -140,47 +140,46 @@ msgstr ""
 "\n"
 "¿Instalar la integración de escritorio ahora?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "¿Añadir aMule al menú de aplicaciones?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Instalar"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Ahora no"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "No volver a preguntar"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "No se puede instalar la integración de escritorio: la variable de entorno APPDIR no está definida. Esto generalmente significa que el AppImage no se inició de forma normal."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "La integración de aMule ha fallado"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "No se puede instalar la integración de escritorio: error al crear %s. Compruebe que su directorio personal tenga permisos de escritura."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "No se puede instalar la integración de escritorio: error al escribir %s. Compruebe que su directorio personal tenga permisos de escritura."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, fuzzy, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integración de AppImage: aMule se ha añadido al menú de aplicaciones."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -194,103 +193,100 @@ msgstr ""
 "\n"
 "¿Reiniciar aMule ahora?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule instalado"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Reiniciar ahora"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Más tarde"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Error al abrir el archivo de enlaces ED2K."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k teniendo Id Baja."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Ahora, saliendo de la aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleweb con pid '%d'... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Falló"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Cerrando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando la instancia de amuleapi con pid '%d'... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: terminando el núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Cierre de aMule completado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados de depuración de memoria en la salida de aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Vinculando el tráfico P2P de aMule a la interfaz: %s (las actualizaciones HTTP usan la ruta predeterminada)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Vinculando todo el tráfico de red a la interfaz: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ADVERTENCIA: la interfaz de red configurada '%s' no se encontró; el tráfico NO está vinculado a ella y puede salir por la ruta predeterminada. Compruebe el nombre de la interfaz en Preferencias."
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ADVERTENCIA: vincularse a la interfaz de red '%s' requiere privilegios elevados y NO se aplicó; el tráfico puede salir por la ruta predeterminada. Conceda la capacidad (por ejemplo, \"sudo setcap capnetraw+ep\" al binario de aMule) o ejecute con privilegios suficientes."
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ADVERTENCIA: no se pudo vincular a la interfaz de red '%s'; el tráfico puede salir por la ruta predeterminada."
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Su configuración regional se ha cambiado a la predefinida del sistema debido a un cambio en la configuración. Disculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -298,20 +294,19 @@ msgstr ""
 "\n"
 "Configuración de la EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Contraseña fijada y conexiones externas habilitadas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -319,51 +314,48 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web corriendo con pid: %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi corriendo con pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ha solicitado ejecutar amuleapi al inicio pero no se puede ejecutar el binario amuleapi. Por favor, instale el paquete que contiene el servidor API REST de aMule, o compile aMule desde el código fuente con -DBUILD_AMULEAPI=YES e instálelo."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se pueden asociar los puertos con la dirección especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "El puerto %u no está disponible. Tendrás Id Baja\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -378,48 +370,48 @@ msgstr ""
 "\n"
 "Comprueba la red y asegúrate de que el puerto está abierto para salida y entrada."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Error al crear el archivo de firma online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Error al crear el archivo de firma online de aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "El idioma seleccionado no parece estar instalado en tu sistema. (Nota: intentaré configurarlo de todos modos)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Es la primera vez que inicias aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta es una versión de prueba, actualizada diariamente, y\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "no garantizamos que no rompa nada, no queme su casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o no mate a su perro. Pero *debería* ser seguro usarla de todas formas.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "En nuestra web podrá encontrar más información, soporte y nuevas versiones,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, o en nuestro canal de IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Envíenos cualquier fallo a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -427,222 +419,218 @@ msgstr ""
 "¡El directorio que ha especificado para archivos de firma digital no es válido!\n"
 "La firma digital se ha deshabilitado hasta que lo arregle en las preferencias."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "La reserva del espacio en disco para el archivo '%s' ha fallado: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERROR: no se puede abrir el archivo de registro"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: el archivo de registro está vacío. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "El registro se ha borrado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaje del servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se ha descartado la descarga de %s, porque el archivo solicitado no es más nuevo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Error al descargar la lista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Error al abrir el archivo de comprobación de versión descargado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Archivo de comprobación de versión dañado"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "¡Estás usando una versión desactualizada de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Su versión de aMule es %i.%i.%i y la última versión es %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La última versión siempre se puede encontrar en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: su versión de aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Su copia de aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Error al descargar el archivo de comprobación de la versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Archivos: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Archivos: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "No hay redes seleccionadas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "con Id Baja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "con Id Alta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad detenido."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (correcto)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (tras cortafuegos)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La red Kad no se puede usar si el puerto UDP está deshabilitado en las preferencias, no se inicia."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Red Kad deshabilitada en las preferencias, no se conecta."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERROR: el demonio de aMule no se puede usar cuando están desactivadas las conexiones externas. Para activarlas, use un aMule normal, inicie amuled con la opción --ec-config, o bien, establezca \"AcceptExternalConnections\" a 1, en el archivo ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERROR: se requiere una contraseña válida para usar conexiones externas, y el demonio de aMule no se puede usar sin conexiones externas. Para iniciar el demonio de aMule, debe especificar en el campo \"ECPassword\" del archivo ~/.aMule/amule.conf el valor apropiado. Ejecute amuled con el parámetro --ec-config para especificar la contraseña. Se puede encontrar más información en https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - iniciando el temporizador"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "No se puede crear el archivo Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto es aMule %s basado en eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -657,191 +645,184 @@ msgstr ""
 "\n"
 "¿Le gustaría abrir la página de descarga?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "No hay red"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Control remoto de aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Error fatal: no se ha podido crear el temporizador del núcleo"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Conectar con un amule remoto"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Conexión perdida"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "Interrumpir y salir"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "Reconectando... (intento %d)"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "Próximo intento en %d s..."
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -854,40 +835,40 @@ msgstr ""
 "\n"
 "La interfaz está en pausa hasta que se restablezca la conexión."
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Error fatal: no se ha podido crear el temporizador de sondeo"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Entrando en el bucle de eventos..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Conectando..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Conexión fallida. Por favor, compruebe el host, puerto y contraseña."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Gestor de eventos de la EC de la interfaz remota"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Error de conexión. No se puede conectar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Apagándose"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Intento de reconectar expirado; reintentando."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -896,681 +877,658 @@ msgstr ""
 "Tiempo de conexión agotado. No se ha podido contactar con %s:%d dentro del tiempo asignado.\n"
 "Compruebe el host, el puerto y que aMule esté en ejecución con las Conexiones Externas habilitadas."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Se perdió la conexión con el núcleo remoto. Intentando reconectar..."
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "Reconectado al core remoto."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Intento de reconexión %d: conectando a %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "No se pudo iniciar la reconexión; se reintentará en breve."
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Listo"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Todos"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "no legible"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "no encontrado"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "El núcleo rechazó estas carpetas compartidas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "El enlace no es válido o ya está en la lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantiene el directorio '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando un amigo para conexión con Id Baja"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versión falsa de eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Falso eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falso eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basado en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alias: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitado: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadísticas de archivo para esta sesión: aceptada %d de %d petición, %s transferidos\n"
 msgstr[1] "Estadísticas de archivo para esta sesión: aceptadas %d de %d peticiones, %s transferidos\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadísticas de archivo para todas las sesiones: aceptada %d de %d petición, %s transferidos\n"
 msgstr[1] "Estadísticas de archivo para todas las sesiones: aceptadas %d de %d peticiones, %s transferidos\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Se ha pedido un archivo desconocido"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensaje filtrado de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuevo mensaje de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "El usuario %s (%u) ha pedido la lista de archivos compartidos de un directorio que no existe, '%s' -> Se ignora"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "AVISO: no se puede abrir %s."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVISO: la lista de archivos cancelados está dañada, contiene una cabecera inválida."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Error de E/S al leer el archivo %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Error guardando el archivo %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nueva categoría"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Elija una carpeta para los archivos entrantes"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "¡Debe especificar un nombre para la categoría!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "¡Debe especificar una ruta para la categoría!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Error al crear el directorio entrante para la categoría. Por favor, ¡especifique una ruta correcta!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sesión de chat iniciada: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Conectado al cliente ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Conectando al cliente ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Error al conectar con el cliente / Conexión perdida ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Ha pasado la comprobación del captcha y el usuario ha recibido su mensaje. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Su respuesta al captcha ha sido incorrecta y su mensaje se ha ignorado. Puede pedir un nuevo captcha enviando un nuevo mensaje. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Cerrar la pestaña"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Cerrar todas las pestañas"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Cerrar las otras pestañas"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Añadir a Amigos"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Archivo de créditos cargado, %u cliente conocido"
 msgstr[1] "Archivo de créditos cargado, %u clientes conocidos"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - ¡Ha expirado el crédito de %u cliente!"
 msgstr[1] " - ¡Han expirado los créditos de %u clientes!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "No se ha encontrado el archivo 'cryptkey.dat', se crea."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalles del cliente"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Id Baja"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Id Alta"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Habilitada"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Soportada"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "No soportada"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Deshabilitada"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "No completado"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Cliente sospechoso"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - Correcto"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "No disponible"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "El usuario %s (%u) ha pedido la lista de sus archivos compartidos -> Aceptada"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "El usuario %s (%u) ha pedido la lista de sus archivos compartidos -> Denegada"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "El usuario %s (%u) ha pedido la lista de sus directorios compartidos -> Aceptada"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "El usuario %s (%u) ha pedido la lista de sus directorios compartidos -> Denegada"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "El usuario %s (%u) ha pedido la lista de sus archivos compartidos en el directorio %s -> Aceptada"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "El usuario %s (%u) ha pedido la lista de sus archivos compartidos en el directorio %s -> Denegada"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "El usuario %s (%u) comparte el directorio '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "El usuario %s (%u) ha enviado directorios compartidos no solicitados."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "El usuario %s (%u) ha enviado su lista de archivos compartidos del directorio '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "El usuario %s (%u) ha finalizado el envío de su lista de archivos compartidos"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "El usuario %s (%u) ha enviado una lista de archivos compartidos no deseada"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "El usuario %s (%u) ha denegado el acceso a su lista de directorios/archivos compartidos"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentarios del archivo"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentario"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "No se pudo iniciar una búsqueda Kad"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "No se puede buscar en Kad si no está conectado a Kad"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "Buscando comentarios en Kad…"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "No hay comentarios"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentario"
 msgstr[1] "%u comentarios"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Cliente bloqueado %s por enviar %s en datos corruptos de un total de %s para el archivo '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Error al cargar los datos de países para '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Automática [Ba]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Automática [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Automática [Al]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Muy alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Lanzamiento"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Preguntando"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Conectando vía servidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Cola llena"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Recibiendo hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Partes no necesitadas"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "No se puede conectar Id Baja con Id Baja"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Demasiadas conexiones"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Conectando vía Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Demasiadas conexiones Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Bloqueado"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Error de conexión"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Cola remota llena"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Antiguo MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nuevo MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatible con eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Servidor local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Intercambio de fuentes"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasivo"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Enlace"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Semillas fuente"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultado de la búsqueda"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "En progreso"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "ERROR: no queda espacio en disco"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERROR: partmet no encontrado"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERROR: ¡error de E/S!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERROR: ¡no se ha podido realizar la acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "En la cola"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Ya se está descargando"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formato de archivo temporal incorrecto o desconocido."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidad"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fuentes"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridad"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Estado"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tiempo restante"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Visto completo por última vez"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Última recepción"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "¿Seguro que desea borrar el archivo seleccionado?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "¿Seguro que desea borrar los archivos seleccionados?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1579,109 +1537,106 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Detener"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausar"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Reanudar"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Limpiar los completados"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Intercambiar todas las fuentes A4AF a este archivo ahora"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Intercambiar todas las fuentes A4AF a este archivo (automático)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Intercambiar todas las fuentes A4AF a otro archivo ahora"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opciones adicionales"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Mostrar los detalles del archivo"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Mostrar todos los comentarios"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiar el URI magnético al portapapeles"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copiar el en&lace eD2k al portapapeles"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar la respuesta al portapapeles"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "no asignado"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Asignar a la categoría"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir el archivo"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Introduzca el nuevo nombre para el archivo:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Renombrar el archivo"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "la terminal predeterminada de Windows"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1690,346 +1645,345 @@ msgstr ""
 "Para evitar la aparición de este aviso en cada previsualización,\n"
 "defina el reproductor de vídeo en las preferencias (%s por defecto)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Previsualizar el archivo"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: ¡no se ha podido ejecutar el reproductor de medios externo! Comando: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Guardando el archivo de partes %u de %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Todos los archivos de partes han sido guardados."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Cargando archivos temporales desde %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Cargando el archivo de partes %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERROR: no se ha podido cargar el archivo de copia de seguridad. Busque en https://github.com/amule-org/amule/discussions para encontrar soluciones de recuperación de archivos .part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Todos los archivos de partes han sido cargados."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "No se han encontrado archivos de partes"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Encontrado %u archivo de partes"
 msgstr[1] "Encontrados %u archivos de partes"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "El sistema de ficheros del directorio Temporal no puede manejar archivos grandes."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "El sistema de ficheros del directorio Entrante no puede manejar archivos grandes."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Descargando %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Ya está intentando descargar el archivo '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Ya tiene el archivo '%s' (solicitado como '%s')"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Ya tiene el archivo '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ya está intentando descargar el archivo %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "No se puede convertir el enlace magnético a eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocolo desconocido del enlace: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "No se pudo añadir el enlace %u (consulte el registro para más detalles)."
 msgstr[1] "No se pudieron añadir los enlaces %u (consulte el registro para más detalles)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "¡Enlace eD2k inválido! ERROR: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "El cliente ha enviado un paquete después de una autentificación fallida."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Conexión externa cerrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "¡Las conexiones externas están deshabilitadas por estar la contraseña en blanco!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Conexiones externas deshabilitadas en el archivo de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nueva conexión externa aceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROR: no se ha podido aceptar una nueva conexión externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "¡Conexión externa rechazada por estar la contraseña en blanco en las preferencias!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando con el cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versión desconocida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de versión de EC incorrecto, debe haber una incompatibilidad. Use núcleo y remoto de la misma versión."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "¡No puede conectar a una versión final desde una versión de desarrollo cualquiera! *suspiro* posible error evitado"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versión de protocolo no válida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Falta la etiqueta de versión de protocolo."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Error de autentificación: se ha dado un hash inválido como contraseña de la EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Error de autentificación: contraseña incorrecta."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Error de autentificación: falta la contraseña."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitud no válida, debe autentificarse primero."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar el mensaje de error \"%s\" al cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso no autorizado desde %s. Conexión cerrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Error en el comando del archivo de partes remoto: hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash de archivo no encontrado: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "¡Huy! ¡Error procesando el código de operación!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Servidor no añadido"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor no encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "necesita definir el servidor que va a borrar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Amigo no encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Cliente no encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requiere EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La búsqueda web desde una interfaz remota no tiene sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Búsqueda en proceso. ¡Resultados obtenidos en breve!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "No hay puntos para el gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Su cliente no está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Ya se está cerrando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: añadiendo el enlace '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d enlaces fallaron(no válidos o ya está en la lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "La comprobación de versión se ha limitado; inténtelo de nuevo en breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "La comprobación de versión no está disponible en este demonio."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Archivo no encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nombre de archivo incorrecto."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "No se puede renombrar el archivo."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad está deshabilitado en las preferencias."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Ya está conectado a eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Conectado a eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Ya está conectado a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Todas las redes están deshabilitadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: se ha recibido un código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operación no válido (¿versión de protocolo incorrecta?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensión desconocida '%s' para el comando '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comando desconocido '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2037,7 +1991,7 @@ msgstr ""
 "\n"
 "El comando no puede tener argumentos.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2045,7 +1999,7 @@ msgstr ""
 "\n"
 "El comando debe tener un argumento.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2053,7 +2007,7 @@ msgstr ""
 "\n"
 "El comando está incompleto, debe usar una de la extensiones de abajo.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2061,11 +2015,11 @@ msgstr ""
 "\n"
 "Extensiones disponibles:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comandos disponibles:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2076,17 +2030,17 @@ msgstr ""
 "Todos los comandos distinguen mayúsculas de minúsculas.\n"
 "Escriba '%s <comando>' para obtener información detallada de <comando>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Sale de la aplicación."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Mostrar la ayuda."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2094,7 +2048,7 @@ msgstr ""
 "Para obtener la ayuda de un comando, escriba 'help <comando>'.\n"
 "Para obtener la lista completa de comandos, escriba 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2105,46 +2059,46 @@ msgstr ""
 "Use '%s' para obtener la lista de comandos\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "¡Error de sintaxis!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Error procesando el comando - ¡nunca debería pasar! Informe del fallo, por favor\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "El comando no debe tener ningún parámetro."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "El comando debe tener un parámetro."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argumento no válido."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "El comando está incompleto."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Escriba '%s' para obtener más ayuda.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Esto es %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Esto es %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2152,7 +2106,7 @@ msgstr ""
 "\n"
 "Creando cliente...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2161,7 +2115,7 @@ msgstr ""
 "\n"
 "Vale, terminando %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2175,331 +2129,326 @@ msgstr ""
 "\n"
 "Saliendo...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Mostrar esta ayuda."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host donde se está ejecutando aMule (por defecto: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "El puerto de aMule para la conexión externa (por defecto: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Contraseña para conexiones externas."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Leer la configuración desde el archivo."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "No mostrar ninguna salida en stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Modo detallado - muestra también los mensajes de depuración."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Establece la configuración regional (idioma) del programa."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Escribir las opciones de la línea de comandos al archivo de configuración."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Crear archivo de configuración basado en el archivo de configuración de aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Imprimir la versión del programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forzar compresión ZLIB aunque se conecte a una IP local/LAN (útil cuando se conecta al servidor a través de un túnel VPN que se resuelve a una IP de LAN)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "Añadir una copia de toda la salida de la consola a este archivo de registro (predeterminado: <config-dir>/amuleapi.log)."
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "No escribir un archivo de registro; imprimir solo en la consola."
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalles del archivo"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% terminado"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "¡Bienvenido!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Conectando a amigo"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Tipo de conexión:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Redes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Puerto TCP estándar "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Puerto UDP adicional (Kad / búsqueda global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para el reenvío del puerto del \"router\""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Inicialización"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ya está intentando descargar el archivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Autoactualizar la lista de servidores al inicio"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar aMule automáticamente al iniciar sesión"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para los enlaces ed2k://"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registrar aMule para los enlaces magnet:"
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Examinar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Carpeta para los archivos temporales de las descargas"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para lectura!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amigos"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Mostrar los &detalles"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Añadir un amigo"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Eliminar al amigo"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Enviar un &mensaje"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ver los archivos"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Asignar un puesto reservado de amigo"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "¿Seguro que desea borrar al amigo seleccionado?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "¿Seguro que desea borrar los amigos seleccionados?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2507,11 +2456,11 @@ msgstr ""
 "No se le permite asignar más de un puesto reservado.\n"
 " Solo se ha asignado uno."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selección múltiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2519,206 +2468,205 @@ msgstr ""
 "No se le permite asignar más de un puesto reservado.\n"
 " Solo se ha asignado uno."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Enviar un mensaje al usuario"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensaje a enviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Borrar de Amigos"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Enviar un mensaje"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este archivo"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En la cola: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Se ha pedido otro archivo"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Esperando un puesto de subida"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "En la cola: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Subiendo"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ninguno"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sí"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP cancelada"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "El URL a descargar no puede estar en blanco"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "No se ha podido crear la petición HTTP para %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Descarga HTTP: cuerpo de respuesta vacío para %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "No se ha podido mover el archivo descargado a %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargado %s (%llu bytes)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "La URL %s ha devuelto: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descarga HTTP fallida para %s: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 No autorizado para %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "GeoLite2-Country.mmdb migrado a %s"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country: Se ha seleccionado MaxMind como fuente GeoIP, pero no se ha configurado ninguna clave de licencia. Abra Preferencias -> IP2Country, pegue su clave de licencia gratuita de MaxMind y haga clic en «Actualizar ahora»."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country: Se ha seleccionado URL personalizada como fuente GeoIP, pero no se ha configurado ninguna URL. Abra Preferencias -> IP2Country e introduzca una URL que apunte a un archivo .mmdb (o .gz / .tar.gz que contenga uno)."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country: La resolución de la URL de la descarga de GeoIP ha fallado."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Descargar nuevo %s desde %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "La descarga del archivo %s ha fallado, cancelando actualización."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Error al borrar el archivo %s, actualización cancelada."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Error al renombrar el archivo %s, actualización cancelada."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Se ha actualizado %s con éxito"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Error actualizando %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "Se ha producido un error al descargar el DB-IP del mes actual; se reintenta con la URL del mes anterior."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Error al descargar %s desde %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Cargando los filtros de IP 'ipfilter.dat' e 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Error al cargar el archivo ipfilter.dat '%s', el formato encontrado es desconocido."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Error al cargar el archivo ipfilter.dat '%s', no se ha podido abrir el archivo."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Cargado %u rango de IP desde '%s'."
 msgstr[1] "Cargados %u rangos de IP desde '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u línea malformada fue descartada."
 msgstr[1] "%u líneas malformadas fueron descartadas."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Error al renombrar el nuevo archivo %s, actualización cancelada."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "El filtro de IP está listo"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2726,860 +2674,828 @@ msgstr ""
 "Inicializar desde \n"
 "clientes conocidos"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP no válida para la inicialización"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Puerto no válido para la inicialización"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Por favor, rellene todos los campos requeridos"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mensaje"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "¿Seguro que quiere descargar un nuevo archivo nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Si lo hace, borrará sus nodos actuales y reiniciará la conexión Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "¿Quiere continuar?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: palabra de búsqueda demasiado corta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: la palabra de búsqueda ya está en la lista de búsqueda: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Error al leer el archivo nodes.dat - es demasiado antiguo. Esta versión (0) ya no está soportada."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Leído %u contacto Kad"
 msgstr[1] "Leídos %u contactos Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Contactos no encontrados; por favor, inicialice o descargue un archivo nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Solo %d contacto Kad disponible, nodes.dat no escrito"
 msgstr[1] "Solo %d contactos Kad disponibles, nodes.dat no escrito"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Escrito %d contacto Kad"
 msgstr[1] "Escritos %d contactos Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Usuario Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: Kad no está conectado."
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: ya hay una búsqueda de notas en ejecución para este archivo"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: el archivo no está en la lista de compartidos, en la cola de descargas ni en los resultados de búsqueda"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: otra búsqueda Kad (por ejemplo, una búsqueda de fuentes) ya está usando el hash de este archivo. Inténtelo de nuevo en breve"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: PrepareLookup falló"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nombre del archivo"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tamaño del archivo"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Media de compartición"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Pedido"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fuentes completas"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "AVISO: la lista de archivos conocidos está dañada, contiene una cabecera inválida."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Error al cargar una entrada de la lista de archivos conocidos, el archivo debe de estar dañado"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida en lista de archivos conocidos, el archivo debe de estar dañado: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Error desconocido %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "No se puede obtener la descripción del error para el error %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Creando el hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Completando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Completado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Debe especificar una contraseña no vacía."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "¡Contraseña incorrecta, no es un hash MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Error de conexión"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "Conexión Externa perdida - saliendo."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "La conexión EC ha fallado. Respuesta vacía."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Conexión externa: respuesta errónea, error al establecer la comunicación. Conexión cerrada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "¡Éxito! Conexión establecida con aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "¡Éxito! Conexión establecida."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Conexión externa: acceso denegado, razón: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: error al establecer la comunicación."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Socket de escucha: correcto."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERROR: no se puede escuchar en el puerto TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERROR: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVISO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Conectado (Id Baja)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Conectado (Id Alta)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Conectado (tras cortafuegos)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Servidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "IP del servidor: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "No conectado"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Puerto TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Puerto TCP: no está listo"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Puerto UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Puerto UDP: no está listo"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Información del cliente"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Límite de subida"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Límite de descarga"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostrar aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Ocultar aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Salir"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menú de la bandeja de aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Límites de velocidad:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "SU: ninguno"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "SU: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DES: ninguno"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DES: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocidad de descarga: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocidad de subida: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Alias: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "¡No hay ningún alias seleccionado!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID de cliente: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nombre del servidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP del servidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "No conectado"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Firma digital: activada"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Firma digital: desactivada"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Tiempo en ejecución: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Archivos compartidos: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clientes en cola: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total DES: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total SU: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "Pegar eD2k o enlaces magnet aquí"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "Añadir enlaces"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Haga clic aquí para añadir el enlace eD2k del campo de texto a la cola de descargas."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Los eventos se muestran aquí. Para obtener una lista completa de eventos, vaya al registro de la pestaña de servidores."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Cargando..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Número de usuarios en el servidor al que está conectado..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Usuarios: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Usuarios conectados al servidor actual y una estimación del número total de usuarios."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Su: 0.0 | De: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Índice medio actual de subidas y descargas. Si está habilitado, los números entre paréntesis indican la sobrecarga en la comunicación con el cliente."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Muestra el estado de la conexión y las transferencias activas. Las flechas rojas significan que está desconectado, las flechas amarillas significan que tiene Id Baja (detrás de cortafuegos) y las flechas verdes significan que tiene Id Alta (el tipo de conexión óptima)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "No conectado..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Conectado al servidor."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Buscar"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nombre:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parámetros adicionales"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrado"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipo de archivo"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archivos comprimidos"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imágenes de CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Imágenes"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programas"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Textos"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vídeos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensión"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Tamaño mínimo"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Tamaño máximo"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilidad"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrar el resultado"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Invertir el resultado"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Ocultar los archivos conocidos"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Comenzar"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Más"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Pide a los pares Kad que ya han respondido que amplíen la búsqueda. Cada clic consulta al siguiente par más cercano para obtener más contactos (KADEMLIA_FIND_VALUE_MORE), revelando coincidencias de archivos adicionales que la frontera alfa inicial de la búsqueda no encontró."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarga"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Reiniciar los campos"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Quita de la lista las descargas completadas"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fuentes del archivo:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "General"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nombre completo:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Archivo met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tamaño:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Estado del archivo de partes:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Visto completo por última vez:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fuentes encontradas:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Fuentes transfiriendo:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Número de partes:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibles:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Tasa de datos:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Tiempo activo de descarga: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferido:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamaño completado:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestión inteligente de corrupción"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdido por corrupción:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Ganado por compresión:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paquetes salvados por I.C.H.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "Compartiendo"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Peticiones"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Peticiones aceptadas"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Datos transferidos"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Media de compartición"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fuentes completas"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "Compartido desde"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "Última subida"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "Información del medio"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Duración :"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Tasa de bits :"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Códec :"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Artista :"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Título:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nombres del archivo"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Tomar"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Limpiar"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Aceptar"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comentario/Valoración del archivo (el texto será visible para todos los usuarios)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3587,570 +3503,568 @@ msgstr ""
 "Para una película, puede poner su duración, historia, idioma...\n"
 "y si es una falsificación puede informar a los demás usuarios de aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Calidad del archivo"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Sin evaluar"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Inválido / Corrupto / Falsificación"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Pobre"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Aceptable"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Buena"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excelente"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Elija la valoración del archivo o advierta a otros usuarios si no es válido..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "Obtener desde Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Descargando; por favor, espere..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Tamaño desconocido"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Información requerida"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Dirección IP:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nombre del usuario:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Añadir"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Media de la sesión"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidad de subida"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Descargas activas"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Árbol de estadísticas"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nombre del usuario:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software del cliente:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versión del cliente:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Dirección IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID del usuario:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP del servidor:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nombre del servidor:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Ofuscación:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferencias al cliente"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Solicitud actual:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Velocidad media de subida:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Velocidad media de descarga:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Subido (sesión):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Descargado (sesión):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Subido (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Descargado (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador de DE/SU:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificación segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Rango de cola:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Puntuación de cola:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Alias"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - la mula multiplataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Este es el nombre que ven los otros usuarios al conectarse con usted."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "El retardo antes de mostrar los mensajes emergentes."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Esto especifica el idioma usado en los controles."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Comprobar periódicamente si hay una versión nueva"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Habilitando esto hará que aMule compruebe si existe una versión nueva al inicio, y una vez al día mientras se ejecuta"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra una entrada en el SO por usuario para arrancar automáticamente aMule al iniciar sesión. Si se mueve el binario de aMule, tras ello deberá lanzarse una vez manualmente para actualizar esa entrada."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Hace que aMule sea el manejador predeterminado de los enlaces ed2k://, de modo que al hacer clic en uno desde el navegador o el gestor de archivos se abra aquí."
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "aMule solo maneja enlaces magnet compatibles con eD2k (que contengan xt=urn:ed2k:). Los magnets de BitTorrent NO son compatibles y al hacer clic en ellos simplemente no funcionarán. Si usa un cliente BitTorrent (Transmission, qBittorrent, etc.), deje esta opción desactivada."
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Iniciar minimizado"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Habilitando esto, hace que aMule se minimice al inicio."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Preguntar al salir"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Hace que aMule pregunte antes de salir."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Habilitar el icono de la bandeja"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Esto habilita/deshabilita el icono de la bandeja del sistema (o de la barra de tareas)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Ocultar la ventana de la aplicación al pulsar el botón de cerrar"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizar al icono de la bandeja"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Activando esto hace que aMule se minimice a la bandeja del sistema, en vez de a la barra de tareas."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Mostrar notificaciones cuando acabe de descargar"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si se activa, aMule mostrará notificaciones cuando acabe de descargar."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Retardo de los mensajes emergentes: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selección del navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Abrir en una pestaña nueva si es posible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Cuando sea posible, abrir la página web en una nueva pestaña en lugar de en una nueva ventana"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Reproductor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Límites del ancho de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Subida"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Asignación de puesto reservado"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este es el puerto eD2k estándar y no puede ser deshabilitado."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Puerto UDP para peticiones del servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este puerto UDP se usa para peticiones adicionales de eD2k y la red Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Puerto TCP para UPnP (opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo para usuarios avanzados: fija todo el tráfico de aMule a una única interfaz de red, seleccionada de la lista o introducida por nombre (p. ej., tun0, eth0, en0) o por índice. A diferencia de vincularlo a una IP, esto evita que el tráfico se filtre por la ruta predeterminada, lo cual es útil con una VPN. No requiere privilegios elevados."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Número máximo de fuentes descargando un archivo:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autoconectar al iniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconectar al perder la conexión"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Eliminar los servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "reintentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar la lista de servidores al conectar a un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualizar la lista de servidores cuando se conecte un cliente"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usar el sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Usar el control inteligente de Id Baja al conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoconectar sólo a servidores fijos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar la prioridad alta a los servidores añadidos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Añadir los archivos a descargar en modo pausado"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Añadir las nuevas descargas con prioridad automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Intentar descargar antes el primer y último trozo"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo endgame: cambiar a fuentes más rápidas para los bloques finales"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Descargar el siguiente archivo pausado cuando otro se complete"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Solo de la misma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "En orden alfabético"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Reservar el espacio en disco para los archivos nuevos"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva en disco el espacio para los archivos nuevos enteros, reduciendo asíla fragmentación"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Detener las descargas cuando el espacio libre en disco alcance "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción si quiere que aMule compruebe el espacio en disco"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Introduzca el espacio mínimo de disco deseado."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fuentes para archivos raros (< 20 fuentes)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Subidas"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Añadir los nuevos archivos compartidos con prioridad automática"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestión inteligente de corrupción (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "El I.C.H. avanzado confía en todos los hash (no recomendado)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "Extracción de metadatos multimedia"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraer la duración, el bitrate y el códec de los archivos multimedia compartidos"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Cuando está activado, aMule ejecuta ffprobe en cada archivo multimedia compartido para rellenar las columnas de Duración / Bitrate / Códec que otros clientes ven cuando encuentran el archivo en una búsqueda. Requiere tener instalado ffmpeg (el binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "Ruta a ffprobe:"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Ruta completa al binario de ffprobe. Déjelo vacío para que aMule lo detecte automáticamente al iniciar."
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4158,383 +4072,382 @@ msgstr ""
 "Las descargas completadas se guardan aquí. Todos los archivos de esta carpeta se compartirán automáticamente con otros usuarios.\n"
 "Si esta carpeta contiene archivos que no quiere compartir, apúntelo a un sub-directorio exclusivo para aMule."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Directorios compartidos por el núcleo. Introduzca una ruta para añadir uno.)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Ruta absoluta de un directorio en la máquina del núcleo, p. ej. /home/user/compartido"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartir todos los subdirectorios bajo éste, incluyendo los creados en el futuro."
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Borrar"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Haga clic derecho en los iconos de carpetas para compartirlas recursivamente)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Compartir los archivos ocultos"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Buscar cambios automáticamente en los directorios compartidos"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Seguir enlaces simbólicos en las carpetas compartidas"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "Excluir archivos coincidentes:"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Patrones comodines separados por '|', p.ej., .DS_Store|Thumbs.db|*.tmp. Los archivos cuyo nombre coincida no serán compartidos. No distingue mayúsculas/minúsculas."
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "Los patrones son expresiones regulares"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Cuando se activa, el campo completo es una expresión regular ('|' es OR). Cuando no se activa, es un listado de comodines separados por '|'."
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 s"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tiempo de promedio del gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala del gráfico de las conexiones: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Escala de la gráfica de descarga:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Colores: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rejilla"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Promedio de descarga en ejecución"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Promedio de descarga en la sesión"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Promedio de subida en ejecución"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Conexiones activas"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuales"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nodos Kad activos"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Árbol"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versiones de clientes a mostrar (0=sin límite)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "¡¡¡ AVISO !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Número máximo de nuevas conexiones cada 5 segundos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "Búsquedas simultáneas de fuentes Kad"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de búsqueda de fuentes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo re‐solicitud de fuentes (minutos)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño del búfer de archivo: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acceso a ficheros mapeados en memoria (menor uso de memoria)"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapea los ficheros de partes en memoria en vez de usar un buffer en la pila, reduciendo la huella de memoria del proceso. Puede reducir la velocidad de descarga en algunos discos; es mejor usarlo en entornos con poca memoria o nodos que principalmente suban datos."
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño de cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de la conexión al servidor: desactivado"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Deshabilitar el modo de reposo del ordenador"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar el \"Gestor rápido de enlaces eD2k\" en todas las ventanas."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información adicional en las pestañas de las categorías"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Mostrar la versión de la aplicación en el título"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Mostrar las tasas de transferencia en el título"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Antes del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Después del nombre de la aplicación"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Mostrar el ancho de banda adicional usado"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientación vertical de la barra de herramientas"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Orden automático de columnas (reordena las filas según cambian sus valores)"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Archivos de la cola de descarga"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Mostrar el porcentaje de progreso"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Mostrar la barra de progreso"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar el acceso de invitado"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Contraseña de invitado para el servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "Ejecutar webserver al iniciar (obsoleto)"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4542,304 +4455,303 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4851,11 +4763,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4871,11 +4783,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4885,504 +4797,504 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Compartidos"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Deshabilitado [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/s"
 msgstr[1] "bytes/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "s"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minutos"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "horas"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "días"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "Todo"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "El resto"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Detenido"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeo"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archivos"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Texto"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Activo"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Usando el directorio de configuración: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando que la tarea de conversión del archivo de partes termine..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importando %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Leyendo el directorio temporal"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Obteniendo información básica del archivo de información de descarga"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Creando el archivo de destino"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Cargando datos desde un antiguo archivo de descarga (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Guardando bloque de datos en un nuevo archivo de descarga (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Obteniendo información del archivo fuente de descarga"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Añadiendo descarga y guardando el nuevo archivo de partes"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importar archivos de partes"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estado"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash del archivo"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disco: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "¡Por favor, elija un directorio donde buscar descargas temporales! (se incluirán los subdirectorios)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "¿Quiere que los archivos originales de las descargas importadas con éxito sean borrados?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "¿Quiere borrar las fuentes?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERROR: no se ha podido crear el archivo de partes"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Intentando cargar una copia de seguridad del archivo met desde %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERROR: no se ha podido abrir el archivo part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERROR: el archivo part.met tiene tamaño 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERROR: versión de archivo part.met inválida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Error: %s (%s) está dañado (etiquetas erróneas: %s), no se puede cargar el archivo."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERROR: %s (%s) está dañado (número de etiquetas erróneo), no se puede cargar el archivo."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Intentando recuperar información del archivo..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Recuperando un archivo sin nombre - se intenta recuperarlo como RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperada toda la información disponible del archivo :D - Intentando usarla..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "No se puede recuperar la información del archivo :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Error al abrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVISO: %s puede estar dañado (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERROR al guardar el archivo de partes: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Error de E/S al guardar el archivo de partes: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "Se escribieron 0/desconocidos bytes a '%s' -- conservando .part.met existente."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Error al guardar el archivo part.met.seeds para %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Se ha guardado %i semilla de fuentes para el archivo de partes: %s (%s)"
 msgstr[1] "Se han guardado %i semillas de fuentes para el archivo de partes: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "No se puede leer el archivo de semillas para el archivo de partes %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Error al leer el archivo de semillas del archivo de partes (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte corrupta encontrada (%d) en %d archivo de partes %s - Resultado del hash del archivo |%s| Hash del archivo |%s|"
 msgstr[1] "Parte corrupta encontrada (%d) en %d partes del archivo %s - Resultado del hash del archivo |%s| Hash del archivo |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte completada encontrada (%i) en %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Recálculo del hash terminado %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Error imprevisto mientras se completaba %s. Archivo pausado"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Descarga terminada: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5391,306 +5303,306 @@ msgstr ""
 "Descarga terminada: \n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Borrando archivo: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: no se puede crear el hash de la parte descargada - hashset incompleto para '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROR: no se puede crear el hash de la parte descargada - hashset incompleto (%s). Esto no debería pasar nunca"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de '%s' marcada completa, pero el archivo de partes es más corto de lo esperado (tiene %llu bytes, necesita %llu); reabriendo hueco para re-descargarlo."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Se ha alcanzado el final del fichero al crear el hash de la parte descargada %u con longitud %u (máximo %u) del archivo de partes '%s' con longitud %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: ¡no hay suficiente espacio libre en el disco! Se pausa el archivo: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte descargada %i corrupta en el archivo: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: recuperada parte corrupta %i de %s -> Bytes salvados: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Asignando"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espacio en disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "Letón"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directorios"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Archivos"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Seguridad"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Firma digital"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Depurando"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5700,15 +5612,15 @@ msgstr ""
 "    %PARTFILE - ruta completa al archivo\n"
 "    %PARTNAME - nombre del archivo"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "El icono de la bandeja requiere libayatana-appindicator3 en tiempo de compilación."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "No disponible en Wayland: el protocolo no informa cuando una ventana es minimizada, por lo que esta opción no puede interceptar el botón de minimizar del sistema. Como alternativa: lanzar aMule con `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5724,35 +5636,35 @@ msgstr ""
 "aMule funciona bien sin cambiar ninguno de\n"
 "estos parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Error al conectar configuración con programa, con el ID %d y clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Error al transferir datos desde la configuración al programa, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "El tipo de proxy al que se está conectando"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Error al transferir datos desde el programa a la configuración, con el ID %d y la clave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Contraseña Admin"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5760,39 +5672,39 @@ msgstr ""
 "aMule debe reiniciarse para aplicar los cambios:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- El puerto TCP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- El puerto UDP ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- La interfaz de red vinculada ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- El puerto para la conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- La aceptación de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- La interfaz de conexión externa ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- El soporte de ofuscación de protocolo ha cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- Ajustes de amuleapi modificados.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5800,7 +5712,7 @@ msgstr ""
 "Su lista autoactualizable de servidores esta vacía.\n"
 "Se desactivará 'Autoactualizar la lista de servidores al inicio'."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5808,32 +5720,32 @@ msgstr ""
 "Tiene habilitadas las conexiones externas, pero no ha especificado ninguna contraseña.\n"
 "Las conexiones externas no pueden ser habilitadas a menos que especifique una contraseña válida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Carpeta temporal cambiada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Red ED2K habilitada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "El patrón de exclusión de archivos compartidos no es una expresión regular válida. El filtro ha quedado deshabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5841,7 +5753,7 @@ msgstr ""
 "eD2k y Kad están desactivados.\n"
 "No podrá conectarse hasta que active al menos uno de ellos."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5849,7 +5761,7 @@ msgstr ""
 "Kad no se inicia si el puerto UDP está deshabilitado.\n"
 "Habilite un puerto UDP o deshabilite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5859,68 +5771,68 @@ msgstr ""
 "DEBE reiniciar aMule ahora.\n"
 "Si no reinicia ahora, no se queje si sucede algo malo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "No se pudo registrar aMule para arrancar automáticamente al iniciar sesión. El almacén de arranque automático podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "No se pudo eliminar la entrada de arranque automático."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Arranque automático"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "Registrar manejador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule sólo maneja magnet:\\\\ compatibles con eD2k. Si reemplazas el manipulador de magnet:\\\\ actual (%s), los enlaces magnet de BitTorrent dejarán de funcionar: aMule no puede descargar contenido BitTorrent. ¿Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Otra aplicación es actualmente el controlador predeterminado para estos enlaces (%s). ¿Reemplazarlo por aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "No se pudo registrar aMule como el manejador de URL. El almacenamiento del registro podría ser de sólo lectura."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "No se pudo retirar el manejador URL del registro."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "El servidor web y el API de aMule requieren que las conexiones externas estén habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "El servidor web aMule está obsoleto. Considere usar el API de aMule en su lugar."
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5930,64 +5842,64 @@ msgstr ""
 "Por favor, introduzca al menos un URL que apunte a un archivo server.met válido.\n"
 "Haga clic en el botón \"Lista\" junto a esta casilla para introducir un URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Archivos temporales"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Archivos entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Firmas digitales"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Elija una carpeta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Excluiría %u de %u archivo compartido"
 msgstr[1] "Excluiría %u de %u archivos compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Buscar un reproductor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Seleccione el navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "Seleccione el binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Ejecutable %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe no se encuentra en la ruta PATH o en las ubicaciones estándar de instalación. Instala ffmpeg (el cual provee ffprobe) o utiliza Examinar para elegir un binario manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "¿Desea restablecer los ajustes de esta página a sus valores por defecto?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "Restablecer a valores por defecto"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editar la lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5995,114 +5907,114 @@ msgstr ""
 "Añada aquí los URL para descargar los archivos server.met.\n"
 "Sólo un URL por línea."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "Error al actualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "Datos de MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "Fuente personalizada"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "Datos de DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado: Cargado%s"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado: Cargado%s -%s"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: No se ha podido cargar. Haz clic en 'Actualizar ahora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: No encontrado. Haz clic en 'Actualizar ahora' para descargarlo."
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualización: %d segundo"
 msgstr[1] "Intervalo de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tiempo medio del gráfico: %d minuto"
 msgstr[1] "Tiempo medio del gráfico: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica de conexiones: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño del búfer de archivo: %d byte"
 msgstr[1] "Tamaño del búfer de archivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño de la cola de subida: %d cliente"
 msgstr[1] "Tamaño de la cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización de la conexión al servidor: %d minuto"
 msgstr[1] "Intervalo de actualización de la conexión al servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización de la conexión al servidor: deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ejecutar comando en el evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Habilitar la ejecución de comandos en el núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comando del núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Habilitar la ejecución de comandos en la interfaz"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comando de la interfaz:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Las siguientes variables serán sustituidas:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6110,1084 +6022,1083 @@ msgstr ""
 "Estas carpetas parecen ubicaciones sensibles o de sistema:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartirlas recursivamente publicará todos los archivos en las redes eD2k/Kad. ¿Realmente quiere hacerlo?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Escaneando por subcarpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Actualizando carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Escaneadas %u carpetas..."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Carpeta compartida"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Error de búsqueda"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Aviso de búsqueda"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "No se puede realizar una búsqueda en eD2k si no se está conectado a eD2k"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "No hay ninguna palabra para buscar con Kad - cancelada"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Error imprevisto al intentar la búsqueda en Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Búsqueda Kad: solicitados más resultados a otro par."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Búsqueda Kad: no quedan pares a los que volver a pedir más resultados (límite alcanzado o aún sin respuestas)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID del archivo"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Duración"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Tasa de bits"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Códec"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Descargar en la categoría"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtener %s para este archivo"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Buscar archivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marcar como archivo conocido"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar el enlace eD2k al portapapeles"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Actualmente no estás conectado a un servidor que admita la función de búsqueda de 'Archivos Relacionados'"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Cancelada"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nuevo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Error al conectar a todos los servidores ofuscados listados. Se va a dar otra pasada sin ofuscación."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Error al conectar a todos los servidores ofuscados listados. Se va a dar otra pasada sin ofuscación."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Error al conectar a todos los servidores. Se va a dar otra pasada."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Error al conectar a todos los servidores. Se va a dar otra pasada."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolo eD2k deshabilitado en las preferencias, no se hace la conexión."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "No se han encontrado servidores válidos a los que conectar en la lista de servidores"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Conectado a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Conexión establecida en: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Error fatal al hacer la conexión. La conexión a Internet podría estar caída"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Conexión perdida con %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) parece estar caído."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar lleno."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Se reintentará la conexión automática al servidor en %d segundo"
 msgstr[1] "Se reintentará la conexión automática al servidor en %d segundos"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Error al conectar con %s (%s:%i)."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERROR: socket no válido en la comprobación de tiempo de espera"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Tiempo de espera agotado al intentar conectar con %s (%s:%i)."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Recibido un resultado tardío de búsqueda de DNS, se descarta."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Cargando el archivo server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "¡Archivo server.met no encontrado!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Error al cargar el archivo server.met '%s', el formato encontrado es desconocido."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "¡Error al abrir server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Archivo server.met dañado, encontrada etiqueta de versión no válida: 0x%x, tamaño %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i servidor encontrado en server.met"
 msgstr[1] "%i servidores encontrados en server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d servidor añadido"
 msgstr[1] "%d servidores añadidos"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Error: el fichero 'server.met' está dañado: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Error de E/S al leer 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Servidor no añadido: [%s:%d] no especifica un puerto válido."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Servidor no añadido: la IP de [%s:%d] está filtrada o no es válida."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Servidor no añadido: se ha encontrado un servidor con un par IP:Puerto [%s:%d] que coincide en la lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Servidor añadido: servidor en [%s:%d] usando el nombre '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Está conectado al servidor que está intentando borrar. Por favor, desconéctese primero."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Error al abrir '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "¡Error al guardar server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL no válido"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Descarga de la lista de servidores finalizada desde %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "No se ha encontrado una entrada de dirección en 'addresses.dat'. Por favor, pegue una lista de servidores válida en este archivo para poder actualizar de forma automática la lista de servidores"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Descargando lista de servidores de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "AVISO: ha especificado un URL inválido para la actualización automática de servidores: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "No hay ningún URL válido para la autodescarga de server.met en addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Error al descargar la lista de servidores desde %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "El servidor local está filtrado por los filtros de IP, ¡conectando a un servidor diferente!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nombre del servidor"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Dirección"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Puerto"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descripción"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Usuarios"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Servidor fijo"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "Flags TCP"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "Flags UDP"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Está conectado a un servidor que está intentando borrar. Desconéctese primero. El servidor NO ha sido borrado."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nombre desconocido)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "¿Seguro que quiere eliminar el servidor fijo %s?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Servidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectar al servidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marcar el servidor como fijo"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Desmarcar el servidor como fijo"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar los servidores como fijos"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Desmarcar los servidores como fijos"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Borrar el servidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Borrar los servidores"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Eliminar todos los servidores"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copiar los enlaces eD2k al portapapeles"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconectar al servidor"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "¿Seguro que desea borrar todos los servidores?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "¿Seguro que desea borrar el servidor seleccionado?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "¿Seguro que desea borrar los servidores seleccionados?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERROR: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVISO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "El servidor %s (%s) rechazó nuestro login (no se asignó ID de cliente). Desconectando."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "El nuevo ID de cliente es %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVISO: ¡ha recibido Id Baja!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tEsto sucede porque está detrás de un cortafuegos o de un \"router\"."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPara obtener más información, diríjase a https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "¡Información desconocida del servidor recibida! - demasiado pequeña"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Recibido %d servidor nuevo"
 msgstr[1] "Recibidos %d servidores nuevos"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Guardado de la lista de servidores completado."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "El servidor ha rechazado el último comando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Paquete erróneo recibido desde el servidor: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Error no gestionado mientras se procesaba un paquete del servidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "No se puede crear un hilo de resolución de DNS para conectar con %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "La IP %s (%s) del servidor está filtrada. No se hace la conexión."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "usando ofuscación de protocolo."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Conectando a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "No se puede resolver dns para el servidor %s: ¡no se puede conectar!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "Registro de aMuleGUI"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Servidor no añadido: IP o nombre de host no especificado."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor no añadido: el par servidor-puerto dado no es válido."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Estado de eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Tipo de conexión:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Conectado"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Estado de Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Ejecutándose en modo Red Local"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "En ejecución"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID de cliente Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estado de la conexión:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tras cortafuegos - abra el puerto TCP %d en su \"router\" o cortafuegos"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estado de la conexión UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tras cortafuegos - abra el puerto UDP %d en su \"router\" o cortafuegos"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estado tras cortafuegos: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "No se requiere amigo - puerto TCP abierto"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "No se requiere amigo - puerto UDP abierto"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Sin amigo"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Conectando a amigo"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectando a amigo en %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fuentes indizadas:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Palabras clave indizadas:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notas indizadas:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Carga indizada:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Media de usuarios:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Media de archivos:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "No está en ejecución"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Añadiendo archivo %s a compartidos"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i archivo compartido"
 msgstr[1] "Encontrados %i archivos compartidos"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Encontrado %i archivo compartido, %i desconocido"
 msgstr[1] "Encontrados %i archivos compartidos, %i desconocidos"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "Se excluyó %i archivo de compartidos por el filtro"
 msgstr[1] "Se excluyeron %i archivos de compartidos por el filtro"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERROR: intentando compartir %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Directorio compartido no encontrado, se omite: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No se han encontrado archivos para compartir en el directorio: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidad de descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidad de subida"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Partes disponibles"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Estado de la subida"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Estado de la descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nombre del archivo local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Lista de compartidos"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Partes obtenidas"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Ruta del directorio"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Añadir comentario/valoración"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editar comentario/valoración"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Renombrar"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "Verificar datos locales"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Añadir los archivos de la colección a la lista de descargas"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiar el &URI magnético al portapapeles"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiar el enlace eD2k al portapapeles (&Fuente)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiar el enlace eD2k al portapapeles (Fuente) (&Con opciones de cifrado)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiar el enlace eD2k al portapapeles (&Nombre del host)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiar el enlace eD2k al portapapeles (Nombre del host) (&Con opciones de cifrado)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiar el enlace eD2k al portapapeles (información de &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiar el enlace eD2k al portapapeles (información de &AICH + fuente)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "La verificación de datos locales en archivos de partes no está aún implementada: %s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Necesita Id Alta para crear un enlace fuente válido"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nombre del archivo remoto"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Datos subidos (sesión (total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Tráfico adicional total (paquetes): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Tráfico adicional por peticiones de archivos (paquetes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Tráfico adicional por intercambio de fuentes (paquetes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Tráfico adicional del servidor (paquetes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Tráfico adicional por Kad (paquetes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Tráfico adicional por el cifrado (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Subidas activas: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Subidas en espera: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total de sesiones de subida satisfactorias: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de sesiones de subida erróneas: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tiempo medio de subida: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Datos descargados (sesión (total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fuentes encontradas: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Descargas activas (trozos): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Índice de SU:DE de la sesión (total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Velocidad media de descarga (sesión): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Velocidad media de subida (sesión): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Velocidad máxima de descarga (sesión): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Velocidad máxima de subida (sesión): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconexiones: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tiempo desde la primera transferencia: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Conectado al servidor desde hace: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Conexiones activas (estimado): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Alcanzado límite máximo de conexiones: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Media de conexiones (estimada): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexiones (estimado): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clientes"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Desconocidos: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrados: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Bloqueados: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i, conocidos: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servidores activos: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servidores caídos: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servidores borrados: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servidores filtrados: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Usuarios en servidores activos: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Archivos en servidores activos: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Total de usuarios: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Total de archivos: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupación de servidores: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de archivos compartidos: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Tamaño total de los archivos compartidos: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Tamaño medio de archivo: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema operativo"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "No recibido"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Conexiones activas (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "No disponible"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nunca"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "El comando '%s' con pid '%d' ha terminado con el código de salida '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Ejecute <str> y salga."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formato de IP no válido. Use xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Este comando requiere un argumento. Argumentos válidos: 'all' (todo), nombre de archivo o un número.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Procesando por hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Procesando por nombre de archivo: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Este comando requiere un argumento. Argumentos válidos: un hash de archivo.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Número inválido\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Hash no válido (la longitud debería ser exactamente 32 caracteres)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7197,7 +7108,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7207,7 +7118,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7215,82 +7126,80 @@ msgstr ""
 "Tipo de búsqueda sin definir.\n"
 "Escriba 'help search' para obtener más ayuda.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Archivo de descarga: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Solicitud fallida con un error desconocido."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "La operación ha tenido éxito."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Solicitud fallida con el siguiente error: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "El filtrado de IP para clientes está %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Apagado"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Encendido"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "El filtrado de IP para servidores está %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "El nivel de filtrado de IP actual es %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Límites del ancho de banda: subida: %u kB/s, bajada: %u kB/s\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "La rotación de fuentes del modo endgame es %s.\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Búsqueda iniciada (id %u).\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Conectado a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Conectando ahora"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "tras cortafuegos"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "correcto"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7299,7 +7208,7 @@ msgstr ""
 "\n"
 "Descarga:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7308,7 +7217,7 @@ msgstr ""
 "\n"
 "Subida:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7317,7 +7226,7 @@ msgstr ""
 "\n"
 "Clientes en cola:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7326,46 +7235,46 @@ msgstr ""
 "\n"
 "Fuentes totales:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Archivo de partes]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "Búsqueda expirada o ID desconocido. Inicie una nueva búsqueda.\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados de la búsqueda: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progreso de la búsqueda: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progreso de la búsqueda no disponible"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Recibida una respuesta desconocida desde el servidor, código de operación = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Mostrar una breve información de estado."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Mostrar el estado de la conexión, la velocidad subida/descarga actual, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Mostrar el árbol completo de estadísticas."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7379,11 +7288,11 @@ msgstr ""
 "\n"
 "Ejemplo: 'statistics 5' mostraría sólo las 5 versiones más comunes de cualquier cliente.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Terminar aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7393,35 +7302,35 @@ msgstr ""
 "Esto termina también el cliente de modo texto, ya que no se puede\n"
 "usar sin un núcleo funcionando.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recargar el objeto dado."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recargar la lista de archivos compartidos."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recargar la tabla de filtrado de IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Recargar la tabla actual de filtrado de IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Actualizar la tabla de filtrado de IP desde URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Si se omite el URL, se usará el URL de las preferencias."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Conectar a la red."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7433,35 +7342,35 @@ msgstr ""
 "conectarse solo a ese servidor. La IP debe ser una dirección IPv4,\n"
 "o un nombre DNS que se pueda resolver."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Conectar a eD2k solamente."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Conectar a Kad solamente."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desconectado de la red."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Esto le desconectará de todas las redes a las que está actualmente conectado.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desconectarse sólo de eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desconectarse sólo de Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Añadir un enlace eD2k o magnético al núcleo."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7479,51 +7388,51 @@ msgstr ""
 "\n"
 "El enlace magnético debe contener el hash eD2k y el tamaño del archivo.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Establecer el valor de una preferencia."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Establecer las preferencias de filtrado de IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activar el filtrado de IP para clientes y servidores."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Desactivar el filtrado de IP para clientes y servidores."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activar/Desactivar el filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activar el filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Desactivar el filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activar/Desactivar el filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activar el filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Desactivar el filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Seleccionar el nivel de filtrado de IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7531,71 +7440,71 @@ msgstr ""
 "Los niveles válidos de filtrado están en el rango 0-255, y el valor por\n"
 "defecto (inicial) es 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Establecer los límites de ancho de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "El valor dado a estos comandos ha de ser en kilobytes/s.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Establecer el límite de ancho de banda de subida."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "El valor dado ha de ser en kilobytes/s.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Establecer el límite de ancho de banda de descarga."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "Habilitar o deshabilitar la rotación de fuentes al final de la descarga."
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "El valor dado debe ser 1/ON (habilitar) o 0/OFF (deshabilitar).\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obtener y mostrar un valor de preferencias."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obtener las preferencias de filtrado de IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obtener el estado del filtrado de IP para clientes y servidores."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obtener el estado del filtrado de IP solo para clientes."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obtener el estado del filtrado de IP solo para servidores."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Obtener el nivel de filtrado de IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obtener los límites de ancho de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "Obtener el estado de rotación de fuentes de final de la descarga."
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Ejecutar una búsqueda."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7629,23 +7538,23 @@ msgstr ""
 "Ejemplo: 'search global linux iso --type Iso --min-size 100M' devolverá\n"
 "resultados de \"linux iso\" de tipo de archivo Iso de al menos 100 MiB.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Ejecutar una búsqueda global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Ejecutar una búsqueda local"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Ejecutar una búsqueda kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "Mostrar los resultados de una búsqueda."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7653,11 +7562,11 @@ msgstr ""
 "Devuelve los resultados de una búsqueda.\n"
 "Opcionalmente, acepta un id de búsqueda (de 'search ...'); si no se proporciona ningún id, devuelve los resultados de la búsqueda iniciada más recientemente.\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Mostrar el progreso de una búsqueda."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7665,11 +7574,11 @@ msgstr ""
 "Muestra el progreso de una búsqueda.\n"
 "Opcionalmente, acepta un id de búsqueda; si no se especifica un id, muestra el progreso de la búsqueda iniciada más recientemente.\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Empezar a descargar un archivo"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7677,80 +7586,80 @@ msgstr ""
 "Se tiene que dar el número de un archivo de la última búsqueda.\n"
 "Ejemplo: 'download 12' inicia la descarga del archivo con el número 12 de la búsqueda anterior.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pausar la descarga."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Reanudar la descarga."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Cancelar la descarga."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Asignar la prioridad de descarga."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Establece la prioridad de la descarga a Baja, Normal, Alta o Automática.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Establecer la prioridad a baja."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Establecer la prioridad a normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Establecer la prioridad a alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Establecer la prioridad a automática."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Mostrar colas/listas."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Mostrar la cola de subida/descarga, la lista de servidores o la lista de archivos compartidos.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostrar la cola de subida."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostrar la cola de descarga."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostrar el registro."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostrar la lista de servidores."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Mostrar la lista de archivos compartidos."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Borrar el registro."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comando obsoleto, use '%s' en su lugar."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7759,261 +7668,258 @@ msgstr ""
 "Este comando está obsoleto y puede ser borrado en el futuro.\n"
 "Use '%s' en su lugar.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente de texto de aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convirtiendo antiguos hashset de AICH en '%s' a 64b en '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "Verificar datos locales (%s): Resultado correcto para %s"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "Verificar datos locales (%s): ¡ERRORES ENCONTRADOS! %s Bloques fallidos: MD4: %s. %s %s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVISO: el nombre de archivo '%s' es incorrecto y se ha renombrado a '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVISO: el archivo '%s' ya existe, se renombra el nuevo a '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "¿Seguro que desea cancelar y borrar todos los archivos de esta categoría?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Se requiere confirmación"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Sólo se permiten 99 categorías."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "¡Demasiadas categorías!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Sin catalogar"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Seleccionar un filtro de vista"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Añadir una categoría"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editar la categoría"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Eliminar la categoría"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Solicitado hashset de un archivo desconocido: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Reanudando las subidas del archivo: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendiendo la subida del archivo: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Error al ejecutar el comando `%s' en el evento `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Descarga completada"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "La ruta completa al archivo."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "El nombre del archivo sin la ruta."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "El hash eD2k del archivo."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "El tamaño del archivo en bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tiempo de actividad de descarga acumulado."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nueva sesión de chat iniciada"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remitente del mensaje."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Espacio agotado"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partición de disco."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Error completando"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Procesando el archivo número %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ha pedido los hash de partes (sólo los usan archivos > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> ¡ El archivo no existe !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, el creador de enlaces eD2k para aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "¡Bienvenido!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parámetros de entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Archivo al que calcular el hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Añadir URL opcionales para este archivo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Introduzca aquí el archivo del que quiera calcular el enlace eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Introduzca aquí el URL que quiere añadir al enlace eD2k: añada \"/\" al final para permitir a aLinkCreator agregar el nombre del archivo actual"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Crear enlace con hashes de partes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ayuda a difundir archivos nuevos y raros más rápidamente, a costa de un tamaño de enlace mayor"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hash de archivo MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Hash del archivo eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Enlace eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Guardar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Abrir un archivo para calcular su enlace eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiar el enlace eD2k calculado al portapapeles"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Guardar como"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Guardar el enlace eD2k calculado en un archivo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Acerca de aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Seleccione el archivo del que quiera calcular el enlace eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "No se puede abrir el portapapeles"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "¡No hay nada que copiar por ahora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleccione el fichero para el enlace eD2k calculado"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "No se puede abrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Por favor, introduzca un nombre de archivo no vacío"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "¡No hay nada que guardar por ahora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8033,167 +7939,159 @@ msgstr ""
 "\n"
 "Distribuido bajo la licencia GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Calculando el hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator está trabajando para usted"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calculando el hash MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calculando los hash eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "¡Cancelado!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Terminado en %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "¡Ya ha añadido ese URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Por favor, introduzca un URL no vacío"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "No se puede abrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "¡Memoria agotada al calcular el hash ed2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i día(s) %i hora(s) %i minuto(s) %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02ud %02uh %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, estadísticas de aMule en línea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Máximo índice de descarga desde que wxCas está ejecutándose"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Máximo índice de descarga absoluto durante ejecuciones anteriores de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Borrar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Detener la actualización automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Guardar imagen de estadísticas en línea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimir imagen de estadísticas en línea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Configuración de las preferencias"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Acerca de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Iniciar la actualización automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Actualización automática detenida"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Actualización automática iniciada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Guardar imagen de estadísticas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estadísticas de aMule en línea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8201,11 +8099,11 @@ msgstr ""
 "Ha habido un problema al imprimir.\n"
 "¿Es posible que su impresora actual no esté configurada correctamente?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8223,375 +8121,364 @@ msgstr ""
 "\n"
 "Distribuido bajo GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh oh, aMule no está ejecutándose..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule ya está ejecutándose"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule se está ejecutando, pero está desconectado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule está conectando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh oh, el estado de aMule es desconocido..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " ha estado en ejecución durante "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " está detenido!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " no está conectado!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " está conectando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " está haciendo algo extraño, ¡compruébelo!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " está conectado a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "apagado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " conectado "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " con "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Total descargado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", subida: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Descarga de esta sesión: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Descargado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, subida: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Compartiendo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " archivo(s), clientes en cola: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tiempo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " en "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Carga media del sistema (1-5-15 minutos): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Tiempo de ejecución del sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Directorio que contiene el archivo amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Introduzca el directorio donde está su archivo amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervalo de actualización en segundos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Generar un archivo de estadísticas con cada evento de actualización"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Introduzca el directorio donde quiere generar la imagen de estadísticas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Subir periódicamente su imagen de estadísticas al servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL del FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Directorio FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Introduzca el URL de su servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Introduzca el directorio del servidor FTP donde poner su imagen de estadísticas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Usuario"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Introduzca el nombre de usuario para conectarse a su servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Introduzca la contraseña de usuario para conectarse a su servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalo de actualización del FTP en minutos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Carpeta que contiene su archivo de firma"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Directorio donde se genera la imagen de estadísticas"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carga la plantilla <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Puerto HTTP del servidor web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Usar la redirección de puertos UPnP en el puerto del servidor web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Puerto UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usar la compresión gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Contraseña de acceso total para el servidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Contraseña de invitado para el servidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permitir el acceso de invitado"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Denegar el acceso de invitado"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Cargar/guardar la configuración del servidor web desde/a aMule remoto"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Ruta al archivo de configuración de aMule. ¡NO USAR DIRECTAMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deshabilitar el intérprete PHP (obsoleto)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompilar las páginas PHP en cada solicitud"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Servidor web de aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "conexión aceptada del cliente web\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERROR: no se puede aceptar la conexión del cliente web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Solicitud fallida con el siguiente error: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Fichero de índice no encontrado: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesión terminada - solicitando conexión\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesión correcta, conectado\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesión correcta, no conectado\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "No hay ninguna sesión - se conectará de nuevo\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sesión creada - solicitando conexión\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Procesando la solicitud [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "Se rechaza leer `pass` de la cadena de consulta de la URL\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Contraseña no especificada, el inicio de sesión no se permitirá."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Comprobando la contraseña\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash de la contraseña incorrecto\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Contraseña correcta\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Contraseña errónea\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "No ha introducido ninguna contraseña. No se permite una contraseña en blanco.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Desconexión solicitada\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Procesando solicitud [redirigida]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (obligatorio)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Acceso directo en el escritorio"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "Iniciar aMule al iniciar sesión"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Eliminar datos de usuario (configuración, servidores ED2K, nodos Kad, archivos parciales)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "Archivos de la aplicación aMule (obligatorio)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Crea un acceso directo de aMule en el escritorio."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Inicia aMule automáticamente cuando el usuario actual inicia sesión (configuración por usuario)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Elimine los archivos de la aplicación aMule, los accesos directos del menú Inicio/escritorio, la entrada del registro para inicio automático, los registros del esquema de URL y la entrada de Agregar o quitar programas (obligatorio)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Elimina permanentemente %APPDATA%\\aMule del usuario actual (aMule.conf, lista de servidores ED2K, nodos Kad, archivos parciales, filtros de IP, lista de amigos). Déjelo sin marcar para conservar su configuración."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8599,7 +8486,7 @@ msgstr ""
 "aMule parece estar en ejecución desde $INSTDIR.\r\n"
 "Por favor, cierre aMule (y aMuleD / aMuleGUI) e inténtelo de nuevo."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8607,11 +8494,11 @@ msgstr ""
 "El demonio de aMule (amuled.exe) parece estar en ejecución desde $INSTDIR.\r\n"
 "Por favor, deténgalo e inténtelo de nuevo."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Eliminando la instalación anterior de aMule en $0..."
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8619,11 +8506,11 @@ msgstr ""
 "No se pudo eliminar la instalación anterior de aMule en $0.\r\n"
 "Por favor, cierre los procesos de aMule en ejecución e inténtelo de nuevo, o desinstale primero la versión anterior manualmente."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecutar el desinstalador."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -21,20 +21,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Näita aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule kaugjuhtimine "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Piiluvaade:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -42,7 +42,7 @@ msgstr ""
 " eMulel põhinev, platvormist sõltumatu, p2p klient \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -51,79 +51,79 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule Meeskond \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMule põhineb \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Sõlmest-Sõlmeni ruutimine põhineb XOR meetrikal.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov <petar@maymounkov.org>\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foorum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Ühendun Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Info puudub"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Lisa Sõber"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Pead sisestama kehtiva IP ja pordi!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informatsioon"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Määratud kasutaja kontrollsumma pole kehtiv!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -132,49 +132,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Ühendus ebaõnnestus "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -183,103 +182,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Ei suuda avada ED2KLinks faili."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad lowid'd."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Ok, lahkun põhiprogrammist..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Nurjunud"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Mõrvan amuleweb tegelase, protsessi id '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Peatan tuuma."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule seiskamine lõpetatud."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule väljumise mälu veajälituse tulemus:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Sinu keelelokaat muudeti süsteemi vaikeväärtuseks seoses konfiguratsiooni muudatustega. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -287,74 +283,70 @@ msgstr ""
 "\n"
 "EC seadistused"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "HOIATUS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "VIGA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web server töötab protsessi id'ga %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei suuda siduda porti määratud aadressiga: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u ei ole kasutatav. Sa saad LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +361,48 @@ msgstr ""
 "Kasuta netstat programmi kontrollimaks kuna port vabaneb\n"
 "ja proovi amule uuesti käivitada."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Ei suutnud luua OnlineSig Faili"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ei suutnud luua aMule OnlineSig Faili"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Tundub et valitud keelelokaat pole sinu karpi installeritud. (Märkus: Ma proovin seda seada sellest hoolimata)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "See on aMule %s käivitamise esimene kord"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "See on testversioon, mida igapäevaselt uuendatakse ja\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "me ei anna mingit garantiid, et see ei lõhu midagi, ei süüta sinu elamist\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ega tapa sinu koera. Sellest hoolimata peaks see olema *turvaline* kasutada.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Rohkem informatsiooni, tuge ja uusi programmi versioone leiad meie kodulehelt,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "aadressil https://amule-org.github.io või meie IRC kanalis #aMule aadressil irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Tunne ennast vabalt suvaliste vigade leidmisest teavitamisel aadressil https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,224 +410,220 @@ msgstr ""
 "Online Allkirja kataloog on VIGANE!\n"
 " Online Allkirja ei kasutata, kuni parandad vea seadetes."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Kettaruumi eraldamine faili '%s' jaoks ebaõnnestus: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "VIGA: Ei suutnud avada logifaili"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "HOIATUS: logifail on tühi, miskit on kapitaalselt viltu."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Log on nullitud"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serveri teade: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Fail %s jäeti vahele, sest soovitud fail pole uuem."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Ebaõnnestus sõlmede nimekirja tõmbamine."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Ebaõnnestus tõmmatud versiooni kotrollfaili avamine"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Versiooni kontrollfail on korrumpeerunud"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Kasutad aegunud aMule versiooni!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sinu aMule versioon on %i.%i.%i ja uusim versioon on %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "HOAITUS: Sinu aMuled versioon on vananenud: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Sinu aMule koopia on ajakohane."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Versiooni kontrollfaili tõmbamine ebaõnnestus"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kasutajaid: %s | Faile: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kasutajaid: E: %s K: %s | Faile E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Ühtegi võrku pole valitud"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "koos LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "koos HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ühendatud %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ühendun %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "eD2k ühendus katkestatud."
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad käivitatud."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad peatatud."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Ühendus Kad võrk (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad võrku ei saa kasutada kui seadetes on UDP port väljalülitatud, ei ühendu."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad on seadetes väljalülitatud, ei ühenda."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "VIGA: aMule deemonit ei saa katkestatud Välisühendustega kasutada. Välisühenduste lubamiseks kasuta tavalist aMule, käivita amuled võtmega '--ec-config' või määra võtme \"AcceptExternalConnections\" väärtuseks 1 konfiguratsioonifailis ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "VIGA: Väliste ühenduste jaoks peab olema määratud kehtiv parool ning aMule deemonit ei saa kasutada ilma väliste ühendusteta. aMule deemoni kasutamiseks pead määrama konfiguratsioonifailis ~/.aMule/amule.conf  \"ECPassword\" väärtuseks kohase väärtuse.Parooli seadmiseks käivita amuled võtmega '--ec-config'. Lisainformatsiooni leiad https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - käivituse stopper"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Ei suuda luua PID faili"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "VIGA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "See on eMulel põhinev aMule %s."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Seaded"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,193 +633,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Võrk puudub"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule kaugjuhtimine"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Fataalne VIGA: Ei suutnud stopperit."
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Ühendu eemalasuva amuulaga"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Ühendus kadunud"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Kinnita väljumine"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -840,727 +821,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua Poll stopperit."
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Lähen tegevuse tsüklisse..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Ühendun..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Võrgu GUI EC sündmuse haldur"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Ühendus ebaõnnestus. Ei suuda määratud ühenduda %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Peatun "
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Serveriga '%s (%s:%i)' ühendumise katsed aegusid."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Ühendu võrguga."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Ühendus ebaõnnestus. Ei suuda määratud ühenduda %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Valmis"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Kõik"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Info Puudub"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Faili ei leitud."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Vigane link või on juba loetelus."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' kataloogi."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Teadmata"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Otsin lowid ühenduse jaoks semu"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Valetatud eMule versioon %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Valetatud eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Valetatud eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseerub eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Kasutajanimi: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Küsitud: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Selle seansi failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 msgstr[1] "Selle seansi failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Kõikide seansside failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 msgstr[1] "Kõikide seansside failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Küsiti tundmatut faili"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s' (IP:%s) teade filtreeriti"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s' (IP:%s) saatis uue teate"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kasutaja %s (%u) küsis sinu jagatudfailde loetelu kataloogile %s -> keeldusid"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "HOIATUS: %s faili ei saa avada."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "HOIATUS: Katkestatud failde loetelu on riknenud, sisaldab riknenud päist."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO viga %s faili lugemisel: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "VIGA: tekkis %s faili salvestamisel: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategooria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Uus Kategooria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Vali sissetulevate failide kataloog"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Sa pead kategooria jaoks nime defineerima!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Sa pead kategooria jaoks asukoha defineerima!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Ei suutnud luua kategooria sisendkataloogi. Palun defineeri kehtiv asukoht!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "VestlusSeanss Alustatud: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Ühenduses Kliendiga ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Ühendun Kliendiga ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Kliendiga ühendumine ebaõnnestus / Ühendus kadunud ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Läbisid inimtesti ja kasutaja sai sinu sõnumi kätte. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Sinu vastus inimtestile oli vale, sinu sõnumit ignoreeriti. Inimtesti uuesti läbimiseks saada uus sõnbum. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Vestle"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Sulge leht"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Sulge kõik lehed"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Sulge teised lehed"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Lisa sõprade nimistusse"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Fail 'creditfile' loetud, tuvastati %u klienti"
 msgstr[1] "Fail 'creditfile' loetud, tuvastati %u klienti"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u Kliendi Krediit aegunud!"
 msgstr[1] " - %u Kliendi Krediit aegunud!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Ei leidnud 'cryptkey.dat' faili, loon uue."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Kliendi detailid"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Lubatud"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Toetatud"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Pole toetatud"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Keelatud"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ühendatud"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Pole ühendust"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Pole täielik"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Paha Poiss"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Kontrollitud - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Info Puudub"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Kasutaja %s (%u) küsis sinu jagatud kataloogide nimekirja -> Kinnitasid"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Kasutaja %s (%u) küsis sinu jagatud kataloogide nimekirja -> Keeldusid"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Kasutaja %s (%u) küsis sinu jagatud kataloogide nimekirja -> Kinnitasid"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Kasutaja %s (%u) küsis sinu jagatud kataloogide nimekirja -> Keeldusid"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Kasutaja %s (%u) küsis sinu jagatudfailde loetelu kataloogile %s -> Kinnitasid"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Kasutaja %s (%u) küsis sinu jagatudfailde loetelu kataloogile %s -> keeldusid"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Kasutaja %s (%u) jagab kataloogi %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Kasutaja %s (%u) saatis soovimatu jagatud kataloogide nimekirja."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Kasutaja %s (%u) saatis kataloogi %s jagatud failide nimekirja"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Kasutaja %s (%u) lõpetas jagatud failide nimekirja saatmise"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Kasutaja %s (%u) saatis soovimatu jagatud failide nimekirja"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Kasutaja %s (%u) keelas ligipääsu jagatud kataloogide/failide nimekirjale"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Faili kommentaarid"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Kasutajanimi"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Faili nimi"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Hinnang"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Kommentaar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad otsing pole võimalik kui Kad ei tööta"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Otsin lowid ühenduse jaoks semu"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Kommentaarid puuduvad"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u kommentaar"
 msgstr[1] "%u kommentaar(i)"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Klient %s bänniti %s riknenud info saatmise eest (kokku %s faili '%s' kohta)"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "'%s' riigiinfo laadimine ebaõnnestus."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Madal]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [Norm.]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Kõrge]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Kõrge"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Väga Kõrge"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Versioon"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Pärin"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Ühendun serveri kaudu"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Järjekord täis"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Järjekorras"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Tõmban"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Võtan vastu kontrollsumma"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Pole vajalikke osi"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Ühendus LowID <-> LowID ei õnnestu"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Liiga palju ühendusi"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Ühendun Kad kaudu"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Liiga palju Kad ühendusi"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Blokeeritud"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Ühenduse viga"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "KaugJärjekord täis"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Vana MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Uus MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule Kokkusobiv"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Kohalik server"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Allikate Vahetus"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiivne"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Link"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Allikaid"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Otsingu tulemus"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmis"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Edenemine"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "VIGA: Kettaruum otsas"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "VIGA: Osamet faili ei leitud."
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "VIGA: IO viga!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "VIGA: Ebaõnnestus!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Järjekorras"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Juba tõmbad"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Tundmatu või paha tempfaili formaat."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Siiratud"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Kiirus"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Edenemine"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Allikaid"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Olek"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Lõpetamiseni"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Viimati nähtud terviklikuna"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Viimane vastuvõtt"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Oled kindel et tahad valitud faili kustutada?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Oled kindel et tahad valitud failid kustutada?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1569,109 +1527,106 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Seis"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Paus"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Taasta"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Va&lmis"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Tõsta (A4AF) allikad selle faili külge"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Tõsta automaatselt kõik (A4AF) allikad selle faili külge"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Tõsta (A4AF) allikad teiste failide külge"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Laiendatud valikud"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Eelvaade"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Näita &detaile"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Näita kõiki kommentaare"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopeeri magnet URI lõikepuhvrisse"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopeeri eD2k &link lõikepuhvrisse"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopeeri tagasiside lõikepuhvrisse"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "määramata"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Määra kategooria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Ava Fail"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Sisesta selle faili uus nimi:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Faili ümbernimetamine"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%H:%M:%S %d/%m/%y"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Tõmbamised (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1680,348 +1635,347 @@ msgstr ""
 "Et seda viga eelvaatuse ajal rohkem mitte näitdata \n"
 "määra oma seadetes eelistatud video mängija (vaikimisi %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Faili eelvaade"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIGA: Ei suutnud käivitada välist meediamängijat! Käsk: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Salvestan osafaili %u %u-st"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Kõik osafailid salvestatud"
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Laen temp faile %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Laen osafaili %u %u-st"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "VIGA: Ei suutnud laadida tagavarafaili. Vaata aadressilt https://github.com/amule-org/amule/discussions, kas leiad juhiseid .part. met faili taastamiseks"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Kõik osafailid laetud"
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Part(osalisi) faile ei leidnud!"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Leidsin %u osalist faili"
 msgstr[1] "Leidsin %u part(osalist) faili."
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Temp kataloogi failisüsteem ei suuda suuri faile käidelda."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Sisenevate failide kataloogi failisüsteem ei suuda suuri faile käidelda."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Tõmban '%s'"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Sa juba proovid faili '%s' tõmmata"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Fail '%s' on juba olemas"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Fail '%s' on juba olemas"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Sa juba proovid '%s' faili tõmmata"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Ei suuda muuta magnet linki eD2k lingiks: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Lingi %s protokoll on tundmatu"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Vigane eD2k link! VIGA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Klient saatis paketi peale ebaõnnestunud autoriseerimist."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Välisühendus suleti"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Välisühendused on tühja parooli tõttu mitteaktiivsed"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Välisühendused on konfiguratsioonifailis defineeritud mitteaktiivsena."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Kinnitati uus väline ühendus"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIGA: Ei suutnud uut välist ühendust aksepteerida"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Välisühendustest keelduti tühja parooli tõttu seadetes!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ühendan klienti: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versioon teadmata"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Mittekorrektne Välisühenduste versiooni ID, siin võib olla binaarne kokkusobimatus.Kasuta sama versiooni tuuma ja kaugklienti."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ajutise arendusversiooniga ei saa ühenduda reliisi versiooniga!!!! *RRRRRR* hoidsin ära võimaliku crässi"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Vigane protokolli versioon."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Puudub protokolli versiooni märgis"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autoriseerimine ebaõnnestus: EC parooliks on määratud vigane räsi."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Autoriserimine ebaõnnestus: vale parool."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Autoriserimine ebaõnnestus: parool puudub."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Vigane päring, alustuseks pead ennast autoriseerima."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Ligipääs Lubatud."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Veateade \"%s\" kliendile saadetud."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Autoriseerimata pääsukatse %s. Ühendus suletud."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kaug OsaFaili käsk ebaõnnestus: Faili kontrollsummat ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Faili '%s' kontrollsummat ei leitud"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode töötlemise viga!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Serverit ei lisatud"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "serverit ei leidnud: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "eemaldatav server on vaja määrata"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Web Otsing kaugtöökohast ei oma mõtet."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Otsing on käimas. Varsti näed tulemusi!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Graafiku jaoks pole punkte."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Sinu klient pole seadistatud sellise detailsuse astme jaoks."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Väline Ühendus: nõutakse seiskamist"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Juba sulgun..."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Väline ühendus: lisan lingi '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Vigane link või on juba loetelus."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Faili ei leitud."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Vigane failinimi."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ei suuda faili ringinimetada."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad on seadetes väljalülitatud."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Juba ühendatud eD2k võrku."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Ühendun eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Juba ühendatud Kad võrku."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Ühendun Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Kõik võrgud on väljalülitatud."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "eD2k ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kad ühendus katkestatud."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Väline Ühendus: sain vigase opkoodi: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Vigane opcode (vale protokolli versioon?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Tundmatu laiend '%s' käsule '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Tundmatu käsk '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2029,7 +1983,7 @@ msgstr ""
 "\n"
 "See käsk ei saa omada parameetrit.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2037,7 +1991,7 @@ msgstr ""
 "\n"
 "Sellel käsul peavad olema parameetrid.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2045,7 +1999,7 @@ msgstr ""
 "\n"
 "Käsk on lõpetamata, pead kasutama üht laienditest allpool.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2053,11 +2007,11 @@ msgstr ""
 "\n"
 "Saadaval laiendid:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Võiamlikud käsud:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2068,17 +2022,17 @@ msgstr ""
 "Kõik käsud on tõstutundetud.\n"
 "Tipi '%s <käsunimi>' et saada <käsunimi> kohta rohkem infot.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Lahkub rakendusest."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Näita Abimeest."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2086,7 +2040,7 @@ msgstr ""
 "Käsu kohta abi saamiseks tipi 'help <käsunimi>'.\n"
 "Käskude täieliku loetelu saamiseks tipi 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2097,46 +2051,46 @@ msgstr ""
 "Käsuloendi saamiseks kasuta '%s'\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Süntaksi viga!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Viga käsu töötlemisel - sede ei tohiks mitte kunagi juhtuda!! Palun informeeri sellest\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Sellel käsul peab olema parameeter."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Vigane muutuja."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "See on poolik/lõpetamata käsk."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Rohkema info saamiseks tipi '%s'.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "See on %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "See on %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2144,7 +2098,7 @@ msgstr ""
 "\n"
 "Loon klienti ....\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2153,7 +2107,7 @@ msgstr ""
 "\n"
 "Ok, lahkun %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2167,331 +2121,326 @@ msgstr ""
 "\n"
 "Lahkun...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Näita seda abiteksti."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Masin milles aMule töötab. (vaikimisi: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule välisühenduse port. (vaikimisi: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Välisühenduse parool."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Loen konfiguratsiooni failist."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Ära trüki midagi standardväljudisse."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Ole jutukas - näita ka veajälituse infot."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Määrab programmi keele."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Kirjuta käsurea valikud konfiguratsioonifaili."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Loob konfiguratsioonifaili alusel aMule konfigratsioonifaili."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Näita programmi versiooni."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Faili detailid"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% tehtud"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Ohoo, rõõm sind näha!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Ühendun semuga"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Ühenduse olek:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Võrgud"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Vaikimisi TCP Port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laiendatud UDP port (Kad / globaalne otsing) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Luba UPnP ruuteri portide suunamiseks"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Sa juba proovid '%s' faili tõmmata"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Lehitse"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Sõprade faili 'emfriends.met' avamine lugemiseks ebaõnnestus!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Sõbrad"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Näita &detaile"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Lisa sõber."
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Eemalda sõber"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Saada sõnu&m"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Vaata faile"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Taasta sõbraslot"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Oled kindel et tahad valitud sõbra(d) kustutada?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Oled kindel et tahad valitud sõbra(d) kustutada? "
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2499,11 +2448,11 @@ msgstr ""
 "Sul pole lubatud määrata rohkem kui üks sõbraslot.\n"
 "Määrati ainult üks slott."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Vali mitu"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2512,206 +2461,205 @@ msgstr ""
 "Sul pole lubatud määrata rohkem kui üks sõbraslot.\n"
 "Määrati ainult üks slott."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Saada kasutajale teade"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Saadetav teade:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Eemalda sõpradest"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Saada teade"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Tõsta selle faili külge"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "JK: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Küsitud teist faili"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Ootan saatmise slotti"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Järjekorras: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Saadan"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Mitte keegi"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Jah"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Tõmban..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP allalaadimine katkestatud"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Tõmbamise URL ei saa olla tühi."
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Tõmmatud %d baiti"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s ütles: %i - VIGA (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP allalaadimine katkestatud"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Tõmban uut GeoIP.dat faili aadressilt %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "GeoIP.dat faili tõmbamine ebaõnnastus, katkestan uuendamise."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Faili %s eemaldamine ebaõnnastus, katkestan uuendamise."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Faili %s ümbernimetamine ebaõnnestus, katkestan uuendamise."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s uuendamine õnnestus"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "GeoIP.dat uuendamise viga"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Faili %s tõmbamine aadressilt %s ebaõnnestus"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Laen IP-filtrid 'ipfilter.dat' ja 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Ebaõnnestus ipfilter.dat faili '%s' laadimine, arusaamatu formaat sattus ette."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Ebaõnnestus ipfilter.dat faili '%s' laadimine, ei suuda faili avada."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Laetud %u IP-piirkond failist '%s'."
 msgstr[1] "Laetud %u IP-piirkonda failist '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "ignoreeritud %u vigast rida."
 msgstr[1] "ignoreeritud %u vigast rida."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Faili %s ümbernimetamine ebaõnnestus, katkestan uuendamise."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP filter on lähtestatud"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2719,876 +2667,844 @@ msgstr ""
 "Tuntud klientide \n"
 "Bootstrap"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Sõlmed (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Bootstrapil vigane IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Bootstrapil vigane port"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Palun täida kõik nõutud väljad"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Teade"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Oled kindel et tahad tõmmata uut nodes.dat faili?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Nii tehes eemaldad oma olemasolevad sõlmed ja taaskäivitad Kademlia ühenduse."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Kas jätkata?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: otsingu võtmesõna on liiga lühike"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: otsingu võtmesõna on juba loetelus: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "nodes.dat faili laadimine ebaõnnestus -  fail on liiga vana. See versiooni (0) on toetuseta."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Loetud %u Kad kontakti"
 msgstr[1] "Loetud %u Kad kontakti"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Kontakte ei leitud, palun bootstrap või tõmba nodes.dat fail."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Saadaval ainult %d Kad kontakt, nodes.dat ei lisatud"
 msgstr[1] "Saadaval ainult %d Kad kontakti, nodes.dat ei lisatud"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Salvestatud %d Kad kontakt"
 msgstr[1] "Salvestatud %d Kad kontakti"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad võrk"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Faili nimi"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Faili suurus"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Üles- ja allalaadimise suhe"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Küsitud"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aksepteeritud"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Täielikke allikaid"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "HOIATUS: Tuttavate failde loetelu on riknenud, sisaldab riknenud päist."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Tuntud falide loetelu laadimine ebaõnnestus, fail võib olla vigane"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Tuntud falide loetelus vigane kirje, fail võib olla vigane: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Versioon teadmata"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Ei suuda luua sihtkoha faili %s."
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Räsin"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Lõpetatud"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Peatatud"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vigane"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ootan"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Pead defineerima mittetühja parooli."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Vigane parool, pole MD5 kontrollsumma!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Ühenduse viga"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Välisühendus suleti"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC ühendus ebaõnnestus. Tühi vastus."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Väline Ühendus: Vigane vastus, kätlemine ebaõnnestus. Ühendus suletud."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Õnnestus! Ühendus aMulaga loodud "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Õnnestus! Ühendus loodud."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Väline Ühendus: Ligipääs keelatud sest: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "VIGA: Ei suuda kuulata TCP porti."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "VIGA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "HOIATUS: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Sulge"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Lõika"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Aseta"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Puhasta"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Vali kõik"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Ühendatud"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Ühendatud"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Ühendus Kad võrku (tulemüüriga)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "ServeriIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Serveri IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Pole ühendatud"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP port: Pole valmis"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP port: Pole valmis"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Kliendi informatsioon"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Saatmise limiit"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Tõmbamise limiit"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Näita aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Peida aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Välju"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Piiramatu"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule Riba Menüü"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Kiiruse piirangud:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "ÜL: puudub"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "ÜL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "AL: pole"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "AL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Tõmbamise kiirus: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Saatmise kiirus: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Hüüdnimi: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Hüüdnime pole valitud!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "KliendiID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Serveri nimi: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ServeriIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Pole ühendust"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Allkiri: Lubatud"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Allkiri: Keelatud"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Elus juba: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Jagatud failid: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Kliente sabas: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Kokku AL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Kokku ÜL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Lisa tuumale eD2k või magnet link."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Lisa sõprade nimistusse"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Klikka siia, et lisada eD2k link tekstiväljalt tõmbamise järjekorda."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Siin näidatakse sündmusi. Kogu sündmuste loetelu on logis Serverid lehel."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Laadimine..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Kasutajate arv serveris, kuhu sinagi oled ühendunud ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Kasutajad: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Kasutajaid serveriga ühenduses ja arvatav kasutajate koguarv."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Üles: 0.0 | Alla: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Hetkel kehtivad keskmised saatmise ja tõmbamise kiirused. Valituna näitavad numbrid sulgudes kliendikommunikatsiooni raisatud pakette."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Näitab ühenduse olekut ja käimasolevaid siirdamisi. Punane nool näitab, et sa pole hetkel üheduses, kollane nool näitab, et sul on LowID (või oled ühenduses läbi tulemüüri) ja roheline nool näitab et omad HighID (Optimaalseim) ühenduse tüüp."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Pole ühendust ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Sa oled serveriga ühenduses."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Otsing"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nimi:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tüüp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Kohalik"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Üleüldine"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Laiendatud parameetreid"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtreerimine"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Faili tüüp"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Suvaline"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archiwum"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Muusika"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Image"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Pildid"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programmid"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Tekst"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Filmid"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Laiend"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Vähim Suurus"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Baiti"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Suurim Suurus"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Saadavus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtreerimise tulemused"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Tulemus peeglisse"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Vaata faile"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Alusta"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Rohkem"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Seiska"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Tõmbamine"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Lähtesta väljad"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Tulemused"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Puhastab lõpetatud tõmbamised"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Faili allikad:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Üldine"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Täis nimi :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-Fail :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Kontrollsumma :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Faili suurus :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Liiklus"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Osafaili staatus :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Viimati nähtud tervikuna :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Leitud allikaid :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Saatvaid allikaid :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Failiosi :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Saadaval :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Aktiivne Tõmbamine: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Siiratud :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Valmis suurus :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligentne riknemise vältimine"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Riknemise tõttu kaotatud :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Võidetud tänu kokkusurumisele :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.C.H. päästetud paketid :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Jagamine: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Päringuid"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Aktsepteeritud päringuid"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Siiratud andmed"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Jagamise suhe"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Täielikke allikaid"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Jagatud failid"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Saatmine: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Pole hinnatud"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Tiitel :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Failide nimed"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Võta Üle"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Puhasta"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Jõusta"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Kommenteeri/Hinda faili (Tekst on nähtav kõigile)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3596,1270 +3512,1266 @@ msgstr ""
 "Filmi puhul saad öelda tema pikkuse, tema süzee, keele ....\n"
 "ja kui see on võltsing siis saad sellest teisi aMule kasutajaid hoiatada."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Faili kavliteet"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Pole hinnatud"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Vigane / Vigastatud / Pole õige"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Halb"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Hea"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Keskpärane"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Väga hea"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Määra faili hinnang või hoiata kasutajaid juhul kui fail on vigane ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Ühendus Kad võrguga katkestatud"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Tõmban, palun oota ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Suurus teadmata"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Vajalik informatsioon"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP Aadress :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Lisainformatsioon"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Kasutajanimi :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Lisa"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Seansi keskmine"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Saatmise kiirus"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistika Puu"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Kasutajanimi:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Kasutaja kontrollsumma:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Klienditarkvara:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Kliendiversioon:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP aadress:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Kasutaja ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Serveri IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Serveri nimi:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Hämatud:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Liiklus kliendile"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Praegune päring:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Keskmine saatmise suhe:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Keskmine tõmbamise suhe:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Saadetud (selles seansis):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Tõmmatud (selles seansis):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Saadetud (kokku):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Tõmmatud (kokku):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skoorid"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "AL/ÜL kordaja:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Turvaline ident:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Järjekorras:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Saba skoor:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nimi"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - mitme platvormi Muul"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "See on see nimi mida teised näevad kui sinuga ühenduvad."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Keel: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Abitekstide kuvamise ajaline viide."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "See määrab kasutatava keele."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Valituna kontrollib aMule käivitumisel värskema versiooni olemasolu"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Käivita vähendatult"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Valituna minimeerib aMule ennast peale käivitumist."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Kinnita väljumine"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Sunnib aMule väljumiseks kinnitust küsima."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Luba Riba(tray) ikoon"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Valituna lubadab süsteemiriba (või tegumiriba) ikooni."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Vähenda Ribale ikooniks"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Valituna vähendab aMule ennast pigem Süsteemiribale, kui tööriistaribale."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Abitekstide viide sekundites: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekundit"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Lehitseja valik"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Võimalusel ava uus sakk"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ava, kui võimalik, webileht uuel lehel selle asemel et avada uus aken"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video mängija"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Ribalaiuse piirid"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Saatmine"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Määratud pesa"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Pordid"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "See on eD2k standard port ja seda ei saa välja lülitada."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port serveri päringute jaoks (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Seda UDP porti kasutatkse laiendatud omadustega eD2k ja Kad võrgu puhul"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnp TCP Port (Lisana):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automaatne ühendumine käivitumisel"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Ühenduse kadumisel taasta ühendus"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Eemalda surnud server peale"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "katset"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Loend"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Värskenda serverite nimekirja serveriga ühendumisel"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Värskenda serverite nimekirja kliendi ühendumisel"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Kasuta prioriteedisüsteemi"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Ühendumisel kasuta nutikat LowID kontrolli "
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Ohutu ühendumine"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automaatne ühendumine ainult staatilises serverinimekirjas olevate serveritega"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Määra käsitsi lisatud serveritel Kõrge Prioriteet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Lisa failid tõmbamiseks peatatud olekus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Lisa failid tõmbamiseks automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Proovi alustuseks tõmmata esimene ja viimane tükk"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Alusta järgmise peatatud failiga, kui fail lõpetab"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Samast kategooriast"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Tähestikulises järjekorras"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Eralda kettaruum uute failide jaoks"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Eraldab uuet failide jaoks vajamineva kettaruumi, seeläbi väheneb faili fragmenteerumine"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Lõpeta tõmbamine, kui vaba kettaruumi on jäänud "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vali see kui soovid et aMule sinu kettaruumi kontrolliks"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Sisesta siia vähim soovitud kettaruum"
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvesta haruldaste failide 10 allikat (< 20 allikat)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Saatmised"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Lisa uued jagatud failid automaatse prioriteediga"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligentne Riknemise Vältimine (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Luba"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Laiendatud I.C.H. usaldab suvalist kontrollsummat (pole soovitatav valik)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Eemalda"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rekursiivseks jagamiseks tee paremklikk kataloogi ikoonil)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Jaga peidetud failid"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graafikud"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Värskenduste vahe : 5 sekundit"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Keskmine graafiku aeg: 100 minutit"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Ühenduse graafiku skaala: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Tõmbamise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Saatmise graafiku skaala:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Värvid: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Taust"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Alusvõrk"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Allalaadimine, jooksev"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Allalaadimine, jooksev keskmine"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Allalaadimine, seansi keskmine"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Saatmine hetkel"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Hetke saatmise keskmine"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Süsteemiriba Kiirvaliku Ikoon"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-sõlmi hetkel"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-sõlmi jooksvalt"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Vali"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Kuvatavate Kliendi Versioonide arv (0=piiramatu)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! HOIATUS !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maksimaalne arv uusi ühendusi / 5 sek."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Faili puhvri suurus: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Saatmise saba suurus: 5000 klienti"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveriühenduse värskenadamise intervall: Ei kasuta"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Keela arvuti ajastatud uinumine"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Kasutatav rüü: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näita igas aknas \"Kiiret eD2k lingi käsitlejat\". "
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Näita kategooria juures laiendatud infot"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Näita tiitelribal siirdamise kiirusi"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Eelmise rakenduse nimi"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Järgneva rakenduse nimi"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Näita raisatud ribalaiust"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Vertikaalne tööriistariba paigutus"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Tõmbamise Järjekorrafailid"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Näita edenemist protsentuaalselt"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Näita edenemise riba"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Lame"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Keela külalise (guest) ligipääs"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Webserveri külalise (guest) parool"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4867,11 +4779,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4881,828 +4793,828 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Eemaldatud [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "baiti"
 msgstr[1] "baiti"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "baiti/sek"
 msgstr[1] "baiti/sek"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sek"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "tundi"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "päev(a)"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "kõik"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "kõik teised"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Poolik"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Peatatud"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Film"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arhiiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktiivne"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Kasutan seadete kataloogi: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Ootan osafaili konverteerimise lõime suremist ..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Impordin %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Loen ajutist kataloogi"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Hangin põhiinformatsiooni tõmmatavast infofailist"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Loon sihtkohafaili"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Laen vanast tõmbamisefailist andmeid (%u %u-st)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Salvestan andmeblokki uude, üksikusse tõmbamisefaili (%u %u-st)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Hanging allika tõmmatavate failide informatsiooni"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Lisan tõmbamise ja salvestan osafili"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Imporditud osafailid"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Olek"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Faili kontrollsumma"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Ketas: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Palun vali ajutiste tõmbamiste otsingu kataloog (alamkataloogid kuuluvad ka siia)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Kas soovid õnnestunult imporditud tõmmatud failide allikad kustutada?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Eemaldan allikaid?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "VIGA: Ei suutnud luua osafaili!"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Proovin laadida met-faili tagavarakoopiat aadressilt %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "VIGA: Ei suuda avada part.met faili: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "VIGA: part.met faili on 0 suurusega: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "VIGA: Vigane fail part.met versioon : %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "VIGA: %s (%s) on vigane (vale märgiseloendur), ei suuda faili laadida."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "VIGA: %s (%s) on vigane (vale märgiseloendur), ei suuda faili laadida."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Proovin taastada faili infot..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Taastan nimetu faili - proovin ta taastada nimega RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Taastatud kogu olemasolev failiinfo :D - Proovin nüüd kasutada..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Ei suuda faili infot taastada :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Ei suuda avada: %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "HOIATUS: %s võib olla riknenud (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "VIGA salvestades osafaili: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "IO viga osafaili salvestamisel: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Ei saanud salvestada faili part.met.seeds %s jaoks!"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Salvestatud %i allikat osafailile: %s (%s)"
 msgstr[1] "Salvestatud %i allikat osafailile: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Salvestatud %i allikat osafailile: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "VIGA osafaili toitefaili lugemisel (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Leidsin riknenud osa (%d) %d osast fail '%s' - Arvutatud Kontrollsumma |%s| Saadetud Kontrollsumma |%s|"
 msgstr[1] "Leidsin riknenud osa (%d) %d osast fail '%s' - Arvutatud Kontrollsumma |%s| Saadetud Kontrollsumma |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Leitud lõpetatud osa (%i)  %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "'%s' faili kontrollsumma arvutamine lõpetatud"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ootamatu viga %s lõpetamisel. Fail peatatud"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Faili '%s' tõmbamine lõpetatud"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Faili '%s' tõmbamine lõpetatud"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Kustutan faili: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "HOIATUS: Ei suuda tõmmatud osale arvutada kontrollsummat - kontrollsumma on mittetäielik '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "VIGA: ei suuda tõmmatud osale arvutada kontrollsummat- kontrollsumma on mittetäielik(%s). Seda ei tohiks kunagi juhtuda."
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "HOIATUS: Pole piisavalt vaba kettaruumi! Pausin faili: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Tõmmatud osa %i on failis %s vigane"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Taastatud riknenud osa %i %s jaoks -> Päästsin: %s baiti"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Eraldamine"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Ebapiisav kettaruum"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Allalaetud"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Ühendus"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serverid"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Failid"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Turvalisus"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Liides"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Puhverserver"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtrid"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Kaugjuhtimine"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online Allkiri"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Muud"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Sündmused"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Veajälitus"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5712,15 +5624,15 @@ msgstr ""
 "   %PARTFILE - fail täis rada\n"
 "   %PARTNAME - faili nimi"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5736,35 +5648,35 @@ msgstr ""
 "aMule toimib ilusasti ilma siinolevaid seadeid muutmata\n"
 "You Are WARNED!!."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Widgeti ühendamine Cfg'a, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Andmete ülekandmine Cfg'st Widget'isse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Selle puhverserveri tüüp kuhu sa ühendud"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Andmete ülekandmine Widgetist Cfg'sse, kasutades ID %d ja võtit %s, ebaõnnestus"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrollin parooli\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5772,42 +5684,42 @@ msgstr ""
 "Nende muudatuste jõustamiseks pead aMUle taaskäivitama:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP port muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Välisühenduse port on muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Välisühenduse luba on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Välisühenduse liides muutunud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli Hämamine"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5815,7 +5727,7 @@ msgstr ""
 "Sinu automaane serverinimekirja värskendamise loetelu on tühi.\n"
 "Käivitamisel serverinimekirja automaatselt ei uuendata."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5823,33 +5735,33 @@ msgstr ""
 "Lülitasid sisse välised ühendused kuid ei määranud parooli.\n"
 "Väliseid ühendusi ei saa enne kehtiva parooli määramist kasutada."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Keel on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Ajutiste failide kataloog on muudetud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K võrk on lubatud.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Vigane protokolli versioon."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5857,7 +5769,7 @@ msgstr ""
 "Mõlemad, nii eD2k kui ka Kad võrgud on mitteaktiivsed.\n"
 "Sa ei saa ühenduda enne, kui vähemalt üks neist on aktiivne."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5865,7 +5777,7 @@ msgstr ""
 "Kad ei saa käivitada kuni UDP port on väljalülitatud.\n"
 "Lülita UDP port sisse, või Kad välja."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5875,69 +5787,69 @@ msgstr ""
 "Sa PEAD aMule nüüd taaskäivitama.\n"
 "Kui sa seda ei tee siis ära tänita kui midagi paha juhtub.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Ajutiste tõmmatavate failide kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Parool on määratud ja välised ühendused võimalikud."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5947,66 +5859,66 @@ msgstr ""
 "Palun sisesta vähemalt üks server.met faili asukoha kehtiv URL.\n"
 "URL sisestamiseks kliki nupule 'Loend'."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Ajutised failid"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Saabuvad failid"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online Allkirjad"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vali %s kataloog"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Otsi filmi taasesitamise programmi"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vali lehitseja (browser)"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Käivitusprogramm%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Muuda serverite nimekirja"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6014,1213 +5926,1212 @@ msgstr ""
 "Lisa siia server.met faili(de) laadimise URL.\n"
 "Üks URL rea kohta."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Täielikke allikaid"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Olek:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Värskenduse viide: %d sekundit"
 msgstr[1] "Värskenduse viide: %d sekundit"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskmiste graafiku aeg: %d minutit"
 msgstr[1] "Keskmiste graafiku aeg: %d  minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ühenduse graafiku skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Failipuhvri suurus: %d baiti"
 msgstr[1] "Failipuhvri suurus: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Saatmise Saba suurus: %d klienti"
 msgstr[1] "Saatmise Saba suurus: %d klienti"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveri ühenduse värskendamise intervall: %d minutit"
 msgstr[1] "Serveri ühenduse värskendamise intervall: %d minutit"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveri ühenduse värskendamise intervall: Ei kasuta"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "keelatud"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Käivita käsk peale '%s' sündmust"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Luba käskude käivitamine tuumas"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Tuumkäsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Luba käskude käivitamine GUI's"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI Käsk:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Järgnevad muutujad asendatakse:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Otsingu hoiatus"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Peamine"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k otsing pole võimalik kui eD2k pole ühendatud"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Otsingu märksõna: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ootamatu viga proovides Kad otsingut: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Pole hinnatud"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Tõmba kataloogi"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Lisa selle faili alternatiivsed URL'id"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Otsi seotud faile (eD2k, kohalik server)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Märgi fail tuntuks"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopeeri eD2k link lõikepuhvrisse"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sa oled serveriga, mida soovid kustutada, ühenduses. Palun katkesta ühendus. Serverit ei kustutatud."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Loobutud"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Uus"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Kõigi näidatud hämatud serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele, seekord ilma hämamiseta."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Kõigi näidatud hämatud serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele, seekord ilma hämamiseta."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k on seadetes väljalülitatud, ei ühendu"
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Serverite loetelus pole ühendumiseks sobivat kehtivat serverit"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Ühendus %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Ühendus loodud: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Fataalne viga ühendumisel. Kontrolli ühendust."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Kaotasin ühenduse %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) on vist surnud."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) on vist täis."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Proovin %d sekundi pärast serveriga uuesti automaatselt ühenduda."
 msgstr[1] "Proovin %d sekundi pärast uuesti serveriga automaatselt ühenduda."
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Ühendumine %s (%s:%i) ebaõnnestus."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "VIGA: Vigane socket aegumise kontrollil"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Serveriga '%s (%s:%i)' ühendumise katsed aegusid."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Saabus DNS päringu hilinenud vastus, ignoreerin."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Laen server.met faili: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met faili ei leitud."
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "server.met faili '%s' laadimine ebaõnnestus, arusaamatu formaat sattus ette."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Ei saanud avada server.met faili!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met fail on riknenud, leidsin vigase versiooni sildi: 0x%x, suurus %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "Failis server.met on %i serverit"
 msgstr[1] "Failis server.met on %i serverit"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d server lisatud"
 msgstr[1] "%d server(it) lisatud"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "IO viga %s faili lugemisel: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serverit ei lisatud: [%s:%d] ei määra kehtivat porti."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serverit ei lisatud: [%s:%d] IP aadress on filtris või vigane."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serverit ei lisatud: Sama server IP:Port [%s:%d] on juba loetelus."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Lisati server: Server [%s:%d] kasutab nime *%s*."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Sa oled serveriga, mida soovid kustutada, ühenduses. Palun katkesta ühendus. Serverit ei kustutatud."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Ei suuda avada '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ei saanud salvestada server.met faili!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Vigane URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Serverite nimekirja tõmbamine aadressilt %s lõpetatud"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "'addresses.dat' failis puudub serverite nimekirja asukoha kirje. Palun lisa kehtiv serveri nimekirja asukoha aadress sellesse faili, vastasel juhul nimekirja automaatset värskendamist ei toimu."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Tõmba serverite nimekiri aadressilt %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "HOIATUS: vigane URL on määratud serverinimekirja automaatseks värskendamiseks: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "addresses.dat failis pole kehtivat server.met faili automaatse tõmbamise URL'i"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Serverite nimekirja tõmbamine aadressilt %s ebaõnnestus"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Kohalik server on IPFiltri poolt väljafiltreeritud, ühendud teise serveriga!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serveri nimi"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Aadress"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Kirjeldus"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Kasutajad"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Staatiline"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioon"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Sa oled ühenduses selle serveriga mida soovid kustutada. Palun katkesta ühendus. Serverit ei kustutatud."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Tundmatu nimi)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Oled kindel et tahad kustutada staatilise serveri %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servereid (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Ühendu serveriga"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Märgi server staatilisena"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Märgi server mittestaatilisena"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Märgi serverid staatilisena"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Märgi serverid mittestaatilisena"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Eemalda server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Eemalda serverid"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Eemalda kõik serverid"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopeeri eD2k lingid lõikepuhvrisse"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Taasühendu serveriga"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Oled kindel et tahad kõik serverid kustutada?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Oled kindel et tahad valitud serveri kustutada?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Oled kindel et tahad valitud serverid kustutada?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "VIGA: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "HOIATUS: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Uus kliendi ID %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "HOIATUS: Said omale Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tTõenäolisem põhjus on sinu asumine tulemüüri või ruuteri 'taga'."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tTäpsemat informatsiooni leiad https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Saabus tundmatu serveriinfo! - liiga lühike"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Sain %d uut serverit"
 msgstr[1] "Sain %d uut serveri nime"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Serverite loetelu salvestamine lõpetatud."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server lükkas viimase korralduse tagasi"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Tüngapakett saabus serverist: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Defineerimatu viga serverist %s saabunud paketi töötlemisel"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Ei suuda luua DNS lõime serveriga %s ühendumiseks"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Server IP %s (%s) on filtris. Ei ühenda."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "kasutan protokolli hämamist"
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Ühendun %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Ei suuda masina %s dns nime lahendada: Ei saa ühenduda!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule Logi"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serverit ei lisatud: IP aadressi või masinanime pole defineeritud."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serverit ei lisatud: Defineerisid vigase pordi."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k Olek:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Ühenduse olek:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Ühendatud"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia Olek:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Jookseb LAN olekus"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Töötab"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademlia Olek:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Olek:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Ühenduse olek:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tulemüüriga - ava oma ruuteris või tulemüüris TCP%d port"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP ühenduse olek:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tulemüüriga - ava oma ruuteris või tulemüüris UDP %d port"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Olek tulemüüriga: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Semu pole tarvis - TCP port on avatud"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Semu pole tarvis - UDP port on avatud"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Semu puudub"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Ühendun semuga"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ühendus semuga %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indekseeritud allikaid:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indekseeritud märksõnu:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indekseeritud märkmeid:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indekseeritud laadimisi:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Keskmiselt kasutajaid:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Keskmiselt faile:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Ei tööta"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Lisan faili '%s' jagatute hulka"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Leitud %i tuntud ja jagatud faili, %i tundmatut"
 msgstr[1] "Leitud %i tuntud ja jagatud faili, %i tundmatut."
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "VIGA: Katse jagada %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Jagatud kataloogi ei leitud, jätan vahele: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Kataloogis '%s' pole jagatavaid faile"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Kasutaja nimi"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Saatmise kiirus"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Saadaval osi"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Saatmise olek"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Tõmbamise olek"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Allikas"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Kohalik faili nimi"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Jagatud failid"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Saadud osi"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Kataloogi asukoht"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Lisa Kommentaar/Hinnang"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Muuda Kommentaari/Hinnangut"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Nimeta ümber"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lisa failid ülekantavate failide loetellu"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopeeri magnet &URI lõikepuhvrisse"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (Allika&s)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (Allikas)(&Koos Krüpto seadetega)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (&Hostinimi)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (Hostinimi)(Koos &Krüpto seadetega)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopeeri eD2k link lõikepuhvrisse (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Allika lingi loomiseks pead omama HighID'd."
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Kaugfaili nimi"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Saadetud andmeid (Seansil (Kokku)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Raisatud Kokku (pakette): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Raisatud faili päringuid (pakette): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Raisatud allikavahetusi (pakette): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Raisatud Servereid (pakette): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Raisatud Kad (pakette): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Krüpteerimise ulatus (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktiivsed saatmised: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Ootel saatmised: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Kokku õnnestunud saatmisi: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Kokku ebaõnnestunud saatmisi: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Keskmine saatmise aeg: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Tõmmatud Andmed (Seansil (Kokku)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Leitud allikaid: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktiivsed tõmbamised (tükid): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Seanss ÜL:AL suhe (Kokku): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Keskmine tõmbamise kiirus (Sessioon): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Keskmine saatmise kiirus (Sessioon): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Maksimaalne tõmbamise kiirus (Sessioon): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Maksimaalne saatmise kiirus (Sessioon): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Ühenduse taastumised: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Aeg alates esimesest saatmisest: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Ühendatud serveriga alates: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktiivseid ühendusi (hinnang): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Saavutati maksimaalne arv ühendusi: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Keskmiselt ühendusi (hinnang): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Suurim ühenduste arv (hinnang): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Kliendid"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Tundmatu: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtreeritud: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Blokeeritud: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Kokku: %i Tuntuid: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Töötavad serverid: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Ebaõnnestunud serverid: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Kokku: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Kustutatud serverid: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtreeritud serverid: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Kasutajaid töötavail servereil: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Faile töötavail servereil: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Kokku kasutajaid: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Kokku faile: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Serveri hõivatus: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jagatud failide arv: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Jagatud failide suurus kokku: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Keskmine faili suurus: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operatsioonisüsteem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Pole vastu võetud"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktiivseid ühendusi (l:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Info puudub"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Mitte kunagi"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Käsk '%s' protsessi'id '%d' lõpetas staatusega '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Käivita <str> ja välju."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Vigane IP formaat. Kasuta xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "See käsk vajab muutujat. Sobivad muutujad on: 'all', failinimi või number.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Töötlen räsi järgi: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Töötlen failinime järgi: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "See käsk vajab argumenti. Sobivad argumendid on: faili räasi.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Pole korrektne number\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Pole kehtiv kontrollsumma (pikkus peab olema täpselt 32 märki)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7229,7 +7140,7 @@ msgstr "Rohkema info saamiseks tipi '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7238,89 +7149,87 @@ msgstr "Rohkema info saamiseks tipi '%s'.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Rohkema info saamiseks tipi '%s'.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Tõmban '%s'"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Päring ebaõnnestus tundmatu vea tõttu."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operatsioon oli edukas."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Päring ebaõnnestus järgneval põhjusel: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Klientide IP-Filter on %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Väljas"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Sees"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Serverite IP-Filter on %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Kehtiv IPFilter Tase on %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Ribalaiuse piirangud: Üles :%u kB/s, Alla: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Ühendatud %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Ühendun"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "tulemüüriga"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7329,7 +7238,7 @@ msgstr ""
 "\n"
 "Tõmbamine:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7338,7 +7247,7 @@ msgstr ""
 "\n"
 "Saatmine:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7347,7 +7256,7 @@ msgstr ""
 "\n"
 "Kliente järjekorras:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7356,46 +7265,46 @@ msgstr ""
 "\n"
 "Kokku allikaid:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[FailiOsa]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Otsingu tulemusi: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Otsing : %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Otsingu edenemist ei saa näidata"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Serverilt saabus tundmatu vastus, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Näitab lühikest oleku ja statistika infot."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Näita ühenduse olekut, kehtivat saatmise/tõmbamise kiirust jne.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Näitab täieliku statistika puud."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7409,11 +7318,11 @@ msgstr ""
 "\n"
 "Näiteks: 'statistics 5' näitab ainult 5 enamesinenud versiooni iga kliendi tüübi kohta.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Seiska aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7422,35 +7331,35 @@ msgstr ""
 "Seiska eemalasuv töötav tuum (amule/amuled).\n"
 "Seiskab ka tekstikliendi, kuna see on kasutu ilma töötava tuumata.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Määratud objekt taaslaadimine."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "IP Filteri taaslaadimine."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Lae preagune IP filtreerimise tabel uuesti."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Uuenda IP filtrit URL'ist."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Kui URL puudub siis kasutatakseseadetes määratud URL'i."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Ühendu võrguga."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7461,35 +7370,35 @@ msgstr ""
 "Võid lisaks määrata serveri aadressi moel IP:Port, et ühenduda ainult selle\n"
 "serveriga. IP peab olema IPv4 vastav aadress või DNS lahenduv nimi."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Ühendu ainult eD2k võrku."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Ühendu ainult Kad võrku."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Lahku võrgust."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Lõpetad ühenduse kõigi, hetkel ühenduses olevate võrkudega.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Lõpeta ühendus ainult eD2k võrguga."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Lõpeta ühendus ainult Kad võrguga."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Lisa tuumale eD2k või magnet link."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7506,124 +7415,124 @@ msgstr ""
 "   serverid serverite nimekirja.\n"
 "Magnet link peab sisaldama eD2k kontrollsummat ja faili pikkust.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Määra seade väärtus."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Määra IP filtri seaded."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Lülita serverite ja klientide IP filtreerimine sisse."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Lülita serverite ja klientide IP filtreerimine välja."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Rakenda/ära rakenda klientide IP Filtreerimist."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Lülita klientide IP-filtreerimine sisse."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Lülita klientide IP-filtreerimine välja."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Rakenda/ära rakenda serverite IP Filtreerimist."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Lülita serverite IP-filtreerimine sisse."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Lülita serverite IP-filtreerimine välja."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Vali IP Filtreerimise tase."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr "Võimalikud filtreerimise tasemed on vahemikus 0 kuni 255, vaikeväärtus on 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Määra ribalaiuse piirang."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Väärtus, mis nendele käskudele antakse, peab olema kilobaiti/sekundis.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Määra saatmise ribalaiuse piirang."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Väärtus, mis nendele käskudele antakse, peab olema kilobaiti/sekundis.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Määra tõmbamise ribalaiuse piirang."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Väärtus, mis nendele käskudele antakse, peab olema kilobaiti/sekundis.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Hangi ja näita atribuudi väärtus."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Hangi IP filtri seaded."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hangi IP filtri olek nii klientide kui ka serverite kohta."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Hangi IP filtri olek ainult klientide kohta."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Hangi IP filtri olek ainult serverite kohta."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Vali IP filtreerimise tase."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Kehtiv Ribalaiuse piirang."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Käivita otsing."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7642,44 +7551,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Käivita globaalne otsing."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Käivita lokaalne otsing."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Käivita otsing kad võrgust."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Näita viimase otsingu tulemusi."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Näita otsingu edenemist."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Alusta faili tõmbamist"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7687,81 +7596,81 @@ msgstr ""
 "Pead andma eelmise/viimase otsingu faili numbri.\n"
 "Näiteks 'download 12' alustab eelmise otsingu 12'nda faili tõmbamist.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Peata tõmbamine."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Jätka tõmbamist."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Katkesta tõmbamine."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Määra tõmbamise prioriteet."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Määra tõmbamise prioriteet Low, Normal, High või Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Määra madal prioriteet."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Määra normaalne prioriteet."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Määra kõrge prioriteet."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Määra automaatne prioriteet."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Näita järjekorda/nimekirja."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Näita saatmise/tõmbamise järjekorda, serveri jagatud failide loetelu.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Näita saatmise saba."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Näita tõmbamise järjekorda."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Näita logi."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Näita serverite nimekirja."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Jagatud failide loetelu taaslaadimine."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Tühjenda logi."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Aegnud käsk, kasuta selle asemel '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7770,262 +7679,259 @@ msgstr ""
 "See on vananenud/aegunud käsk ja võidakse tulevikus eemaldada.\n"
 "Selle asemel kasuta '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstiline klient"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverteerin vanad '%s' AICH kontrollsummad 64b '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "HOIATUS: Fail ninega '%s' on vigane ja nimetatati ringi '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "HOIATUS: Sama nimega fail '%s' on olemas, uus fail nimetatati ringi '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Oled kindel et tahad katkestada ja kustutada kõik selle kategooria failid?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Ootan kinnitust"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Liiga palju ühendusi"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "kõik teised"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Vali vaate filter"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Lisa kategooria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Muuda kategooria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Eemalda kategooria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Tundmatu faili '%s' jaoks küsiti kontrollsummat."
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Taastan faili '%s' saatmise"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Peatan faili '%s' saatmise"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Käsu '%s' käivitamine '%s' sündmuse puhul ebaõnnestus"
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Tõmbamine lõpetatud"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Faili asukoht koos täieliku rajaga."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Faili nimi ilma raja osata."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Faili eD2k räsi."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Faili suurus baitides."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Kumuleeruv tõmbamise aeg."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Uus vestlussession alustatud"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Teate saatja."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Pole enam ruumi"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Ketta partitsioon."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Viga lõpetamisel"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Töötlen faili number %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Soovisid osade kontrollsummasid (Kasutatakse ainult failidel mis on > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Faili pole olemas !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, aMule eD2k lingilooja"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Ohoo, rõõm sind näha!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Sisendparameetrid"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Räsitav fail"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Lisa selle faili alternatiivsed URL'id"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Sisesta siia fail, millele soovid luua eD2k linki"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Sisesta siia see URL mida soovid eD2k lingile lisada: Lisa / lõppu, et aLinkCreator lisaks sellele faili nime"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Loo link osa-kontrollsummadega"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Aita suurenenud lingi hinnaga uusi ja haruldasi faile kiiremini levitada."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 Faili kontrollsumma"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k Faili kontrollsumma"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k link"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Salvesta"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopeeri lõikepuhvrisse"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Ava"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Ava fail tema eD2k lingi loomiseks"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopeeri arvutatud eD2k link lõikepuhvrisse"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Salvesta kui"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Salvesta arvutatud eD2k link faili"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "aLinkCreator'ist"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Vali fail, mille eD2k linki soovid arvutada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Ei suuda lõikepuhvrit avada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Praeguseks hetkeks pole midagi kopeerida !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Vali fail mille eD2k lingi arvutasid"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Ei suuda avada "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Palun sisesta mittetühi faili nimi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Pole midagi praeguseks hetkeks salvestada !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8045,167 +7951,159 @@ msgstr ""
 "\n"
 "Jaotatakse GPL litsentsi järgselt"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Räsin..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator toimib sinu jaoks"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Arvutan MD4 räsi..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Arvutan eD2k räsi..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Tühistatud !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Tehtud %.2f sekundiga"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Oled juba selle URL lisanud !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Palun sisesta mittetühi URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ei suuda %s avada"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i päev(a) %i tundi %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uP %02ut %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02ut %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule Online Statistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Suurim Tõmbamine alates wxCas käivitamisest"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absoluutselt suurim Tõmbamine wxCas eelmistest käivitamistest"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Algväärtusta"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Süsteem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Peata Automaatne Värskendus"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Salvesta Ühenduse Statistiline pilt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Trüki Ühenduse Statistiline pilt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Seaded"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "wxCas Info"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Käivita automaatne värskendamine"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automaatne värskendamine on peatatud"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automaatne värskendamine on käivitatud"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Salvesta Statistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule Online Statistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8213,11 +8111,11 @@ msgstr ""
 "Tekkis viga printimisel.\n"
 "Võibolla pole su printer korralikult seadistatud?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Trükin"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8235,403 +8133,392 @@ msgstr ""
 "\n"
 "Jaotatakse GPL litsentsi järgselt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule ei tööta ..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule töötab"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule töötab aga ühendus on katkestatud"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule ühendub..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, aMule olek on teadmata..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " on toimetanud juba "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " on seiskunud !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " pole ühendatud !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " ühendub..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " teeb midagi imelikku, kontrolli !!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " on ühendatud  "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "väljas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " baseerub "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " koos "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Kokku Tõmbamisi: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Saatmine: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Seansil Tõmmatud: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Tõmbamine: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Saatmine: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Jagamine: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " faili, Klienti järjekorras: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Kellaaeg: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " on "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Süsteemi koormuse keskmised (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Süsteem on elus juba: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat fail asukoht"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Siia sisesta kataloog kus asub sinu amulesig.dat fail"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Värskendamise intervall sekundites"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Genereeri igal värskendamisel staatiline pilt"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Kataloog, kuhu soovid salvestada genereeritud staatilised pildid"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Saada perioodiliselt oma stat fail FTP serverisse"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP asukoht"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Sisesta siia oma FTP serveri URL"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Sisesta siia FTP serveri kataloog kuhu paigutada staatilised pildid"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Kasutaja"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Sinu kasutajanimi FTP serverisse logimiseks"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Sinu parool FTP serverisse logimiseks"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP värskendamise intervall minutites"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Kinnita/kontrolli"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Sinu allkirjafaili asukoha kataloog"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Genereeritud statistiliste piltide kataloog"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Laeb malli <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "WEB serveri HTTP port"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Kasuta UPnP pordisuunamist webserveri portide suunamiseks"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Webserveri täieliku ligipääsu parool"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Webserveri külalise (guest) parool"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Luba külalise (guest) ligipääs"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Keela külalise (guest) ligipääs"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Lae/salvesta webserveri parameetrid eemal-asuvast/asuvasse aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule seadetefaili asukoht. ÄRA KASUTA OTSE!!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Ära kasuta PHP interpretaatorit (aegunud)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Loo PHP lehed iga päringu puhul uuesti"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule WebServer"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "web kliendi ühenus lubatud\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "VIGA: ei luba web kliendil ühenduda\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Päring ebaõnnestus, põhjus: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indeksfaili ei leidnud: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Seanss on aegunud - vajalik uuestilogimine\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Seanss ok, sisselogitud\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Seanss ok, pole sisselogitud\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Pole avatud seanssi - nõuan logimist\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Seanss loodud - nõuan logimist\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Töötlen päringut [algupärane]:"
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Ilma paroolita logimine pole lubatud."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Kontrollin parooli\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Parooli kontrollsumma vigane\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Parool ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Parool, paha\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Sa ei sisestanud parooli. Tühja prooli kasutamine pole lubatud.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Nõuti väljalogimist\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Töötlen päringut [ümbersuunatud]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Ühendus ebaõnnestus "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule erakutsi"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule urruneko kontrola "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Argazkia:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "'Plataforma-orotarako' p2p bezeroa eMulen oinarritua \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,79 +52,79 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule taldea \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "aMuleren zati bat \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Parez-pareko routing-a XOR metrikan oinarritua.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Webgunea:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foroa:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Arakatu bertsio berrien bila abiaraztean"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad-era konektatzen..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ez dago erabilgarri"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Gehitu laguna"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Baliozko IP helbide eta ataka sartu behar dituzu!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Argibideak"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Emandako erabiltzaile egiaztapena ez da baliozkoa!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -133,49 +133,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Konexioak huts egin du "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -184,103 +183,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Huts ED2KLinks fitxategia irekitzerakoan."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Orain, aplikazio nagusia ixten..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia amaitzen ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid-a duen amuleweb instantzia hiltzen ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule irteten: Muina ixten."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule itzaltzea osaturik."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule ixtearen memoria arazte irteera:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Zure lokalak sistemako lehenetsira aldatu dira konfigurazio aldaketa bat dela eta. Barkatu."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Argb"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +284,70 @@ msgstr ""
 "\n"
 "EC konfigurazioa"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "OHARRA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERROREA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ezin da atakak ezarritako helbidean ireki: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "%u ataka ez dago eskuragarri. IDBaxua izango duzu\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +362,48 @@ msgstr ""
 "\n"
 "Egiaztatu zure sarea ataka sarrera eta irteerarako irekirik dagoela ziurtatzeko."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Huts online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Huts aMule online sinadura fitxategia sortzerakoan"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Aukeratutako lokalak ez dirudi zure sisteman instalaturik. (Oharra: Hala ere erabiltzen saiatuko da)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule %s abiarazten duzun lehen aldia da"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bertsioa hau beta bertsio bat da, egunero eguneratzen da, eta\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ez gara ezer apurtu, zure etxea erre, edo zure zakurra akatzen\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "badu ere kargu egingo. Baina erabiltzeko ziurra izan *beharko* litzateke.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Argibide gehiago, laguntza eta bertsio berriak gure webgunean aurki ditzakezu,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io -en, edo irc.libera.chat IRC sareko #aMule kanalean.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Edozein akatsen berri emateko:https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,224 +411,220 @@ msgstr ""
 "Zuk aukeratutako sinadura karpeta BALIOGABEA da!\n"
 " Lehenespenak konpondu artean lineako sinadura EZGAITU egingo da."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Disko aurresleipenak huts egin du '%s' fitxategiarentzat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERROREA: ezin da erregistro fitxategia ireki"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ABISUA: erregistro fitxategia hutsik dago. Zerbait oker dago."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Erregistroa berrezarri egin da"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ZerbitzariMezua: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s-ren deskarga baztertua, eskatutako fitxategia ez da berria eta."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Huts egin du nodo zerrenda deskargatzerakoan."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Huts egin du"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Hondaturiko bertsio arakatze fitxategia"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Zaharkiturik dagoen aMule bertsio bat erabiltzen ari zara!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Zure aMule bertsioa %i.%i.%i da eta azken bertsioa %li.%li.%li da"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OHARRA: Zure aMuled bertsioa zaharkiturik dago: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Zure aMule kopia zaharkiturik dago."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Huts bertsio arakatze fitxategia deskargatzerakoan"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Erab: %s | Fitx: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Erab: E: %s K: %s | Fitx: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Ez dago sarerik hautatuta"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "IDBaxuarekin"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "IDAltuarekin"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s-ra konektaturik"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s-ra konektatzen"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "eD2k-tik deskonektatua"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad abiarazirik."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad gelditurik."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kad-era Konektatuta (ondo)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad sarea ezin da erabili hobespenetan UDP ataka ezgaiturik badago, ez da abiaraziko."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad sarea hobespenetan ezgaiturik, ez da konektatuko."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERROREA: aMule deabrua ezin da erabili kanpo konexioak ezgaiturik badaude. Kanpo konexioak gaitzeko aMule arrunta erabili, amuled --ec-config aukeraz abiarazi edo ezarri \"AcceptExternalConnections\" gakoa 1 balioaz ~/.aMule/amule.conf fitxategian"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERROREA: Pasahitz erabilgarri bat behar da kanpo konexioak onartzeko, eta aMule deabrua ezin da erabili kanpo konexiorik gabe. aMule deabrua abiarazteko \"ECPassword\" eremua dagokion balioarekin ezarri behar duzu ~/.aMule/amule.conf fitxategian. Exekutatu amule --ec-config banderarekin pasahitza ezartzeko. Argibide gehiago https://amule-org.github.io/docs gunean"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: Abioan - ordularia abiarazten"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Ezin da Pid fitxategia sortu"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERROREA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Hau eMulen oinarrituriko aMule %s da."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -646,193 +634,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Sarerik ez"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule urruneko kontrola"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Errore konponezina: Akats ordutegi nagusia sortzerakoan"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Urruneko amulera konektatu"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Konexioa galdu egin da"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Galdetu irteterakoan"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -841,727 +822,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Errore konponezina: Akats ilara ordutegia sortzerakoan"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Gertaera begizta batera joaten..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Konektatzen..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Urruneko interfaze KK gertaera kudeatzailea"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Konexioak huts egin du. Ezin da %s-ra konektatu:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Itzaltzen"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "%s (%s:%i) -ra konexio saiakera denboraz kanpo geratu da."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Sarera konektatu."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Konexioak huts egin du. Ezin da %s-ra konektatu:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Prest"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Guztiak"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Ez dago erabilgarri"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa mantenduko da."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ezezaguna"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Laguna bilatzen id-baxu konexiorako"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Gezurrezko eMule bertsioa %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Gezurrezko eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Gezurrezko eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule v0.%u-tan oinarriturik)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Ezizena: %s ID-a: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Eskaerak: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fitxategi estatistikak saio honentzat. Onarturik %d - eskakizun %d-etik, %s transferiturik\n"
 msgstr[1] "Fitxategi estatistikak saio honentzat. Onarturik %d - %d eskakizunetik, %s transferiturik\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fitxategi estatistikak saio guztientzat: Onarturik %d eskakizun %d-etik, %s transferiturik\n"
 msgstr[1] "Fitxategi estatistikak saio guztientzat: Onarturik %d %d eskakizunetik, %s transferiturik\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Fitxategi ezezaguna eskaturik"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s'-ren mezu bat iragazi da (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s'-ren mezu berria (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "%s (%u) erabiltzaileak ez dagoen %s direktorioaren partekatutako fitxategi zerrenda eskatu du -> Ukatua"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "Oharra: %s ezin da ireki."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "Abisua: Utzitako fitxategi zerrenda hondaturik dago, buru baliogabeak ditu."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "SI errorea %s fitxategia irakurtzean: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Errorea %s fitxategia gordetzerakoan: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Kategoria berria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Aukeratu karpeta bat deskargatutako fitxategientzat"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Kategoria izen bat ezarri behar duzu!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Kategoriarentzat bide bat ezarri behar duzu!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Huts kategoriarentzat sarrera karpeta sortzerakoan. Mesedez ezarri baliozko bide bat!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Berriketa saioa abiarazirik: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Bezerora konektaturik ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Bezerora konektatzen ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Huts bezerora konektatzerakoan / Konexio galdua ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Kaptxa egiaztapena pasa duzu eta erabiltzaileak zure mezua jaso du. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Kaptxa egiaztapena huts egin du eta zure mezua baztertua izan da. Mezu berri bat bidaliaz kaptxa berri bat eskatu dezakezu. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Elkarrizketa"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Itxi fitxa"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Itxi fitxa guztiak"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Itxi beste fitxak"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Gehitu lagun zerrendara"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Kreditu fitxategia kargaturik, bezero %u ezagutzen da"
 msgstr[1] "Kreditu fitxategia kargaturik, %u bezero ezagutzen dira"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - bezero %u-ren kredituak amaitu dira!"
 msgstr[1] " - %u bezeroren kredituak amaitu dira!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Ez da 'cryptkey.dat' fitxategia aurkitu, sortzen."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Bezero xehetasunak"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaxua"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAltua"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Gaitua"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Onartua"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Ez da onartzen"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Ezgaitua"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Konektaturik"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Deskonektatuta"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Ez osorik"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Tipo gaiztoa"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Egiaztaturik: Ondo"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Ez dago erabilgarri"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "%s (%u) erabiltzaileak zure partekatutako fitxategi zerrenda eskatu du -> Onartua"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "%s (%u) erabiltzaileak zure partekatutako fitxategi zerrenda eskatu du -> Ukatua"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "%s (%u) erabiltzaileak zure partekatutako direktorioen zerrenda eskatu du -> Onarturik"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "%s (%u) erabiltzaileak zure partekatutako direktorioen zerrenda eskatu du -> Ukaturik"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "%s (%u) erabiltzaileak '%s' direktorioaren partekatutako fitxategi zerrenda eskatu du -> Onartua"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "%s (%u) erabiltzaileak '%s' direktorioaren partekatutako fitxategi zerrenda eskatu du -> Ukatua"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "%s (%u) erabiltzailearen '%s' partekatutako direktorioa"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "%s (%u) erabiltzailea eskatu gabeko partekatutako direktorioak bidali ditu."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "%s (%u) erabiltzaileak '%s' direktorioko partekatutako fitxategi zerrenda bidali du"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "%s (%u) erabiltzaileak partekatutako fitxategi zerrenda bidaltzeaz bukatu du"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "%s (%u) erabiltzaileak eskatu gabeko partekatutako fitxategi zerrenda bidali du"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "%s (%u) erabiltzaileak fitxategi/direktorio partekatuen zerrenda ikustea ukatu du"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Fitxategi Iruzkinak"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Erabiltzaile izena"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxategi izena"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Kalifikazioa"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Iruzkina"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Ezin da Kad bilaketarik egin Kad ez badago abiarazirik"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Laguna bilatzen id-baxu konexiorako"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ez dago iruzkinik"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "Iruzkin %u"
 msgstr[1] "%u iruzkin"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Baztertutako %s bezeroa %s datu hondatu bidaltzeagatik '%s' fitxategiaren osotasunaren %s"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Huts '%s'-ren estatu datuak kargatzean."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Bax]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [Nor]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto[Alt]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Altua"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Oso Altua"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Bertsioa"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Eskatzen"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Konektatu zerbitzaria bidez"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Ilara Osoa"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ilaran"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Deskargatzen"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Aztertze ezarpenak jasotzen"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Ez du behar den zatirik"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Ezin da IDBaxua-IDBaxua konektatu"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Konexio gehiegi"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Kad bidez Konektatzen"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Kad konexio gehiegi"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Ukatuak"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Konexioa errorea"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Urruneko ilara betea"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "MLDonkey zaharra"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "MLDonkey berria"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule bateragarria"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Zerbitzari lokala"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Jatorri trukaketa"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasibo"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Esteka"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Jatorri haziak"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Bilaketa emaitza"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Amaitua"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Martxan"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERROREA: Disko-leku gabe"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERROREA: Partmet ez da aurkitu"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERROREA: SI errorea!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERROREA: Huts egin du!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Ilaran"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Dagoeneko deskargatzen"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Aldiroko fitxategia formatu ezezagun edo okerrekoa."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Zatia"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferituta"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Abiadura"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Egoera"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Jatorriak"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Lehentasuna"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Egoera"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Denbora faltan"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Azkenez osoa ikusirik"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Azkenez jasoa"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1570,109 +1528,106 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Gelditu"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Berrekin"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "G&arbitu bukaturikoak"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Jaitsi fitxategi honen A4AF guztiak orain"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Jaitsi fitxategi honen A4AF guztiak (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Jaitsi fitxategi guztien A4AF guztiak orain"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Hedatutako aukerak"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Aurrebista"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Erakutsi &xehetasunak"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Erakutsi iruzkin guztiak"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopiatu URI magnetikoa arbelera"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopiatu eD2k &lotura arbelera"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiatu berrelikadura arbelera"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "ezarri gabea"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Ezarri kategoria bat"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Ireki fitxategia"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Sar izen berri bat fitxategi honentzat:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Fitxategia berrizendatu"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Deskargak (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1681,348 +1636,347 @@ msgstr ""
 "Ohar hau aurreikuspen bakoitzean agertzea saihesteko,\n"
 "ezarri zure bideo erreproduzigailu gogokoena hobespen leihoan (lehenetsia %s da)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Fitxategi aurreikuspena"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROREA: Huts kanpo bideo erreproduzigailua abiaraztean! Komandoa: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "%u zati fitxategia gordetzen %u-tik"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "ZatiFitxategi guztiak gorde dira."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "%sd-tik aldiroko fitxategiak kargatzen."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "%u zati fitxategia kargatzen %u-tik"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERROREA: Huts babeskopia fitxategia kargatzerakoan. Bilatu https://github.com/amule-org/amule/discussions -en .part.met fitxategi berreskuratze konponbideak."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "ZatiFitxategi guztiak kargatu dira."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Ez da zati fitxategirik aurkitu"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "zati fitxategi %u aurkitu da"
 msgstr[1] "%u zati fitxategi aurkitu dira"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Aldiroko direktorioaren fitxategi sistemak ez ditu fitxategi luzeak onartzen."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Sarrera direktorioaren fitxategi sistemak ez ditu fitxategi luzeak onartzen."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "%s Deskargatzen"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Dagoeneko '%s' fitxategia deskargatzen ari zara"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Dagoeneko baduzu '%s' fitxategia"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Dagoeneko baduzu '%s' fitxategia"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Ezin da lotura magnetikoa eD2k bihurtu: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Lotura protokolo ezezaguna: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Okerreko eD2k lotura! ERROREA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Bezeroak pakete bat bidali du egiaztapenak huts egin ondoren."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Kanpo konexioa ukaturik."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Pasahitz zuria dela eta kanpo konexioak ezgaiturik!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Kanpo konexioak ezgaiturik konfigurazio fitxategian"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Kanpo konexio berri bat onartu da"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERROREA: ezin da kanpo konexio berria onartu"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Hobespenetan pasahitza zurian dela eta kanpo konexioak ukaturik!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Bezerora konektatzen: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Bertsio ezezaguna"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Okerreko bertsio ID-a, bitar bateratze ezintasuna dago. Erabili urruneko eta nagusi bertsio berdina."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ezin zara argitaratutako bertsio batetara konektatu edozein garapen bertsiotik! *ikusi* apurketa aukera saihestua"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Protokolo bertsio marka falta da."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentifikazio errorea: okerreko egiaztapena ezarri da EC pasahitz gisa."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Egiaztapenak huts egin du: okerreko pasahitza."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Egiaztapenak huts egin du: pasahitza falta da."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Eskakizun baliogabea, mesedez identifikatu aurretik."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Sarrera onartua."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" errore mezua bezerora bidalia."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Baimendu gabeko sarrera saiakera %s-tik. Konexioa itxia."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Urruneko ZatiFitxategi komandoak huts egin du: Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Ez da %s fitxategi egiaztapena aurkitu"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! OpCode prozesu errorea!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Zerbitzaria ez da gehitu"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "ez da zerbitzaria aurkitu: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "ezabatzeko zerbitzaria ezarri behar da"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Urruneko interfazeko Web bilaketak ez du zentzurik."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bilaketa bidean. Emaitzak emango une batean!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Ez dago punturik grafikoarentzat."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Zure bezeroa ez dago xehetasun maila honetarako konfiguraturik."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Kanpo konexioa: itzaltzea eskatuta"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Dagoeneko irteten."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "KanpoKonexioa: '%s' lotura gehitzen."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Fitxategia ez da aurkitu."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Fitxategi izen baliogabea."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ezinda fitxategia berrizendatu."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad ezgaiturik dago hobespenetan."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Dagoeneko eD2k-ra konektaturik."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "ed2k-era konektatzen..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Dagoeneko Kad-era konektaturik."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kad-era konektatzen..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Sare guztiak ezgaiturik daude."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "eD2k-tik deskonektatua."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kad-etik deskonektaturik."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Kanpo Konexioa: okerreko opcode-a jasoa: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode baliogabea (okerreko protokolo bertsioa?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "'%s' luzapen ezezaguna '%s' komandoarentzat.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "'%s' komando ezezaguna.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2030,7 +1984,7 @@ msgstr ""
 "\n"
 "Komando honek ezin du argumenturik eduki.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2038,7 +1992,7 @@ msgstr ""
 "\n"
 "Komando honek argumentu bat eduki behar du.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2046,7 +2000,7 @@ msgstr ""
 "\n"
 "Komando hau osotu gabe dago, beheko luzapen hauetako bat erabili dezakezu.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2054,11 +2008,11 @@ msgstr ""
 "\n"
 "Gehigarri erabilgarriak:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Komando erabilgarriak:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2069,17 +2023,17 @@ msgstr ""
 "Komando guztietan berdin da maiuskula/minuskula.\n"
 "Idatzi '%s <komandoa>' <komandoa>-ri buruzko xehetasunak ikusteko.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Aplikaziotik ateratzen da."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Laguntza bistarazi."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2087,7 +2041,7 @@ msgstr ""
 "Komando bati buruz laguntza jasotzeko, idatz ezazu 'help <komandoa>'.\n"
 "Komandoen zerrenda osoa eskuratzeko, 'help' idatzi.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2098,46 +2052,46 @@ msgstr ""
 "Erabili '%s' komando zerrendarentzako\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Sintaxi errorea!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Errorea komandoa prozesatzekoan - Ez zen inoiz pasa beharko! Mesedez zorriaren berri eman\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Komando honek ez luke parametrorik eduki beharko."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Komando honek parametro bat eduki beharko luke."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argumentu baliogabea."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Hau komando osatugabe bat da."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Sakatu '%s' laguntza gehiagorako.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Hau %s %s %s da\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Hau %s %s da\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2145,7 +2099,7 @@ msgstr ""
 "\n"
 "Bezeroa sortzen...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2154,7 +2108,7 @@ msgstr ""
 "\n"
 "Ados, %s uzten...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2168,331 +2122,326 @@ msgstr ""
 "\n"
 "Irteten...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Laguntza testu hau bistarazi."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule abiarazirik duen ostalaria. (lehenetsia: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Kanpo konexioetarako aMuleren ataka. (Lehenetsia 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Kanpo konexio pasahitza."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Konfigurazio fitxategitik irakurri."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Ez ezer bistarazi irteera estandarrean."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Luze - arazten mezuak ere bistarazi."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Programa lokala (hizkuntza) ezarri."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Idatzi komando lerroko aukerak konfigurazio fitxategira."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "aMuleren konfigurazio fitxategian oinarriturik konfigurazio fitxategia sortzen du."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Programa bertsioa bistarazi."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Fitxategi xehetasunak"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% egina"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Ongietorria!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Lagunera konektatzen"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Konexio egoera:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Sareak"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "TCP ataka estandarra "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Hedatutako UDP ataka (Kad / bilaketa orokorra) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Gaitu UPnP router ataka berbideraketarako"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Autoabioa"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia irakurketarako irekitzean!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Lagunak"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Erakutsi &xehetasunak"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Gehitu laguna"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Ezabatu laguna"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Bidali &mezua"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ikusi fitxategiak"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Ezarri lagunen ataka"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Ziur zaude hautatako laguna ezabatu nahi duzula?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Ziur zaude hautatako lagunak ezabatu nahi dituzula?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2500,11 +2449,11 @@ msgstr ""
 "Ez duzu lagun-ataka bat baino gehiago ezartzeko baimenik.\n"
 " Ataka bat bakarrik dago sinaturik."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Aukera anitza"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2513,206 +2462,205 @@ msgstr ""
 "Ez duzu lagun-ataka bat baino gehiago ezartzeko baimenik.\n"
 " Ataka bat bakarrik dago sinaturik."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Bidali mezua erabiltzaileari"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Bidali behar de mezua:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Lagunetatik kendu"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Mezua bidali"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Swap fitxategi honentzat"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Ilaran: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Beste fitxategi batez galdeturik"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Igoera ataka baten zain"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Ilaran: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Igotzen"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Batez"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ez"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Bai"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Deskargatzen..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP deskarga utzia"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Deskargatzeko URLa ezin da hutsik egon"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d byte deskargaturik"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "%s URL-aren erantzuna: %i - Errorea (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP deskarga utzia"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Deskargatu GeoIP.dat berria %s-tik"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "GeoIP.dat deskargak huts egin du eguneraketa baztertzen."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Huts %s fitxategia ezabatzean, eguneraketa baztertzen."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Huts %s fitxategia berrizendatzean, eguneraketa baztertzen."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s behar bezala eguneratu da"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Huts GeoIP.dat deskargatzean"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Huts %s %s-tik deskargatzean"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "'ipfilter.dat' eta 'ipfilter_static.dat' IP iragazkiak kargatzen."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Huts egin du ipfilter.dat '%s' fitxategia kargatzerakoan, formatu ezezagunak aurkitu dira."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Huts egin du ipfilter.dat '%s' fitxategia kargatzerakoan, ezin da fitxategia ireki."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "IP-eremu %u kargaturik'%s'-tik."
 msgstr[1] "%u IP-eremu kargaturik'%s'-tik."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "Gaizki eratutako lerro %u alde batetara utzi da."
 msgstr[1] "Gaizki eratutako %u lerro alde batetara utzi dira."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Huts %s fitxategi berria berrizendatzean, eguneraketa baztertzen."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP iragazkia presta dago"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2720,876 +2668,844 @@ msgstr ""
 "Hemendik abiarazi:\n"
 "bezero ezagunak"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodoak (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Abiarazteko ip baliogabea"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Abiarazteko ataka baliogabea"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Beharrezko eremu guztiak bete"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mezua"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ziur zaude nodes.dat fitxategi berri bat deskargatu nahi duzula?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Hau eginez zure nodo zerrenda ezabatu eta Kademlia konexioa berrabiaraziko da."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Jarraitu?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: bilaketa gako laburregia"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Bilaketa gakoa dagoeneko bilaketa zerrendan dago: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Huts nodes.dat fitxategia irakurtzean - zaharregia. Bertsioa hau (0) ez da luzaroago onartzen."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Irakurri Kad kontaktu %u"
 msgstr[1] "Irakurri %u Kad kontaktu"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Ez da kontakturik aurkitu, mesedez autoabiatu edo deskargatu nodes.dat fitxategi bat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Bakarrik Kad kontaktu %d dago eskuragarri, nodes.dat ez da idatziko"
 msgstr[1] "Bakarrik %d Kad kontaktu daude eskuragarri, nodes.dat ez da idatziko"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Idatzi Kad kontaktu %d"
 msgstr[1] "Idatzi %d Kad kontaktu"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad sarea"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Fitxategia"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Fitxategi tamaina"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Partekatze erlazioa"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Eskatutakoa"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Onartua"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Jatorri osoak"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "Abisua: Fitxategi ezagun zerrenda hondaturik dago, buru baliogabeak ditu."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Huts fitxategi ezagunen zerrendako sarrera bat kargatzean, hondaturik egon liteke"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Okerreko sarrera fitxategi ezagunen zerrendako fitxategian, hondaturik egon liteke: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "%d errore ezezaguna"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Ezin da %d errorearen azalpena eskuratu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Aztertzen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Osotzen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Amaitua"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Geraturik"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Akasdun"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Zain"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Pasahitz ez zuri bat ezarri behar duzu."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Pasahitz baliogabea, ez da MD5 egiaztapena!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Konexio errorea"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Kanpo konexioa ukaturik."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC konexioa huts egin du. Erantzun hutsa."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Kanpo konexioa: Okerreko erantzuna, esku-emateak huts egin du. Konexioa itxirik."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Lortua! Amulera konexioa sortua "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Lortua! Konexioa sortua."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Kanpo konexioa: Sarrera ukatze arrazoia: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ondo."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERROREA: Ezin da TCP ataka entzun."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERROREA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "OHARRA: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Itxi"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Ebaki"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Garbitu"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Hautatu dena"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Konektaturik"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Konektaturik"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Kad-era Konektatuta (suebakirik)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "ZerbitzariIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Zerbitzaria IP-a:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "konektatu gabe"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP ataka: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP ataka: Ez dago prest"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "TCP ataka: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP ataka: Ez dago prest"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Bezero argibidea"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Igoera muga"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Deskarga muga"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "aMule erakutsi"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "aMule ezkutatu"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Irten"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Mugarik gabea"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule tresna-barra Menua"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Abiadura mugak:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "IG: Batez"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "IG: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DE: Batez"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DE: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Deskarga abiadura: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Igoera abiadura: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Ezizena: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Goitizena ez hautatuta!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "BezeroID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Zerbitzari izena: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ZerbitzariIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Konektatu gabe"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Linean sinadura: Gaituta"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Linean sinadura: Ezgaitua"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Abiarazia: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Partekatutako fitxategiak: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Bezeroak ilaran: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "DE guztira: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "IG guztira: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Ed2k edo lotura magnetiko bat gehitu muinera."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Gehitu lagun zerrendara"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Hemen klikatu eD2k lotura deskarga ilararen testu kontrolean gehitzeko."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Gertaerak hemen agertuko dira. Gertaera zerrenda osorako, begiratu Zerbitzari fitxako erregistroan."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Kargatzen ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Konektatuta zauden zerbitzariaren erabiltzaile kopurua ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Erabiltzaile: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Uneko zerbitzarira konektaturiko erabiltzaileak eta guztirako erabiltzaile kalkulua."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Gora: 0.0 | Behera: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Unekoa igoera eta deskarga batez bestekoa. Gaiturik badago parentesi arteko zenbakiak bezero goiburu datuak dira."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Konexio egoera eta uneko transferentziak bistaratzen ditu. Gezi gorriak deskonektaturik zaudela adierazten du, horiak berriz ID baxua (suebakia) duzula eta berdeak ID altua (konexio mota hoberena)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ez konektaturik ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Une honetan konektaturiko zerbitzaria."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Bilatu"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Izena:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Mota"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokala"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Orokorra"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Hedatutako parametroak"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Iragazten"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Fitxategi mota"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Edozein"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Konprimituak"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audioa"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-irudiak"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Irudiak"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programak"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Testuak"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Bideoak"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Hedapena"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Gutx. tamaina"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Byte"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Gehi. tamaina"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Eskuragarritasuna"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Iragazkia:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Iragazi emaitzak"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Emaitza alderantzikatu"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Fitxategi ezagunak ezkutatu"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Hasi"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Gehiago"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Gelditu"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Deskargatu"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Eremuak garbitu"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Emaitzak"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Garbitu amaituriko deskargak"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fitxategiaren iturburua:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "E/G"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Orokorra"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Izen osoa :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-fitxategia :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Fitxategi tamaina :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferentzia"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Fitxategi zati egoera :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Azkenez osorik ikusia :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Aurkitutako jatorriak :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Jatorriak transferitzen :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Fitxategi zati kopurua :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Erabilgarri :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Deskarga aktibo denbora: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferituta :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Amaitua tamaina :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Hondatze kudeaketa adimentsua"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Hondaketan galdutakoa :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Konpresioaz irabazitakoa :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.C.H. gordetako paketeak :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Partekatuak: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Eskaerak"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Onartutako eskaerak"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Transferitutako datuak"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Partekatze erlazioa"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Jatorri osoak"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Igoerak: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Kalifikatu gabea"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titulua :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Fitxategi izenak"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Konpondu"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Garbitu"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Ezarri"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Iruzkin/tasa fitxategia (testua erabiltzaile guztiek ikusgarria)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3597,1269 +3513,1265 @@ msgstr ""
 "Filma batentzat iraupena, istorioa, hizkuntza ...\n"
 "eta faltsua den esan dezakezu, aMule beste erabiltzaileei esan diezaiekezu."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Fitxategi kalitatea"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Kalifikatu gabea"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Baliogabe / Apurturik / Gezurra"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Pobrea"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Oso ona"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Ondo"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Hobezina"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Fitxategi kalifikazioa hartu edo fitxategia baliogabea bada besteak abisatu ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Kad-etik deskonektatua"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Berritu"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Deskargatzen, itxoin mesedez ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Ezezaguna"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Behar den Informazioa"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP helbidea :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Ataka :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Bestelako informazioa"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Erabiltzaile-izena :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Igoera abiadura"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Estatistika zuhaitza"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Erabiltzaile izena:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Erabiltzaile-Egiaztapena:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Bezero softwarea:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Bezero bertsioa:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP helbidea:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Erabiltzaile ID-a:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Zerbitzaria IP-a:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Zerbitzari izena:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Nahasmena:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "bezerora transferentziak"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Uneko eskakizuna:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Bataz besteko igoera abiadura:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Bataz besteko deskarga abiadura:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Igoa (saioa):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Deskargatua (saioa):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Igoa (denera):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Deskargatua (denera):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Puntuak"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DE/IG aldagaia:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identitate ziurra:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Ilara ranking-a:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Ilara puntuak:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Ezizena"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - plataforma anitzetarako mandoa"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Hau beste erabiltzaileek zuri konektatzerakoan ikusiko duten izena da."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Hizkuntza: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Argibideak bistarazi aurreko denbora."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Honek kontroletan erabiliko den hizkuntza ezartzen du."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Arakatu bertsio berrien bila abiaraztean"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Hau gaitzean Amulek abiaraztean bertsio berririk dagoen arakatzea egingo du"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Hasi txikiturik"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Gaitzerakoan aMule txikituri abiaraziko da."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Galdetu irteterakoan"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "aMulek irten aurretik galdetzea egiten du."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Tresna-barra ikonoa gaitu"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Honek tresna-barra (edo lan-barra) ikonoa gaitu/ezgaitzen du."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Ezkutatu aplikazio leihoa itxi botoia sakatzean"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Txikitu ikono-barrara"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Hau gaitzeak aMule zeregin-barrara beharrean sistema tresna-barrara txikitzea eragingo du."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Gomendio atzerapena: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundo"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Nabigatzaile hautaketa"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Ireki fitxa berrian aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ireki web orria fitxa berrian leiho berrian ordez aukera dagoenenean"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Bideo-erreproduzigailua"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Konexio mugak"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Igo"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Ataka ezarpena"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Atakak"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Hau eD2k ataka estandarra da eta ezin da ezgaitu."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP ataka zerbitzari eskakizunetarako (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "UDP ataka hau hedaturiko eD2k eskakizun eta Kad sarerako erabiltzen da"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP ataka (aukerakoa):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Jatorri muga deskarga bakoitzerako:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Konektatu abiaraztekoan"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "birkonektatu konexioa galtzean"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Ezabatu hildako zerbitzaria geroago"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "saiakerak"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Zerrenda"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Eguneratu zerbitzari zerrenda zerbitzari batetara konektatzean"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Eguneratu zerbitzari zerrenda bezero bat konektatzean"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Erabili lehentasun sistema"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Erabili IDbaxu egiaztapena konektatzerakoan"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Konexio ziurra"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Estatiko zerbitzarietara bakarrik auto-konektatu"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Ezarri eskuz gehitutako zerbitzariak lehentasun altuan"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Gehitu fitxategiak deskargetara geldirik"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Gehitu fitxategiak deskarga zerrendara auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Saiatu lehen eta azken zatiak hasieran deskargatzen"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Abiarazi lehen pausaturiko fitxategia fitxategi bat osatzean"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Kategoria berdinekoa"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Orden alfabetikoan"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Aurresleitu disko lekua fitxategi berrientzat"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Fitxategi berrientzat fitxategi bakoitzarentzat disko leku osoa aurresleitzen du, honek fragmentazioa murrizten du"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Gelditu deskargak disko-leku librea hona iristean "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Aukera hau hautatu aMulek zure disko-lekua egiaztatzea nahi baduzu"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Ezarri hemen nahi duzu disko toki txikiena."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "10 jatorri gorde fitxategi arraroentzat (< 20 jatorri)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Igoerak"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Gehitu partekatutako fitxategi berriak auto-lehentasunarekin"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Hondatze kudeaketa adimentsua (I.C.H)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Gaitu"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H aurreratuak, egiaztapen bakoitza egiaztatzen du (ez da gomendatzen)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Ezabatu"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Egin klik eskuineko botoiaz karpeta ikono batean barnekoak ere partekatzeko)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Partekatu ezkutatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikak"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Eguneratze atzerapena : 5 seg"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Bataz besteko grafiko denbora : 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Konexio graf eskala: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Deskarga grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Igoera grafiko eskala:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Koloreak: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Sareta"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Uneko deskargak"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Martxan deskargak bataz bestean"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Saioaren bataz besteko deskargak"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Uneko igoerak"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Martxan igoerak bataz bestean"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistema-barra abiadura-barra ikonoa"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Uneko Kad-nodoak"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-nodoak martxan"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Hautatu"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Zuhaitza"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Erakutsiko diren bezero kopurua (0=mugagabea)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! KONTUZ !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Gehienezko konexio berri / 5 seg"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP igoera aldia minututan"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fitxategia buffer tamaina: 240000 byte"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Igoera ilara tamaina: 5000 bezero"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Zerbitzari konexio berritze aldia: Ezgaiturik"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Ezgaitu ordenagailu ordulariaren bigarren planoko modua"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Erabiltzeko azala: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Erakutsi \"eD2k lotura kudeatzaile azkarra\" leiho bakoitzean."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Erakutsi argibide hedatuak kategoria fitxetan"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Erakutsi aplikazio bertsioa izenburuan"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Erakutsi transferentziak izenburuan"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Aplikazio izenaren aurretik"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Aplikazio izenaren ondoren"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Erakutsi goiburu erabilpena"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Tresna-barra bertikal orientazioa"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Deskargatu ilara fitxategiak"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Erakutsi aurrerapen ehunekoa"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Erakutsi aurrerapen barra"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Laua"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Gonbidatu sarrera ezgaitu"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Gonbidatu pasahitza web zerbitzarirako"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4867,11 +4779,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4881,827 +4793,827 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Ezgaitua [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "byte"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "A"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/seg"
 msgstr[1] "byte/seg"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "seg"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ordu"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "egunak"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "denak"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "Beste denak"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Amaitugabea"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Gelditua"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Bideoa"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Fitxategia"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Testua"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Martxan"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Konfigurazio direktorioa: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Zati-fitxategiak aria bihurtzearen zain ixteko..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "%s inportatzen: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Aldiroko karpeta irakurtzen"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Deskarga fitxategiaren argibide oinarrizkoak eskuratzen"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Helburu fitxategia sortzen"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Deskarga fitxategi zaharretik Kargatzen (%u %u-tik)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Datu blokeak deskarga fitxategi berrian gordetzen (%u %u-tik)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Deskarga fitxategi argibide jatorria eskuratzen"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Deskarga gehitu eta zati fitxategi berria gordetzen"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Zati fitxategiak inportatu"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Egoera"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "FitxategiEgiaztapena"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Diskoa: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Mesedez ezarri aldiroko fitxategiak bilatuko diren karpeta! (azpikarpetak ere arakatuko dira)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Behar bezala deskargaturiko fitxategien jatorri fitxategiak ezabatze nahi al duzu?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Ezabatu jatorriak?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERROREA: Huts zati fitxategia sortzerakoan"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "met-file fitxategiaren babes-kopia %s-tik kargatzen saiatzen"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERROREA: Huts part.met fitxategiak irekitzean: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERROREA: part.met fitxategi tamaina 0 da: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERROREA: part.met fitxategi bertsio okerra: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Errorea: %s (%s) hondaturik dago (marka okerrak: %s), ezin da fitxategia kargatu."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERROREA: %s (%s) hondaturik dago (okerreko etiketa-kopurua), ezin da fitxategia kargatu."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Fitxategi informazioa berreskuratzen saiatzen..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Izen gabeko fitxategia berreskuratzen - RecoveredFile.dat bezala berreskuratzen saiatuko da"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Fitxategi informazio eskuragarri guztia berreskuraturik :D - Erabiltzen saiatzen..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Ezin da fitxategi informazioa berreskuratu:("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Huts egin du irekitzerakoan: %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ABISUA: %s agian hondaturik dago (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERROREA zati fitxategia gordetzerakoan: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "SI errorea zati fitxategia gordetzerakoan: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Errorea %s-ren part.met.seeds fitxategia gordetzerakoan"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "jatorri ale %i bildurik zati fitxategiarentzat: %s (%s)"
 msgstr[1] "%i jatorri ale bildurik zati fitxategiarentzat: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "jatorri ale %i bildurik zati fitxategiarentzat: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Errorea zati-fitxategi hazi fitxategia irakurtzerakoan (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Hondaturiko zatia (%d) aurkitu da %d zati %s zati fitxategian - FitxategiEgiaztapenEmaitza |%s| fitxategiEgiaztapena |%s|"
 msgstr[1] "Hondaturiko zatia (%d) aurkitu da %d zatitan %s zati fitxategian - FitxategiEgiaztapenEmaitza |%s| fitxategiEgiaztapena |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Bukatutako (%i) zatia aurkiturik %s-n"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Amaitutako berrazterketa: %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ustekabeko errorea %s osatzean. Fitxategia gelditurik"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Deskarga amaiturik: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Deskarga amaiturik: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "fitxategia ezabatzen:%s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ABISUA: Ezinda deskargaturiko zatia egiaztatu - egiaztapen-bilduma osatugabe '%s'-rentzat"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERROREA: Ezin da deskargaturiko zatia egiaztatu - egiaztapen-bilduma osatugabea (%s). Hau ez zen inoiz gertatu beharko"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Egiaztapenean fitxategi amaiera deskargaturiko %2$u tamaina duen %1$u zatian (geh. %3$u) %5$u tamaina duen '%4$s' zati-fitxategian: %6$s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "KONTUZ: Diskoa leku askieza! Fitxategia gelditzen: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Deskargaturiko %i zatia hondaturik dago fitxategi honetan: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Hondaturiko %i zatia %s-rena -> Gordetako byte-ak: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Esleitzen"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Disko leku askieza"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Deskargatua"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Konexioa"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktorioak"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Zerbitzariak"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Segurtasuna"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfazea"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy-a"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Iragazkiak"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Urruneko kontrolak"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Sinadura linean"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Aurreratua"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Gertaerak"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Araztena"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5711,15 +5623,15 @@ msgstr ""
 "    %PARTFILE - fitxategiaren bide osoa\n"
 "    %PARTNAME - fitxategi-izena soilik"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5735,35 +5647,35 @@ msgstr ""
 "Amulek ondo funtzionatu beharko luke ezarpen\n"
 "hauek aldatu gabe."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara konektatzean"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz konfiguraziotik programara datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Konektatzen ari zaren Proxy-aren mota"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Huts %d IDa eta %s gakoaz programatik konfiguraziora datuak bidaltzean"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5771,42 +5683,42 @@ msgstr ""
 "aMule berrabiarazi egin behar da aldaketa hauek gaitu ahal izateko:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP - ataka aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Kanpo konexio ataka aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Lanpo konexio onarpena aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Kanpo konexio interfazea aldatua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo nahastea"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5814,7 +5726,7 @@ msgstr ""
 "Auto-eguneraketa zerbitzari zerrenda hutsa dago.\n"
 "'Auto-eguneratu zerbitzari zerrenda abioan' ezgaitu egingo da."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5822,33 +5734,33 @@ msgstr ""
 "Kanpo konexioak gaiturik dituzu baina ez duzu pasahitzik ezarri.\n"
 "Kanpo konexiorik ezin da onartu baliozko pasahitza ezarri arte."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Hizkuntza aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Aldiroko karpeta aldaturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K sarea gaiturik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Protokolo bertsio baliogabea."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5768,7 @@ msgstr ""
 "Bai eD2k eta bai Kad sareak ezgaiturik daude.\n"
 "Ezingo zara konektatu behintzat bietako bat gaitu arte."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5776,7 @@ msgstr ""
 "Kad ezin da abiarazi zure UDP ataka ezgaiturik badago.\n"
 "UDP ataka gaitu edo Kad ezgaitu."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,69 +5786,69 @@ msgstr ""
 "aMule orain berrabiarazi BEHAR duzu.\n"
 "Orain ez berrabiaraziaz gero ez kexatu ezer txarra gertatzen bada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Pasahitza ezarria eta kanpo konexioak gaiturik."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5946,66 +5858,66 @@ msgstr ""
 "Mesedez bete behintzat baliozko server.met fitxategi batetara zuzenduaz.\n"
 "Klikatu \"zerrenda\" botoia URL-a sartzeko."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Aldi baterako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Sarrera fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Linean sinadurak"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Aukeratu karpeta bat %s-rentzat"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Arakatu bideo erreproduzigailua"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Hautatu nabigatzailea"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Abiarazgarria%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editatu zerbitzari zerrenda"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6013,1210 +5925,1209 @@ msgstr ""
 "Gehitu hemen server.met deskargatzeko URL-a.\n"
 "URL helbide bat lerro bakoitzean."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Jatorri osoak"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Egoera:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Eguneratze maiztasuna: seg %d"
 msgstr[1] "Eguneratze maiztasuna: %d seg"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Batez besteko grafiko denbora: minutu %d"
 msgstr[1] "Batez besteko grafiko denbora: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Konexio grafiko eskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fitxategi buffer tamaina: byte %d"
 msgstr[1] "Fitxategi buffer tamaina: %d byte"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Igoera ilara tamaina: bezero %d"
 msgstr[1] "Igoera ilara tamaina: %d bezero"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Zerbitzari konexio berritze maiztasuna: minutu %d"
 msgstr[1] "Zerbitzari konexio berritze maiztasuna: %d minutu"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Zerbitzarira konexio berritze maiztasuna: Ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "ezgaiturik"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Gertaeran'%s' komandoa exekutatu"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Gaitu komando exekuzioa muinean"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Muin komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Gaitu komando exekuzioa urruneko interfazean"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Urruneko interfaze komandoa:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Hurrengo aldagaiak aldatuko dira:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezkoa alde batetara utziko da."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Bilaketa oharra"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Nagusia"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Ezin da eD2k bilaketarik egin eD2k ez badago konektaturik"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Bilatzeko gakoa: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Espero gabeko errorea Kad bilaketa egitean: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FitxategiID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Kalifikatu gabea"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Kategori honetan deskargatu"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Eskuratu %s fitxategi honentzat"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Bilatu erlazionatutako fitxategiak (eD2k, zerbitzari lokala)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Markatu fitxategia ezaguna bezala"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiatu ed2k lotura arbelera"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Konektaturik zauden zerbitzaria ezabatu nahi duzu. Mesedez deskonektatu lehenik."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Utzia"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Berria"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Huts zerrendaturiko nahasitako zerbitzarietara konektatzean. Nahaste gabeko beste saiakera bat egiten."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Huts zerrendaturiko nahasitako zerbitzarietara konektatzean. Nahaste gabeko beste saiakera bat egiten."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Huts zerrendako zerbitzari guztietara konektatzen saiatzerakoan. Berriz hasiko nahiz."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Huts zerrendako zerbitzari guztietara konektatzen saiatzerakoan. Berriz hasiko nahiz."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k sarea hobespenetan ezgaiturik, ez da konektatuko."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Ez da konektatzeko baliozko zerbitzaririk aurkitu zerbitzari zerrendan"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "%s (%s:%i)-ra konektaturik"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Konexioa sorturik: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Errore konponezina konektatzen saiatzean. Internet konexioa eroria egon daiteke"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "%s (%s:%i)-ra konexioa galduta"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) hilik dagoela dirudi."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) beterik dagoela dirudi."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da segundo %d-etan"
 msgstr[1] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da %d segundotan"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Huts %s (%s:%i) -ra konektatzerakoan."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERROREA: Socket baliogabea denbora-muga egiaztapenean"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "%s (%s:%i) -ra konexio saiakera denboraz kanpo geratu da."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Zaharkitutako DNS galdeketa erantzuna, baztertzen."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "server.met fitxategia kargatzen: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met fitxategia ez da aurkitu!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Huts '%s' server.met fitxategi irakurtzerakoan, formatu ezezaguna aurkiturik."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Huts server.met fitxategia irekitzerakoan!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met fitxategia hondaturik dago, bertsio marka baliogabea aurkitu da: 0x%x, tamaina %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "zerbitzari %i aurkiturik server.met fitxategian"
 msgstr[1] "%i zerbitzari aurkiturik server.met fitxategian"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "zerbitzari %d gehiturik"
 msgstr[1] "%d zerbitzari gehiturik"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Errorea: 'server.met' fitxategia hondatua dago: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "SI errorea 'server.met' fitxategia irakurtzean: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Zerbitzaria ez da gehitu: [%s:%d] -ek ez du baliozko atakarik ezarri."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Zerbitzaria ez da gehitu: [%s:%d] -ren IP helbidea iragazirik dago edo baliogabea da."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Zerbitzaria ez da gehitu: [%s:%d] IP:Ataka dun zerbitzaria aurkitu da zerrendan."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Zerbitzaria gehiturik: [%s:%d] zerbitzaria '%s' izena erabiltzen."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Konektaturik zauden zerbitzaria ezabatu nahi duzu. Mesedez deskonektatu lehenik."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Huts '%s' irekitzerakoan"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Huts server.met gordetzerakoan!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL Baliogabea"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Amaituta zerbitzari zerrenda %s-tik deskargatzeaz"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Ez da zerbitzari zerrenda helbideri aurkitu 'addresses.dat' fitxategian. Mesedez itsatsi zerbitzari zerrenda erabilgarri bat fitxategi honetan zerbitzari-zerrenda eguneratu ahal izateko"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Hasi zerbitzari zerrenda %s-tik deskargatzen"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "OHARRA: URL baliogabea ezarri zerbitzari auto-eguneraketarako: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Ez da baliozko server.met auto-deskarga url helbiderik aurkitu addresses.dat fitxategian"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Huts zerbitzari zerrenda %s-tik deskargatzerakoan"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Zerbitzari lokala IPIragazkiak iragazirik dago, beste zerbitzari batetara birkonektatzen!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Zerbitzaria izena"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Helbidea"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Ataka"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Azalpena"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Erabi."
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Estatikoa"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Bertsioa"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Ezabatu naian zauden zerbitzarira konektaturik zaude. Mesedez deskonektatu zaitez aurretik. Zerbitzaria EZ da ezabatuko."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Izen ezezaguna)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ziur al zaude %s zerbitzari tinkoa ezabatu nahi duzula"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Zerbitzariak (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Zerbitzaria"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Zerbitzarira konektatu"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Zerbitzaria estatiko bezala markatu"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Zerbitzaria ez-estatiko bezala markatu"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Zerbitzariak estatiko bezala markatu"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Zerbitzariak ez-estatiko bezala markatu"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Ezabatu zerbitzaria"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ezabatu zerbitzariak"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Kendu zerbitzari guztiak"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopiatu eD2k loturak arbelera"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Zerbitzarira birkonektatu"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Ziur zaude zerbitzari guztiak ezabatu nahi dituzula?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Ziur zaude aukeratutako zerbitzaria ezabatu nahi duzula?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ziur zaude aukeratutako zerbitzariak ezabatu nahi dituzula?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERROREA: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ABISUA: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Bezero id berria: %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ABISUA: ID baxua jaso duzu!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tZiurrenik firewall edo router baten atzean zaudelako izan daiteke."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tArgibide gehiagorako begiratu https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Zerbitzari argibide ezezaguna jasoa! - laburregia"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Zerbitzari berri %d jasoa"
 msgstr[1] "%d zerbitzari berri jasoak"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Zerbitzari zerrenda gordetzeaz amaitu da."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Zerbitzariak azken komandoa ukatu du"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Hondaturiko pakete bat jaso da zerbitzaritik: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Errore kudeaezina zerbitzariko paketea prozesatzekoan: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Ezin da DNS ebazpen hari bat sortu %s-ra konektatzeko"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "%s (%s) IP-dun zerbitzaria iragazirik dago.  Ez dago konektatzen."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "protokolo nahastea erabiltzen."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Konektatzen: %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Ezin da %s zerbitzariaren dns-a ebatzi: Ezin da konektatu!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule erregistroa"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Zerbitzaria ez da gehitu: ez da IP edo ostalari izenik ezarri."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Zerbitzaria ez da gehitu: Baliogabeko zerbitzari-ataka ezarririk."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k egoera:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Konexio egoera:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Konektaturik"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia egoera:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "LAN moduan abiarazirik"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Martxan"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademlia egoera:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Egoera:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Konexio egoera:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Suebakirik - ireki %d TCP ataka zure router edo suebakian"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP konexio egoera:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Suebakirik - ireki %d UDP ataka zure router edo suebakian"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Suebaki egoera: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Ez da lagunik behar - TCP ataka irekia"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Ez da lagunik behar - UDP ataka irekia"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Laguna ez"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Lagunera konektatzen"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Lagunera %s-en konektaturik"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indexatutako jatorriak:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indexaturiko gakoak:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indexatutako oharrak:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indexaturiko karga:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Bataz besteko erab:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Bataz besteko fitxategiak:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Geldirik"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "%s fitxategia partekatuei gehitzen"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i ezagututako partekatutako eta ezezagun %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako eta %i ezezagun aurkiturik"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERROREA: %s partekatzeko saiakera"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Partekatutako direktorioa ez da aurkitu, baztertzen: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Erabiltzaile izena"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Deskarga abiadura"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Igoera abiadura"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Zati eskuragarriak"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Igoera egoera"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Deskarga Egoera"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Jatorria"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Fitxategi lokalaren izena"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Partekatutako fitxategi zerrendak"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Eskuratutako zatiak"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Karpeta bidea"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Iruzkina/Kalifikazioa gehitu"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Iruzkina/Kalifikazioa editatu"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Izena aldatu"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Gehitu fitxategiak bildumara zerrenda bidaltzeko"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopiat&URI magnetikoa arbelera"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopiatu eD2k lotura arbelera (&Jatorria)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopiatu eD2k lotura arbelera (Jatorria) (&zifratu aukerekin)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopiatu eD2k lotura arbelera (&ostalaria)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopiatu eD2k lotura arbelera (ostalaria) (&zifratu aukerekin)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopiatu eD2k lotura arbelera (&AICH argb)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopiatu eD2k lotura arbelera (&AICH argb)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "ID altua behar duzu baliozko jatorri lotura bat sortzeko"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Urruneko fitxategiaren izena"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Igotako datuak (saioa (guztira)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Guztira buruak (paketeak): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Fitxategi eskakizun buruak (paketeak): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Jatorri aldaketa buruak (paketeak): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Zerbitzari buruak (paketeak): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad buruak (paketeak): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Zifratu goiburua (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Igoera aktiboak: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Igoerak zain: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Guztira behar bezala igotako saioak: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Guztira oker igotako saioak: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Batez besteko igoera denbora: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Deskargaturiko datuak (saioa (guztira)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Aurkituriko iturburuak: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Deskarga aktiboak (zatiak): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Saio IG/DE abiadura (guztira): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Bataz besteko deskarga tasa (saioa): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Bataz besteko igoera tasa (saioa): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Gehienezko deskarga tasa (saioa): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Gehienezko igoera tasa (saioa): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Berkonexioak: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Denbora lehen transferentziatik: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Zerbitzaria noiztik konektatua: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Konexio aktiboak (estimazioa): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Gehienezko konexio mugara iritsi: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Batez besteko konexioak (ebaluazioa): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Puntako konexioak (estimazioa): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Bezeroak"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Ezezaguna: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Iragazirik: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Ukatuak: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Guztira: %i Ezagunak: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Zerbitzariak martxan: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Huts egindako zerbitzariak: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Guztira: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Ezabatutako zerbitzariak: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Iragaziriko zerbitzariak: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Erabiltzaileak - zerbitzariak martxan: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Fitxategiak - zerbitzariak martxan: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Guztira erabiltzaileak: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Guztira fitxategiak: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zerbitzari lan karga %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Partekatutako fitxategi kopurua: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Guztira partekatutako fitxategi tamaina: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Bataz besteko fitxategi tamaina: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema eragilea"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Ez Jasoa"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Konexio aktiboak (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Ez dago erabilgarri"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Inoiz ere ez"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "'%2$d' pid-a duen '%1$s' komandoa '%3$d' egoera kodeaz amaitu da."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str> exekutatu eta irten."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "IP Formatu baliogabea. Erabili xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Komando honek argumentu bat behar du. Baliozko argumentuak: 'all' fitxategi-izena edo zenbaki bat.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Egiaztapenez prozesatzen: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Izenez prozesatzen: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Komando honek argumentu bat behar du. Baliozko argumentuak: fitxategi egiaztapena.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Ez da baliozko zenbaki bat\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Ez da baliozko egiaztapen bat (luzera zehazki 32 karakterekoa izan behar da)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7225,7 +7136,7 @@ msgstr "Sakatu '%s' laguntza gehiagorako.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7234,89 +7145,87 @@ msgstr "Sakatu '%s' laguntza gehiagorako.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Sakatu '%s' laguntza gehiagorako.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Deskarga tamaina: %i"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Eskakizunak errore ezezagun batez huts egin du."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Ekintza arrakastatsuki amaitu da."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Eskakizunak errore honekin huts egin du: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Bezero IP iragazketa %s dago.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "EZGAITURIK"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "GAITURIK"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Zerbitzari IP iragazketa %s dago.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Uneko IPiragazki maila %d da.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Banda-zabalera mugak: Gora: %u kB/s, Behera: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "%s %s %s-(e)ra konektaturik"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Ez konektatzen"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "suebakirik"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ondo"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7325,7 +7234,7 @@ msgstr ""
 "\n"
 "Deskargatu:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7334,7 +7243,7 @@ msgstr ""
 "\n"
 "Igo:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7343,7 +7252,7 @@ msgstr ""
 "\n"
 "Bezero ilaran:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7352,46 +7261,46 @@ msgstr ""
 "\n"
 "Jatorriak guztira:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[ZatiFitxategia]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Bilaketa emaitza kopurua: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Bilaketa aurrerapena: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Bilaketa aurrerapena ez dago eskuragarri"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Zerbitzaritik erantzun ezezagun bat jaso da, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Egoera informazio laburra bistarazi."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Konexio egoera bistarazi, uneko igo/deskarga abiadura, etab.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Estatistika zuhaitz osoa bistarazi."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7405,11 +7314,11 @@ msgstr ""
 "\n"
 "Adibidea: 'statistics 5' erabiliaz bezero mota bakoitzeko 5 bertsio nagusiak ikusiriko dira.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Itzali aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7419,35 +7328,35 @@ msgstr ""
 "Honek testu bezeroa ere itxiko du ez bait da muinik gabe funtzionatzeko\n"
 "gai.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Emandako objektua birkargatu."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "IP iragazki taula birkargatu."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Uneko Ip iragazte taula birkargatu."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "IP iragazki taula URLtik eguneratu."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "URLa ez bada ezartzen hobespenetakoa erabiliko da."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Sarera konektatu."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7459,35 +7368,35 @@ msgstr ""
 "horretara bakarrik konektatzeko. IP helbidea puntuaturiko IPv4 hamartar helbide\n"
 "bat izan behar da edo ebatzi daitekeen izen bat."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "eD2k sarera bakarrik konektatu."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "KAD sarera bakarrik konektatu."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Saretik deskonektatu."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Honek konektaturik zauden sare guztietatik deskonektatuko zaitu.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "eD2k saretik bakarrik deskonektatu."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Kad saretik bakarrik deskonektatu."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Ed2k edo lotura magnetiko bat gehitu muinera."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7505,51 +7414,51 @@ msgstr ""
 "\n"
 "Lotura magnetikoak ed2k egiaztapena eta fitxategi tamaina eduki behar ditu.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Hobespen balio bat ezarri."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "IP iragazki hobespenak ezarri."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "IP iragazketa gaitu bai bezero bai zerbitzarientzat."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "IP iragazketa ezgaitu bai bezero bai zerbitzarientzat."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "IP iragazketa gaitu/ezgaitu bezeroentzat."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "IP iragazketa gaitu bezeroentzat."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "IP iragazketa ezgaitu bezeroentzat."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "IP iragazketa gaitu/ezgaitu zerbitzarientzat."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "IP iragazketa gaitu zerbitzarientzat."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "IP iragazketa ezgaitu zerbitzarientzat."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Ip Iragazte maila hautatu."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7557,74 +7466,74 @@ msgstr ""
 "Baliozko iragazte maila 0-255 tartekoak dira, eta lehenetsiriko balioa\n"
 "(hasierakoa) 127 da.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Konexio zabalera mugak ezarri."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Komando hauentzat emandako balioa Kb/s-tan egon behar da.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Igoera konexio zabalera muga ezarri."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Komando hauentzat emandako balioa Kb/s-tan egon behar da.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Deskarga konexio zabalera muga ezarri."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Komando hauentzat emandako balioa Kb/s-tan egon behar da.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Hobespen balio bat eskuratu eta bistarazi."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "IP iragazki hobespenak eskuratu."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "IP iragazketa egoera eskuratu bai bezero bai zerbitzarientzat."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "IP iragazketa egoera eskuratu bezeroentzat."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "IP iragazketa egoera eskuratu zerbitzarientzat."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Ip iragazte maila hautatu."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Konexio zabalera mugak eskuratu."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Bilaketa bat egiten."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7643,44 +7552,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Bilaketa orokor bat egin."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Bilaketa lokal bat egin"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Kad bilaketa bat egin"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Azken bilaketaren emaitzak bistaratzen ditu."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Ikusi bilaketaren aurrerapena."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Fitxategia deskargatzen hasi"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7688,81 +7597,81 @@ msgstr ""
 "Azkenengo bilaketako fitxategiaren zenbakia eman behar da.\n"
 "Adibidez: 'download 12' erabiliaz azken bilaketako 12. emaitzaren deskarga abiaraziko da.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Deskarga pausarazi."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Deskarga berrekin."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Deskarga utzi."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Deskarga lehentasuna ezarri."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Deskarga baten lehentasuna ezarri Baxua, Normala, Altua edo Auto bezala.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Ezarri lehentasun txikia."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Ezarri lehentasun normala."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Ezarri lehentasun handia."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Ezarri lehentasun automatikoa."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Ilarak/zerrenda bistarazi."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Igoera/deskarga- ilara, zerbitzari zerrenda edo partekatutako fitxategi zerrenda bistarazi.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Igoera ilara bistarazi."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Deskarga ilara bistarazi."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Erregistroa ikusi."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Zerbitzari zerrenda bistarazi."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Erregistroa garbitu."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Zaharkitutako komandoa, '%s' erabili horren ordez."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7771,261 +7680,258 @@ msgstr ""
 "Hau zaharkituriko komando bat da eta etorkizunean ezabatu egin daiteke.\n"
 "Erabili '%s' horren ordez.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule testu bezeroa"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s'-ko AICH egiaztapen zaharra 64b-ekoa bihurtzen '%s'-en."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "Oharra: '%s' fitxategi izena baliogabea da eta'%s' bezala berrizendatuko da."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "Oharra: '%s' fitxategia badago dagoeneko eta'%s' bezala berrizendatuko da."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Ziur zaude kategoria honetako fitxategi guztiak ezeztatu eta ezabatu nahi dituzula?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Berrespena beharrezkoa"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "99 kategoria soilik onartzen dira."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Kategoria gehiegi!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Beste guztiak"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Hautatu ikuspen iruzkina"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Gehitu kategoria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editatu kategoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Ezabatu kategoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Egiaztapena eskaturik fitxategi ezezagunarentzat: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Fitxategiaren igoerak berriarazten: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Fitxategiaren igoerak gelditzen: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Huts `%s' komandoa `%s' gertaeran exekutatzean."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Deskarga osatua"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Fitxategiaren bide osoa."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Fitxategiaren izena biderik gabe."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Fitxategiaren eD2k egiaztapena."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Fitxategi tamaina byte-etan."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Batutako deskarga aktibitate denbora."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Elkarrizketa saio berria hasia"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Mezu bidaltzailea."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Ez dago lekurik"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Disko partizioa."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Errorea osatzean"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "%u zenbakidun fitxategia prozesatzen: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Zati egiaztapenak eskatu dituzu (9.5 MB baino fitxategi txikiagoekin bakarrik)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fitxategia ez dago !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, aMuleren eD2k lotura sortzailea"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Ongietorria!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Sarrera parametroak"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Egiaztatzeko Fitxategia"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Gehitu aukerako URL gehiago fitxategi honentzat"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Sar hemen eD2k lotura konputatzea nahi duzun fitxategia"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Sartu hemen eD2k loturara gehitzea nahi duzun URLa: Gehitu / amaieran aLinkCreator-ek uneko fitxategi izena gehitzeko"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Zati egiaztapenekin lotura bat sortu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Fitxategi berri eta arraroak zabaltzen laguntzen du, lotura tamaina handitzearen kostuarekin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 fitxategi egiaztapena"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "MD4 fitxategi egiaztapena"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k lotura"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Gorde"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopiatu arbelera"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Ireki"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Ireki fitxategi bat bere eD2k lotura konputatzeko"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopiatu konputaturiko eD2l lotura arbelera"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Gorde honela"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Gorde konputaturiko eD2k lotura fitxategi batean"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "ALinkCreator-ri buruz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Hautatu eD2k lotura konputatzea nahi duzun fitxategia"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Ezin da arbela ireki"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Kopiatzeko ezer ez oraingoz !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Hautatu eD2k lotura konputazioaren fitxategia"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Ezin da ireki "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Mesedez idatzi fitxategi izen bat"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Gordetzeko ezer ez oraingoz !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8045,167 +7951,159 @@ msgstr ""
 "\n"
 "GPL-pean banatua"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Aztertzen..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator zuretzat lanean dago"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "MD4 egiaztapena konputatzen..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "eD2k egiaztapena konputatzen..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Ezeztaturik !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "%.2f seg-etan egina"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "URL dagoeneko gehiturik duzu !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Mesedez idatzi zurian ez dagoen URL bat"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ezin da %s ireki"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i egun %i ordu %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uE %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, amule Estatistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Deskarga abiadura handiena wxCas abiarazirik dagoenetik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Guztizko gehienezko deskarga abiadura wxCas aurreko abiarazteetan"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Garbitu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Auto berritzea gelditu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Gorde estatistikak irudiak"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Inprimatu estatistika irudia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Hobespen ezarpenak"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "WxCas-ri buruz"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Auto berritzea abiarazi"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Auto berritzea geraturik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Auto berritzea abiarazirik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Gorde estatistika Irudia"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule estatistikak"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8213,11 +8111,11 @@ msgstr ""
 "Arazo bat dago inprimatzerakoan.\n"
 "Agian zure inprimagailua ez dago behar bezala ezarririk?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Inprimatzen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8235,403 +8133,392 @@ msgstr ""
 "\n"
 "GPL lizentziapean banaturik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule ez dago abiarazirik..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule abiarazirik dago"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule abiarazirik dago, baina deskonektaturik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule konektatzen ari da..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, aMule egoera ezezaguna da..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " noiz abiarazirik "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " gelditurik dago !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ez dago konektaturik !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " konektatzen..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " zerbait arraroa egiten ari da, araka ezazu !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " hona konektaturik dago: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "deskonektaturik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " hona konektaturik "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " eta "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Deskargak guztira: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Igoerak: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Saio deskargak: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Deskargak: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Igoerak: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Partekatuak: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fitxategia(k), bezero ilaran: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Denbora: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " - "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Sistema karga bataz-bestekoak (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Sistema noiztik abiarazirik: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat fitxategia duen karpeta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Idatzi zure amulesig.dat fitxategia dagoen karpeta izena"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Berritze aldia segundotan"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Sortu estatistika irudi bat berritze bakoitzean"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Idatzi hemen estatistika irudiak sortzea nahi duzun karpeta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Igo aldiro zure estatistika irudia FTP zerbitzarira"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url-a"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP bidea"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Sar hemen zure FTP zerbitzariaren helbidea"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Idatzi hemen estatistika irudiak FTP zerbitzarian gordeko diren karpeta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Erabiltzaile"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Idatzi hemen zure FTP zerbitzarian sartzeko erabiltzaile izena"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Idatzi hemen zure FTP zerbitzarian sartzeko pasahitza"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP igoera aldia minututan"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Egiaztatu"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Zure sinadura fitxategia duen karpeta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Estatistika irudiak sortuko diren karpeta"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "<str> txantiloia kargatzen du"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web zerbitzariaren HTTP ataka"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Erabili UPnP ataka berbideraketa web zerbitzari atakan"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP ataka"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Sarrera osoko pasahitza web zerbitzarirako"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Gonbidatu pasahitza web zerbitzarirako"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Gaitu gonbidatu sarrera"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Gonbidatu sarrera ezgaitu"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Kargatu/gorde web-zerbitzari ezarpenak urruneko aMule-tik/ra"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule konfigurazio fitxategi bidea. EZ ERABILI ZUZENEAN!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP interpretea ezgaitu (zaharkiturik)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "PHP orrialdeak eskakizun bakoitzean birkonpilatu"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule web zerbitzaria"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "web bezero konexioa onartua\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERROREA: ezin da web bezero konexioa onartu\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Eskakizunak errore honez huts egin du: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Ez da index fitxategia aurkitu: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Saioa Iraungirik - saio hasiera eskatzen\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Saioa ondo, saioa hasirik\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Saioa ondo, saioa hasi gabe\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ez dago saio irekirik - saio hasiera eskatuko da\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Saioa sorturik - saio hasiera eskatzen\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Eskakizuna prozesatzen [jatorrizkoa]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Ez da pasahitzik ezarri, ez da saioa hastea onartzen."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Pasahitz egiaztapen baliogabea\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Pasahitza ondo\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Pasahitza oker\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Ez duzu pasahitzik idatzi. Ez da pasahitz zuria onartzen.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Saio amaiera eskakizuna\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Eskakizuna prozesatzen [birbidalia]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Konexioak huts egin du "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Näytä aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule etähallinta "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Tilannevedos:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "'Kaikkien alustojen' p2p-asiakas perustuen eMuleen\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,79 +52,79 @@ msgstr ""
 "Tekijänoikeudet (c) 2003-2019 aMule-Tiimi\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Osa aMulesta perustuu\n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaan: Vertaisreititys perustuen XOR-metriikkaan.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Tekijänoikeudet (c) 2002-2008 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Verkkosivu:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foorumi:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Tarkista uuden version saatavuus käynnistettäessä"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Yhdistetään Kadiin..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ei saatavissa"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Lisää kaveri"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Sinun on annettava kelvollinen IP ja portti!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Tietoa"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Annettu käyttäjätarkiste ei ole kelvollinen!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -133,49 +133,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Yhdistäminen epäonnistui "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -184,103 +183,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "ED2KLinks-tiedoston avaus epäonnistui."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla on LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Pääohjelmaa suljetaan..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Epäonnistunut"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Lopetetaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Tuhotaan amulewebin instanssi prosessinumerolla '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMulen poistuessa: Lopetetaan ydin."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule sammutettu."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Muistin virheiden etsinnän tulokset aMulen sulkeutuessa:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Maa-asetuksesi vaihdettiin järjestelmän oletuksiksi asetusmuutoksen takia. Pahoittelen."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +284,70 @@ msgstr ""
 "\n"
 "Etäyhteyksien asetukset"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "VAROITUS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "VIRHE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web-palvelin käynnissä prosessinumerolla %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Ei voitu sitoa portteja annettuun osoitteeseen: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portti %u ei ole saatavilla. Sinulle annetaan LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,48 +362,48 @@ msgstr ""
 "\n"
 "Tarkista yhteytesi varmistaaksesi että portti on avoinna sekä ulos että sisään."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMulen Online-Signeeraustiedoston luonti epäonnistui"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Valittu maa-asetus ei näytä olevan asennettuna järjestelmääsi. (Huom: Yritän asettaa sen kuitenkin)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Tämä on ensimmäinen kerta kun käynnistät aMulen version %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Tämä versio on testiversio jota päivitetään päivittäin,\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "emmekä me anna takuuta ettei se riko mitään, polta taloasi,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "tai tapa koiraasi. Mutta sen *pitäisi* olla silti turvallinen käyttää.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Lisätietoa, tukea ja uudet julkaisut löytyvät kotisivuiltamme osoitteessa\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io tai IRC-kanavaltamme #aMule palvelimella irc.libera.chat (englanniksi).\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Voit vapaasti raportoida bugeista osoitteessa https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -419,224 +411,220 @@ msgstr ""
 "Online-Signeeraukselle asettamasi kansio ei ole kelvollinen!\n"
 " Online-Signeeraus kytketään pois päältä kunnes korjaat asian asetuksista."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Levytilan esivaraus tiedostolle '%s' epäonnistui: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "VIRHE: Lokitiedostoa ei voida avata"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VAROITUS: Lokitiedosto on tyhjä. Jotain on pielessä."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Loki nollattiin"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Palvelimen viesti: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Hypättiin yli latauksesta %s, koska pyydetty tiedosto ei ole uudempi."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Yhteyspisteiden listan lataus epäonnistui."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Ladatun versiotarkistustiedoston avaus epäonnistui"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Turmeltunut versiotarkistustiedosto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Käytät vanhentunutta versiota aMulesta!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Tämän aMulen versio on %i.%i.%i ja uusin versio on %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VAROITUS: aMulesi versio on vanhentunut: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "aMulesi on uusinta versiota."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Versiotarkistustiedoston lataus epäonnistui"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Käyttäjiä: %s | Tiedostoja: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Käyttäjiä: E: %s K: %s | Tiedostoja: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Ei valittuja verkkoja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "LowID:llä"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "HighID:llä"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Yhdistetty %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Yhdistän %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Käynnistettiin Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Pysäytettiin Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Yhdistetty Kadiin (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-verkkoa ei voida käyttää mikäli UDP-portti on estetty asetuksissa, ei käynnistetä."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-verkko estetty asetuksissa, ei yhdistetä."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "VIRHE: aMule-taustaprosessia ei voida käyttää kun etäyhteydet ovat poissa päältä. Etäyhteydet voidaan kytkeä päälle normaalista aMulesta, käynnistämällä amuled parametrilla --ec-config tai asettamalla avain \"AcceptExternalConnections\" arvoon 1 tiedostossa ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "VIRHE: Kelvollinen salasana vaaditaan etäyhteyksien käyttämiseksi ja aMule-taustaprosessia ei voida käyttää ilman etäyhteyksiä. Käynnistääksesi aMule-taustaprosessin sinun pitää asettaa kenttään \"ECPassword\" tiedostossa ~/.aMule/amule.conf kelvollinen arvo. Käynnistä amuled parametrilla --ec-config asettaaksesi salasanan. Lisää tiedoa löytyy osoitteesta at https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: käynnistettäessä - käynnistän ajastimen"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Ei voitu luoda prosessinumerotiedostoa"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "VIRHE: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -646,193 +634,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Ei verkkoa"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMulen etähallinta"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Kriittinen virhe: Ytimen ajastimen luominen epäonnistui"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Yhdistä etä-aMuleen"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Yhteys katkesi"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Vahvista sulkeminen"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -841,727 +822,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Kriittinen virhe: Kyselyajastimen luominen epäonnistui"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Siirrytään tapahtumasilmukkaan..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Yhdistetään..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Graafisen etäkäyttöliittymän tapahtumakäsittelijä"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Yhdistäminen epäonnistui. Ei saatu yhteyttä %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Suljen"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Yhteysyritys kohteeseen %s (%s:%i) aikakatkaistiin."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Yhdistä verkkoon."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Yhdistäminen epäonnistui. Ei saatu yhteyttä %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Valmis"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Kaikki"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Ei saatavilla"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Etsitään kaveria lowid-yhteydelle"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Vale-eMule versio %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Vale-eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Vale-eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (pohjautuu eMule-versioon v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nimimerkki: %s Tunnus: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pyydetty: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tiedostotilasto tästä sessiosta: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 msgstr[1] "Tiedostotilasto tästä sessiosta: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tiedostotilasto kaikista sessioista: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 msgstr[1] "Tiedostotilasto kaikista sessioista: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Pyydetty tuntematonta tiedostoa"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Viesti suodatettu käyttäjältä '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Viesti käyttäjältä '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista olemattomassa kansiossa '%s' -> Jätettiin huomioimatta"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "VAROITUS: Tiedostoa %s ei voida avata."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "VAROITUS: Peruutettujen latausten lista on turmeltunut, sisältää epäkelvon otsakkeen."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO-virhe luettaessa tiedostoa %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Virhe tallennettaessa tiedostoa %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Luokittelu"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Uusi luokka"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Valitse kansio saapuville tiedostoille"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Sinun on annettava nimi luokalle!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Sinun on annettava polku luokalle!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Saapuvien kansion luonti luokalle epäonnistui. Anna kelvollinen polku!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Keskustelu aloitettu: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Yhdistetty asiakkaaseen ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Yhdistetään asiakkaaseen ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Asiakkaaseen yhdistäminen epäonnistui / Yhteys katkesi ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Läpäisit kuvavarmennuksen ja käyttäjä on saanut viestisi. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Vastauksesi kuvavarmennukseen on väärä ja viestisi on jätetty huomioimatta. Voit yrittää uudestaan lähettämällä uuden viestin. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Keskustelu"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Sulje välilehti"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Sulje kaikki välilehdet"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Sulje muut välilehdet"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Lisää kavereihin"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Pisteytystiedosto avattu, %u tunnettu asiakas"
 msgstr[1] "Pisteytystiedosto avattu, %u tunnettua asiakasta"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Pisteet ovat vanhentuneet %u asiakkaalle!"
 msgstr[1] " - Pisteet ovat vanhentuneet %u asiakkaalle!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Tiedostoa 'cryptkey.dat' ei löydetty, luodaan."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Asiakkaan tiedot"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Tuettu"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Ei tuettu"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Poissa käytöstä"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Yhdistetty"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Yhteys katkaistu"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f KB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Ei vielä valmis"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Pahis"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Vahvistettu - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Ei saatavilla"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista -> Annettu"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista -> Estetty"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista kansioista -> Annettu"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista kansioista -> Estetty"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista kansiossa '%s' -> Annettu"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista kansiossa '%s' -> Estetty"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Käyttäjä %s (%u) jakaa kansion '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Käyttäjä %s (%u) lähetti jakolistan pyytämättä."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Käyttäjä %s (%u) lähetti listan jaetuista tiedostoista kansiossa '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Käyttäjän %s (%u) jaettujen tiedostojen lista on lähetetty"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Käyttäjä %s (%u) lähetti pyytämättä jaettujen tiedostojen listan"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Käyttäjä %s (%u) on estänyt jaettujen kansioiden/tiedostojen listaamisen."
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Tiedoston kommentit"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Käyttäjänimi"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Tiedoston nimi"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Luokitus"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Kommentti"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad-hakua ei voida tehdä mikäli Kad ei ole päällä"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Etsitään kaveria lowid-yhteydelle"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ei kommentteja"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u kommentti"
 msgstr[1] "%u kommenttia"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Estettiin asiakas %s, lähetti turmeltunutta dataa %s yhteismäärästä %s tiedostolle '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Valtiotietojen lataus osoitteesta '%s' epäonnistui."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ma]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Ko]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Korkea"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Erittäin korkea"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Julkaisu"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Kysyy"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Yhdistetään serverin kautta"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Jono täynnä"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Jonossa"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lataa"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Ladataan tarkistejoukkoa"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Ei tarvittavia osia"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Ei voi yhdistää LowID:llä LowID:hen"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Liian monta yhteyttä"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Yhdistetään Kadilla"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Liian monta Kad-yhteyttä"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Estetty"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Yhteysvirhe"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Etäjono Täysi"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Vanha MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Uusi MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule-Yhteensopiva"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Paikallinen Palvelin"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Lähdevälitys"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiivinen"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Linkki"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Lähteitä"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Haun tulos"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmiina"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Käynnissä"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "VIRHE: Levytila on loppu"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "VIRHE: Osatiedostoa ei löytynyt"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "VIRHE: IO-virhe!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "VIRHE: Epäonnistui!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Jonossa"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Lataus on jo käynnissä"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Tuntematon tai käyttökelvoton väliaikaistiedostomuoto."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Siirretty"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Nopeus"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Edistyminen"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Lähteet"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Tärkeys"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Tila"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Aikaa jäljellä"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Viimeksi nähty kokonaisena"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Viimeisin vastaanotto"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Oletko varma että haluat poistaa valitun tiedoston?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Oletko varma että haluat poistaa valitut tiedostot?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1570,109 +1528,106 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automaattinen"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "Py&säytä"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Tauota"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Jatka"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Poista va&lmistuneet"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Vaihda jokainen A4AF tälle tiedostolle nyt"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Vaihda jokainen A4AF tälle tiedostolle nyt (Automaattinen)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Vaihda jokainen A4AF muille tiedostolle nyt"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Laajat asetukset"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Esikatsele"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Näytä tie&doston tiedot"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Näytä kaikki kommentit"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopioi magnet-URI leikepöydälle"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopioi eD2k-&linkki leikepöydälle"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopioi palaute leikepöydälle"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "poista luokittelu"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Luokittele"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Avaa tied&osto"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Anna uusi nimi tälle tiedostolle:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Tiedoston uudelleennimeäminen"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lataukset (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1681,348 +1636,347 @@ msgstr ""
 "Estääksesi tämän varoituksen näyttämisen joka kerralla,\n"
 "aseta haluamasi videotoistin asetuksissa (oletuksena %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Tiedoston esikatselu"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIRHE: Ulkoista mediatoistinta ei voitu käynnistää! Komento: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Tallennetaan osatiedostoa %u / %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Kaikki osatiedostot tallennettu."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Lataan väliaikaistiedostoja kohteesta %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Lataan osatiedostoa %u %u:sta"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "VIRHE: Varmuuskopiotiedostoa ei saatu avattua.  Katso sivuilta https://github.com/amule-org/amule/discussions ratkaisuja .part.met -palautukseen."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Kaikki osatiedostot avattu."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Osatiedostoja ei löytynyt"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Löydetty %u osatiedosto"
 msgstr[1] "Löydetty %u osatiedostoa"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Väliaikaiskansion tiedostojärjestelmä ei osaa käsitellä suuria tiedostoja."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Saapuvien kansion tiedostojärjestelmä ei osaa käsitellä suuria tiedostoja."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Ladataan %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Olet jo lataamassa tiedostoa '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Sinulla on jo tiedosto '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Sinulla on jo tiedosto '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Lataat jo tiedostoa %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Ei voitu kääntää magnet-linkkiä eD2k-linkiksi: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Linkin protokolla tuntematon: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Virheellinen eD2k-linkki! VIRHE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Asiakas lähetti paketin tunnistautumisen epäonnistumisen jälkeen."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Etäyhteys suljettu."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Etäyhteydet kielletty sillä salasana on tyhjä!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Etäyhteydet estetty asetustiedostossa"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Uusi etäyhteys hyväksytty"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "VIRHE: uutta etäyhteyttä ei voitu ottaa vastaan"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Etäyhteys torjuttu koska salasana on tyhjä asetuksissa!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Yhdistän asiakkaaseen: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Tuntematon versio"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Epäkelpo etäversiotunniste, binäärinen epäyhteensopivuus on mahdollinen. Käytä ydintä ja etäpäätettä samasta vedoksesta."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Et voi yhdistää julkaisuversioon mielivaltaisella kehitysversiolla! *huoh* mahdollinen kaatuminen estetty"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Väärä protokollaversio."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Puuttuva protokollan versiomerkintä."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Tunnistautuminen epäonnistui: etäyhteyssalasanan tarkiste on väärin."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Tunnistautuminen epäonnistui: väärä salasana."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Tunnistautuminen epäonnistui: salasana puuttui."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Epäkelpo pyyntö, tunnistaudu ensin."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Pääsy myönnetty."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Virheilmoitus \"%s\" lähetetty asiakkaalle."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Luvaton yhteysyritys osoitteesta %s. Yhteys suljettu."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Etäosatiedoston komento epäonnistui: Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Tiedostotarkistetta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Hupsis! Komentosanan käsittelyvirhe!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Palvelinta ei lisätty"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "palvelinta ei löytynyt: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "poistettava palvelin on määriteltävä"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k on poistettu käytöstä asetuksissa."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Verkkohaku etäliittymästä ei ole mielekästä."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Haku on käynnissä. Nouda tuloksia kohta uudelleen!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Ei pisteitä kaavioon."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Asiakasohjelmaasi ei ole asetettu tälle tarkkuustasolle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Etäyhteys: sulkemista pyydetty"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Sulkeminen on jo käynnissä."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Etäyhteys: lisään linkkiä '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Virheellinen linkki tai se on jo listalla."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Tiedostoa ei löytynyt."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Epäkelpo tiedostonimi."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Tiedostoa ei voitu uudelleennimetä."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad on poistettu päältä asetuksissa."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "eD2k on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Yhdistetään eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Kad on jo yhdistetty."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Yhdistetään Kadiin..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Kaikki verkot ovat pois päältä."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "eD2k-yhteys katkaistu"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kad-yhteys katkaistu."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Etäyhteys: vastaanotettiin epäkelpo komentosana: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Epäkelpo komentosana (väärä protokollaversio?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Tuntematon laajennos '%s' komennolle '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Tuntematon komento '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2030,7 +1984,7 @@ msgstr ""
 "\n"
 "Tälle komennolle ei voi antaa parametria.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2038,7 +1992,7 @@ msgstr ""
 "\n"
 "Tälle komennolle on annettava parametri.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2046,7 +2000,7 @@ msgstr ""
 "\n"
 "Tämä komento on puutteellinen, sinun on käytettävä jotakin alla olevista laajennoksista.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2054,11 +2008,11 @@ msgstr ""
 "\n"
 "Mahdolliset laajennokset:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Käytettävissä olevat komennot:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2069,17 +2023,17 @@ msgstr ""
 "Komennot eivät erottele isoja ja pieniä kirjaimia.\n"
 "Kirjoita '%s <komento>' saadaksesi lisätietoa komennosta.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Poistuu sovelluksesta."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Näyttää ohjeen."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2087,7 +2041,7 @@ msgstr ""
 "Saadaksesi ohjeen komennosta, kirjoita 'help <komento>'.\n"
 "Saadaksesi listan komennoista kirjoita 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2098,46 +2052,46 @@ msgstr ""
 "Käytä '%s' listataksesi komennot\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Syntaksivirhe!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Virhe käsiteltäessä komentoa - näin ei pitäisi tapahtua! Ole hyvä ja raportoi tästä\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Tämä komento ei tarvitse parametreja."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Tälle komennolle on annettava parametri."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Virheellinen parametri."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Komento on puutteellinen."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Kirjoita '%s' saadaksesi lisää ohjeita.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Tämä on %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Tämä on %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2145,7 +2099,7 @@ msgstr ""
 "\n"
 "Luon asiakasta...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2154,7 +2108,7 @@ msgstr ""
 "\n"
 "Ok, suljen %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2168,331 +2122,326 @@ msgstr ""
 "\n"
 "Suljen...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Näytä tämä ohje."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Verkkonimi koneelle jossa aMule on käynnissä. (oletus: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMulen portti etäyhteydelle. (oletus: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Etäyhteyden salasana."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Lue asetukset tiedostosta."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Älä tulosta mitään stdout:iin."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Ole monisanainen - näytä myös virheenetsintäviestit."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Asettaa ohjelman maa-asetukset (kielen)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Kirjoita komentoriviparametrit asetustiedostoon."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Luo asetustiedoston perustuen aMulen asetustiedostoon."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Näyttää ohjelman version."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Tiedoston tiedot"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% valmiina"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Tervetuloa!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Yhdistetään kaveriin"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Yhteyden tila:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Verkot"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Vakio TCP-portti"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Laajennettu UDP-portti (Kad / haku kaikkialta)."
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Käytä UPnP:tä reitittimen portinohjauksessa"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Yhdistämisapu"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Lataat jo tiedostoa %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Päivitä palvelinlista käynnistettäessä"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua luettavaksi!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Kaverit"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Näytä tie&dot"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Lisää kaveri"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Poista kaveri"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Lähetä Viesti"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Näytä tiedostot"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Vapauta kaveripaikka"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Oletko varma että haluat poistaa valitun kaverin?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Oletko varma että haluat poistaa valitut kaverit?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2500,11 +2449,11 @@ msgstr ""
 "Et voi asettaa enempää kuin yhden kaveripaikan.\n"
 " Asetettiin yksi paikka."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Monivalinta"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2513,206 +2462,205 @@ msgstr ""
 "Et voi asettaa enempää kuin yhden kaveripaikan.\n"
 " Asetettiin yksi paikka."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Lähetä viesti käyttäjälle"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Lähetettävä viesti:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Poista ystävistä"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Lähetä viesti"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Vaihda tähän tiedostoon"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Jonossa: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Kysyttiin toista tiedostoa"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Odottaa lähetyspaikkaa"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Jonossa: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Lähettää"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ei yhtään"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Kyllä"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Ladataan..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP-lataus peruutettu"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Ladattava URL ei voi olla tyhjä"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Ladattu %d tavua"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s palautti: %i - Virhe (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-lataus peruutettu"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Hae uusi GeoIP.dat osoitteesta %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "GeoIP.dat-tiedoston lataus epäonnistui, keskeytän päivittämisen."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Tiedoston %s poisto epäonnistui, keskeytän päivityksen."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Tiedoston %s uudelleennimeäminen epäonnistui, keskeytän päivityksen."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Tiedoston %s päivitys onnistui"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Virhe päivitettäessä GeoIP.dat-tiedostoa"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Tiedoston %s lataus osoitteesta %s epäonnistui"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Lataan IP-suodattimet 'ipfilter.dat' sekä 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Ipfilter.dat-tiedoston '%s' avaaminen epäonnistui, muoto tuntematon."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Ipfilter.dat-tiedoston '%s' avaaminen epäonnistui, tiedostoa ei voitu avata."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Ladattu %u IP-alue kohteesta '%s'."
 msgstr[1] "Ladattu %u IP-aluetta kohteesta '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u epämuodostunut rivi ohitettiin."
 msgstr[1] "%u epämuodostunutta riviä ohitettiin."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Uuden tiedoston %s uudelleennimeäminen epäonnistui, keskeytän päivityksen."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP-suodatin on valmiina"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2720,876 +2668,844 @@ msgstr ""
 "Käytä tunnettuja \n"
 "asiakkaita yhdistämisapuna"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Yhteyspisteitä (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP ei kelpaa yhdistämisavuksi"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Portti ei kelpaa yhdistämisavuksi"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Ole hyvä ja täytä kaikki vaaditut kentät"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Viesti"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Oletko varma että haluat ladata uuden nodes.dat-tiedoston?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Tämä toiminto korvaa kaikki tunnetut yhteyspisteet ja uudelleenyhdistää Kademlian."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Jatketaanko?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: hakusana on liian lyhyt"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Hakusana on jo hakulistalla:"
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Tiedoston nodes.dat luku epäonnistui sillä se liian vanha. Versio 0 ei ole enää tuettu."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Luettu %u Kad-kontakti"
 msgstr[1] "Luettu %u Kad-kontaktia"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Ei kontakteja, käytä yhdistämisapua tai hae nodes.dat-tiedosto."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Vain %d Kad-kontakti saatavilla, tiedostoa nodes.dat ei tallennettu"
 msgstr[1] "Vain %d Kad-kontaktia saatavilla, tiedostoa nodes.dat ei tallennettu"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Kirjoitettu %d Kad-kontakti"
 msgstr[1] "Kirjoitettu %d Kad-kontaktia"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad-verkko"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Tiedoston nimi"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tiedostokoko"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Jakosuhde"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Pyydetty"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Hyväksytty"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Täysiä lähteitä"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "VAROITUS: Tunnettujen tiedostojen lista on turmeltunut, sisältää epäkelvon otsakkeen."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Merkinnän luku tunnettujen tiedostojen lista -tiedostosta epäonnistui, tiedosto saattaa olla turmeltunut"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Epäkelpo merkintä tunnettujen tiedostojen lista -tiedostossa, tiedosto saattaa olla turmeltunut: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Tuntematon virhe %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Virheelle %d ei ole virhekuvausta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Luo tarkistetta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Viimeistelee"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Tauotettu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Virheellinen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Odottaa"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Salasana ei voi olla tyhjä."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Virheellinen salasana, ei MD5-tarkiste!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Yhdistäminen ei onnistunut"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Etäyhteys suljettu."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Etäyhteysyritys epäonnistui. Vastaus oli tyhjä."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Etäyhteys: Epäkelpo vastaus, kättely epäonnistui. Yhteys suljettu."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Yhdistetty onnistuneesti kohteeseen aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Yhdistetty onnistuneesti."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Etäyhteys: Pääsy evättiin: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "KuunteluPistukka: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "VIRHE: Ei voida kuunnella TCP-porttia."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "VIRHE: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "VAROITUS: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Sulje"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopioi"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Liitä"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pyyhi"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Yhdistetty"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Yhdistetty"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Yhdistetty Kadiin (palomuurattu)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "Palvelin-IP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Palvelimen IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Ei yhdistetty"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP-portti: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP-portti: Ei valmis"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP-portti: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UPD-portti: Ei valmis"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Asiakkaan tiedot"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Lähetysraja"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Latausraja"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Näytä aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Piilota aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sulje"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "KB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Rajoittamaton"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMulen palkkivalikko"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Nopeusrajoitukset:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Ylös: Ei ole"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Ylös: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Alas: Ei ole"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Alas: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Latausnopeus: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Lähetysnopeus: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Nimimerkki: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nimimerkkiä ei ole valittu!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Asiakastunnus: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Palvelinnimi: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Palvelin-IP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Ei yhdistetty"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online-Signeeraus: Käytössä"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online-Signeeraus: Pois päältä"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Päälläoloaika: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Jaettuja tiedostoja: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Asiakkaita jonossa: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Yht alas: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Yht ylös: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Lisää eD2k- tai magnet-linkin ytimelle."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Lisää kavereihin"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Klikkaa tästä lisätäksesi eD2k-linkin tekstikentästä latauslistaasi."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Tapahtumat näytetään tässä. Nähdäksesi täyden listan tapahtumista, katso loki Palvelimet-välilehdeltä."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Lataa ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Käyttäjien määrä palvelimella johon olet yhteydessä ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Käyttäjiä: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Yhdistettyjen käyttäjien määrä nykyisellä palvelimella sekä arvio kaikkien käyttäjien määrästä."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Ylös: 0,0 | Alas: 0,0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Nykyiset keskimääräiset lähetys- ja latausnopeudet. Mikäli aktivoitu, numerot suluissa näyttävät asiakasyhteyksien otsikkotietojen nopeuksia."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Näyttää yhteyden tilan ja aktiiviset siirrot. Punaiset nuolet osoittavat että et ole yhdistetty, keltaiset nuolet että sinulla on LowID (olet palomuurin takana) ja vihreät nuolet että sinulla on HighID (paras yhdistettävyys)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ei yhdistetty ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Palvelin johon yhdistetty."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Etsi"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nimi:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Paikallinen"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Kaikkialta"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Laajat parametrit"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Suodatus"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tiedostotyyppi"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Pakatut"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Ääni"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-levykuvat"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Kuvat"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Ohjelmat"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Tekstiä"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videot"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Pääte"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Vähimmäiskoko"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Tavua"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Enimmäiskoko"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Suodatin:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Suodata tulokset"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Käännä tulos"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Piilota tunnetut tiedostot"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Käynnistä haku"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Hae lisää"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Pysäytä"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Lataa"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Nollaa kentät"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Tulokset"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Siivoaa valmistuneet lataukset pois näkyvistä"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Tiedostolähteet:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Ei saatavilla"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Yleiset"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Koko nimi :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Osatiedosto (met) :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Tarkiste :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tiedostokoko :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Siirto"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Osatiedoston tila  :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Viimeksi nähty kokonaisena :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Löydetyt lähteet :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Siirtäviä lähteitä :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Osien määrä :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Saatavilla :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Lataus ollut aktiivisena: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Siirretty :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Valmiina :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Menetetty turmeltumille :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Pakkaamalla saatu hyöty :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pelastetut paketit (I.C.H.) :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Jako: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Pyynnöt"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Hyväksytyt pyynnöt"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Siirretty data"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Jakosuhde"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Täysiä kopioita"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Lähetetty: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Ei luokitusta"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Otsikko :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Tiedostonimet"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Muuta nimi"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Siivoa"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Kommentoi/luokittele tiedosto (Teksti näkyy kaikille käyttäjille)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3597,1269 +3513,1265 @@ msgstr ""
 "Elokuvalle voit kertoa sen pituuden, tarinan, kielen ...\n"
 "ja mikäli se on väärennös, voit kertoa sen muille aMulen käyttäjille."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Tiedoston laatu"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Ei luokitusta"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Epäkelpo / Turmeltunut / Väärennös"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Huono"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Kohtalainen"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Hyvä"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Erinomainen"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Valitse tiedoston luokitus tai ilmoita muille käyttäjille jos tiedosto on viallinen ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Yhteys Kadiin katkaistu"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Päivitä"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Lataan, odota hetki ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Koko on tuntematon"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Vaadittavat tiedot"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-osoite :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Portti :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Lisätiedot"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Käyttäjänimi :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Lisää"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Session keskiarvo"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Lähetysnopeus"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Tilastopuu"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Käyttäjänimi:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Käyttäjätarkiste:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Asiakasohjelma:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Asiakasversio:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-osoite:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Käyttäjätunniste:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Palvelimen IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Palvelimen nimi:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Kätkeminen:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Siirrot asiakkaalle"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Nykyinen pyyntö:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Keskimääräinen lähetysnopeus:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Keskimääräinen latausnopeus:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Lähetetty (sessiossa):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Ladattu (sessiossa):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Lähetetty (yhteensä):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Ladattu (yhteensä):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pisteet"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Lähetys/vastaanotto-määre:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Turvattu tunnistus:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Sijoitus jonossa:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Jonopisteet:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nimimerkki"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - monen alustan Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Tämä on nimi jonka muut käyttäjät näkevät yhdistäessään sinuun."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Kieli: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Viive työkaluvihjeiden näyttämiseen."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Tämä määrittää kontrolleissa käytetyn kielen."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Tarkista uuden version saatavuus käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "aMule tarkistaa käynnistyessään uuden version olemassaolon kun tämä on päällä."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Aloita pienennettynä"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Tämä päällä aMule pienentää itsensä käynnistyessään."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Vahvista sulkeminen"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Amule kysyy varmistuksen ennen poistumista."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Näytä kuvake palkissa"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Tämä sallii tai estää kuvakkeen näyttämisen järjestelmä-/tehtäväpalkissa."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Piilota sovelluksen ikkuna painettaessa sulje -nappulaa"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Pienennä palkkikuvakkeeksi"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Tämä päällä aMule pienentyy järjestelmäpalkkiin tehtäväpalkin sijaan."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Työkaluvihjeiden viive:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekuntia"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selaimen valinta"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Avaa uuteen välilehteen mikäli mahdollista"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Avaa verkkosivun uuteen välilehteen uuden ikkunan sijaan kun se on mahdollista"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videotoistin"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Kaistankäytön rajoitukset"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Lähetys"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Paikkavaraus"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portit"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tämä on vakio eD2k-portti eikä sitä voi kytkeä pois päältä."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-portti palvelinpyyntöihin (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tätä UDP-porttia käytetään laajennettuihin eD2k-hakuihin sekä Kad-verkossa"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP:n TCP-portti (Valinnainen):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Lähteitä enintään tiedostoa kohden:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Yhdistä automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Yhdistä uudelleen yhteyden katketessa"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Poista toimimattomat palvelimet"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "yrityksen jälkeen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Päivitä palvelinlista yhdistettäessä palvelimelle"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Päivitä palvelinlista asiakkaan yhdistäessä"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Käytä tärkeysjärjestystä"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Käytä älykästä LowID-tarkistusta yhdistettäessä"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Turvallinen yhdistäminen"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Yhdistä automaattisesti vain pysyville palvelimille"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Aseta käsin syötetyt palvelimet korkealle tärkeydelle"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Lisää tiedostot lataukseen tauotettuna"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Lisää tiedostot lataukseen tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Yritä ladata ensimmäiset ja viimeiset palat ensin"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Käynnistä seuraava tauotetty tiedosto kun tiedosto valmistuu"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Samasta luokasta"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Aakkosellisessa järjestyksessä"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Esivaraa levytila uusille tiedostoille"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Uusia tiedostoja lisätessä varaa levytilaa koko tiedostolle, vähentää pirstaloitumista"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Pysäytä lataukset kun tyhjän levytilan määrä saavuttaa "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Valitse tämä mikäli haluat aMulen tarkistavan vapaan levytilan määrän"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Syötä tähän levytila jonka haluat jättää vapaaksi."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Tallenna 10 lähdettä harvinaisille tiedostoille (< 20 lähdettä)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Lähetykset"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Lisää uudet jaetut tiedostot tärkeys automaattisella"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Käytä"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Kehittynyt I.C.H. luottaa kaikkiin tarkisteisiin (ei suositella)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Poista"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Klikkaa oikealla painikkeella kansion kuvaketta jakaaksesi rekursiivisesti)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Jaa piilotiedostot"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Kuvaajat"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Päivitysväli : 5 sekuntia"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Keskimääräiskuvaajan aika: 100 minuuttia"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Yhteyskuvaajan Skaala: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Latauskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Lähetyskuvaajan skaala:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Värit: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Taustaväri"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Ruudukko"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Hetkittäinen lataus"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Latauksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Latauksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Hetkittäinen lähetys"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Järjestelmäpalkin nopeusnäyttö"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-yhteyksiä tällä hetkellä"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-yhteyksiä aktiivisena"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Valitse"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Puu"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Näytettävien asiakasversioiden määrä (0=rajoittamattomasti)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! VAROITUS !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Enimmäismäärä uusia yhteyksiä / 5 s"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tiedostopuskurin koko: 240000 tavua"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Lähetysjonon koko: 5000 asiakasta"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Palvelinyhteyden päivitysväli: Poissa käytöstä"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Poista käytöstä tietokoneen ajastettu siirtyminen valmiustilaan"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Käytettävä teema: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Näytä \"Nopea eD2k-linkkien käsittelijä\" jokaisessa ikkunassa."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Näytä laajennetut tiedot luokitteluvälilehdillä"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Näytä sovelluksen versio otsikossa"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Näytä siirtonopeudet otsikossa"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Ennen sovelluksen nimeä"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Sovelluksen nimen perässä"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Näytä otsikkotietoihin kuluva kaista"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Pystysuuntainen työkalupalkki"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Latausjonon tiedostot"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Näytä edistyminen prosentteina"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Näytä edistymispalkki"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Tasainen"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Estä vieraskäyttö"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Vieraan salasana web-palvelimelle"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4867,11 +4779,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4881,827 +4793,827 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Poissa käytöstä [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "tavu"
 msgstr[1] "tavua"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "tavu/s"
 msgstr[1] "tavua/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "s"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "m"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "tuntia"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "päivää"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "kaikki"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "kaikki muut"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Keskeneräinen"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Pysäytetty"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Pakattu"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Teksti"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktiivinen"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Asetuskansio: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Odotellaan osatiedostojen muuntosäikeen päättymistä..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Tuon %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Luen väliaikaiskansiota"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Haen perustietoja ladatusta tietopaketista"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Luon kohdetiedostoa"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Lataan tiedot vanhasta lataustiedostosta (%u %u:sta)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Tallennan datalohkon yhteen uuteen lataustiedostoon (%u %u:sta)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Haen lähdelataustiedoston tietoja"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Lisään latauksen ja tallennan uuden osatiedoston"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Tuo osatiedostot"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Tila"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Tiedostotarkiste"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Levy: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Valitse kansio josta etsitään väliaikaislatauksia (alikansiot sisällytetään hakuun)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Haluatko että lähteenä käytetyt tiedostot poistetaan onnistuneen tuonnin jälkeen?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Poistetaanko lähteet?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "VIRHE: Osatiedoston luominen epäonnistui"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Yritän avata met-tiedoston varmuuskopion kohteesta %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "VIRHE: part.met-tiedostoa ei avattu: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "VIRHE: part.met-tiedosto on tyhjä: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "VIRHE: Epäkelpo part.met-tiedoston versio: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Virhe: %s (%s) on turmeltunut (väärät tagit: %s), tiedostoa ei voitu ladata."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "VIRHE: %s (%s) on turmeltunut (väärä tagimäärä), tiedostoa ei voitu avata."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Yritän palauttaa tiedoston tietoja..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Palautan nimetöntä tiedostoa - yritetään tallentaa nimelle RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Saatavissa olevat tiedot palautettiin :D - Yritän käyttää niitä..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Tiedoston tietoja ei saatu palautettua :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Avaaminen epäonnistui: %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "VAROITUS: %s voi olla turmeltunut (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "VIRHE osatiedostoa tallennettaessa: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "IO-virhe osatiedostoa tallennettaessa: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Tiedoston part.met.seeds tallentaminen epäonnistui kohteelle %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Tallennettu %i lähde osatiedostolle: %s (%s)"
 msgstr[1] "Tallennettu %i lähdettä osatiedostolle: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Tallennettu %i lähde osatiedostolle: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Virhe luettaessa osatiedoston lähdetiedostoa (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Turmeltunut osa (%d) %d osasta tiedostossa %s - Tiedostotulostarkiste |%s| Tiedostotarkiste |%s|"
 msgstr[1] "Turmeltunut osa (%d) %d osasta tiedostossa %s - Tiedostotulostarkiste |%s| Tiedostotarkiste |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Valmis osa (%i) kohteessa %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Tarkiste uudelleenluotu: %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Odottamaton virhe viimeistellessä %s. Tiedosto tauotettu"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Lataus suoritettu: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Lataus suoritettu: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Poistetaan tiedosto: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "VAROITUS: Ei voitu laskea tarkistetta ladatusta osasta - tarkistejoukko on puutteellinen kohteelle '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "VIRHE: Ei voitu luoda tarkistetta ladatulle osalle - tarkistejoukko on puutteellinen (%s). Näin ei pitäisi koskaan tapahtua."
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Data loppui (EOF) luotaessa tarkistetta ladatulle osalle %u jonka pituus on %u (maksimi on %u) osatiedostosta '%s' jonka pituus on %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VAROITUS: Levytilaa ei ole tarpeeksi! Tauotan tiedoston: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Ladattu osa %i on turmeltunut tiedostossa: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Ennallistettu turmeltunut osa %i kohteessa %s -> Säästetyt tavut: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Allokoidaan"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Riittämätön levytila"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Ladattu"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Yhteys"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Palvelimet"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Turvallisuus"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Käyttöliittymä"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Välityspalvelin"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Etähallinta"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online-Signeeraus"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Laajennetut"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debuggaus"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5711,15 +5623,15 @@ msgstr ""
 "    %PARTFILE - koko polku tiedostoon\n"
 "    %PARTNAME - pelkästään tiedoston nimi"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5735,35 +5647,35 @@ msgstr ""
 "aMule toimii hyvin vaikka näitä ei\n"
 "säädettäisikään."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Asetuksen kytkeminen widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Datan siirtäminen asetuksesta widgettiin epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Yhdistettävän välityspalvelimen tyyppi"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Datan siirtäminen widgetistä asetukseen epäonnistui ID:llä %d ja avaimella %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5771,42 +5683,42 @@ msgstr ""
 "aMule on käynnistettävä uudelleen näiden muutosten voimaansaattamiseksi:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP-portti muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Etäyhteyden portti vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Etäyhteyden vastaanotto muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Etäyhteyden sovitin muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokollan kätkeminen"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5814,7 +5726,7 @@ msgstr ""
 "Palvelinlistan automaattisen päivityksen lista on tyhjä.\n"
 "'Päivitä palvelinlista käynnistettäessä' kytketään pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5822,33 +5734,33 @@ msgstr ""
 "Olet sallinut etäyhteydet mutta et ole antanut salasanaa.\n"
 "Etäyhteydet eivät ole mahdollisia ellei salasanaa ole annettu."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Kieli vaihtui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Väliaikaiskansio muuttui.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-verkko käytössä.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Väärä protokollaversio."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5856,7 +5768,7 @@ msgstr ""
 "Sekä eD2k- että Kad-verkko on pois päältä.\n"
 "Et voi yhdistää ennen kuin ainakin toinen niistä on sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5864,7 +5776,7 @@ msgstr ""
 "Kad ei käynnisty mikäli UDP-portti on pois päältä.\n"
 "Salli UDP-portti tai kytke Kad pois päältä."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5874,69 +5786,69 @@ msgstr ""
 "Sinun on uudelleenkäynnistettävä aMule nyt.\n"
 "Mikäli et uudelleenkäynnistä nyt, älä valita mikäli jotain pahaa tapahtuu.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Salasana asetettu ja etäyhteydet sallittu."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5946,66 +5858,66 @@ msgstr ""
 "Ole hyvä ja syötä ainakin yksi URL joka osoittaa käypään server.met-tiedostoon.\n"
 "Klikkaa nappia \"Lista\" tämän valintaruudun vierestä syöttääksesi URLin."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Väliaikaiset tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Saapuvat tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online-Signeeraukset"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Valitse kansio kohteelle %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Etsi videosoitin"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Valitse selain"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Suoritettava tiedosto%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Muokkaa palvelinlistaa"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6013,1210 +5925,1209 @@ msgstr ""
 "Syötä tähän URLit joista server.met-tiedostot haetaan.\n"
 "Vain yksi urli riville."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Täysiä lähteitä"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Tila:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Päivitysväli: %d sekunti"
 msgstr[1] "Päivitysväli: %d sekuntia"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Keskimääräiskuvaajan aika: %d minuutti"
 msgstr[1] "Keskimääräiskuvaajan aika: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Yhteyskuvaajan skaala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tiedostopuskurin koko: %d tavu"
 msgstr[1] "Tiedostopuskurin koko: %d tavua"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Lähetysjonon koko: %d asiakas"
 msgstr[1] "Lähetysjonon koko: %d asiakasta"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Palvelinyhteyden päivitysväli: %d minuutti"
 msgstr[1] "Palvelinyhteyden päivitysväli: %d minuuttia"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Palvelinyhteyden päivitysväli: Ei käytössä"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "poissa käytöstä"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Suorita komento tapahtuman '%s' yhteydessä"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Mahdollista komentojen suorittaminen ytimestä"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Ytimen komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Mahdollista komentojen suorittaminen graafisesta käyttöliittymästä"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Graafisen käyttöliittymän komento:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Seuraavat muuttujat korvataan:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jaetut kansiot"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa ei huomioida."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Hakuvaroitus"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Kaikki"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k-hakua ei voida tehdä mikäli eD2k ei ole yhdistettynä"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Avainsana hakuun: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Odottamaton virhe Kad-hakua tehtäessä: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Tiedostotunniste"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Ei luokitusta"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Lataa luokassa"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hanki %s tälle tiedostolle"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Hae tähän liittyviä tiedostoja (eD2k, paikallinen palvelin)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Merkitse tunnetuksi tiedostoksi"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopioi eD2k-linkki leikepöydälle"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olet yhdistettynä palvelimeen jota yrität poistaa, katkaise yhteys ensin."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Peruutettu"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Uusi"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Kätketyt yhteysyritykset palvelimille epäonnistuivat. Yritetään uudelleen ilman kätkemistä."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Kätketyt yhteysyritykset palvelimille epäonnistuivat. Yritetään uudelleen ilman kätkemistä."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Yhdistäminen kaikkiin listattuihin palvelimiin epäonnistui. Aloitetaan uusi kierros."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Yhdistäminen kaikkiin listattuihin palvelimiin epäonnistui. Aloitetaan uusi kierros."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-verkko kytketty pois päältä asetuksista, ei yhdistetä."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Palvelinlistasta ei löytynyt toimivia palvelimia joihin yhdistää"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Yhdistetty %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Yhteys muodostettu: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Kriittinen virhe yhdistettäessä. Internet-yhteys on mahdollisesti poikki"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Yhteys palvelimeen %s (%s:%i) katkesi"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) näyttää kuolleelta."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) on ilmeisesti täysi."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
 msgstr[1] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Yhdistäminen kohteeseen %s (%s:%i) epäonnistui."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "VIRHE: Pistukka virheellinen aikakatkaisutarkistuksessa"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Yhteysyritys kohteeseen %s (%s:%i) aikakatkaistiin."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Vastaanotettiin myöhästynyt vastaus DNS-kyselyyn, ohitetaan."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Lataan tiedostoa server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Tiedostoa server.met ei löytynyt!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Server.met-tiedoston '%s' avaaminen epäonnistui, tuntematon muotoilu."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Server.met:in avaus epäonnistui!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met on turmeltunut, virheellinen versiotunniste: 0x%x, koko %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i palvelin tiedostossa server.met"
 msgstr[1] "%i palvelinta tiedostossa server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d palvelin lisätty"
 msgstr[1] "%d palvelinta lisätty"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Virhe: tiedosto 'server.met' on turmeltunut: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "IO-virhe luettaessa tiedostoa 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Palvelinta ei lisätty: [%s:%d] ei määritä kelvollista porttia."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Palvelinta ei lisätty: IP [%s:%d] on suodatettu tai virheellinen."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Palvelinta ei lisätty: IP:porttia [%s:%d] vastaava palvelin on jo listalla."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Palvelin lisätty: Palvelin [%s:%d] on nimeltään '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Olet yhdistettynä palvelimeen jota yrität poistaa, katkaise yhteys ensin."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Kohteen '%s' avaaminen ei onnistunut"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Server.met:n tallennus epäonnistui!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Virheellinen URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Palvelinlista ladattu osoitteesta %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Palvelinlistan osoitetta ei löydetty tiedostosta 'addresses.dat'. Ole hyvä ja liitä kelvollinen palvelinlistan osoite tähän tiedostoon palvelinlistan automaattiseksi päivittämiseksi"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Aloita palvelinlistan lataus osoitteesta %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "VAROITUS: palvelinlistan automaattisen päivityksen url ei kelpaa: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Addresses.dat-tiedostosta ei löytynyt kelvollisia urleja server.met:in automaattilataukselle"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Palvelinlistan %s lataus epäonnistui"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Paikallinen palvelin IP-suodatetaan, yhdistän toiselle palvelimelle!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Palvelimen nimi"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Osoite"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Portti"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Kuvaus"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Viive"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Käyttäjiä"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Kiinteä"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versio"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Olet yhdistettynä palvelimeen jota yrität poistaa. Katkaise yhteys ensin. Palvelinta EI poistettu."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Tuntematon nimi)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Oletko varma että haluat poistaa pysyvän palvelimen %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Palvelimet (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Palvelin"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Yhdistä palvelimelle"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Merkitse palvelin pysyväksi"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Poista palvelimen pysyvyysmerkintä"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Merkitse palvelimet pysyviksi"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Poista palvelimien pysyvyysmerkintä"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Poista palvelin"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Poista palvelimet"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Poista kaikki palvelimet"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopioi eD2k-linkit leikepöydälle"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Uudelleenyhdistä palvelimelle"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Oletko varma että haluat poistaa kaikki palvelimet?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Oletko varma että haluat poistaa valitun palvelimen?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Oletko varma että haluat poistaa valitut palvelimet?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "VIRHE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "VAROITUS: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Uusi asiakastunnus on %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "VAROITUS: Sinulla on Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tTodennäköisimmin tämä johtuu siitä että olet palomuurin tai reitittimen takana"
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tLisätietoa https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Tuntematon palvelintieto vastaanotettu! - liian lyhyt"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Vastaanotettiin %d uusi palvelin"
 msgstr[1] "Vastaanotettiin %d uutta palvelinta"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Palvelinlista tallennettu."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Palvelin hylkäsi viimeisimmän komennon"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Virheellinen paketti saatu palvelimelta: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Odottamaton virhe käsiteltäessä pakettia palvelimelta: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Ei voitu luoda DNS-selvityssäiettä kohteeseen %s yhdistämiseen"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Palvelin IP %s (%s) on suodatettu. Ei yhdistetä."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "käyttää protokollan kätkentää."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Yhdistetään %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Ei voitu selvittää dns-nimeä palvelimelle %s: Ei voida yhdistää!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule loki"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Palvelinta ei lisätty: IP:tä tai verkkonimeä ei annettu."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Palvelinta ei lisätty: Epäkelpo palvelinportti."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k-tilanne:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Yhteyden tila:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Yhdistetty"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlian tilanne:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Lähiverkkokäyttö"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Käynnissä"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademlian tilanne:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Tila:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Yhteyden tila:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Palomuurattu - avaa TCP-portti %d reitittimestä tai palomuurista"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP-yhteyden tila:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Palomuurattu - avaa UDP-portti %d reitittimestä tai palomuurista"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Palomuurattu tilanne: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Kaveria ei vaadita - TCP-portti auki"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Kaveria ei vaadita - UDP-portti auki"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Ei kaveria"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Yhdistetään kaveriin"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Yhdistetty kaveriin osoitteessa %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indeksoidut lähteet:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indeksoidut avainsanat:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indeksoidut huomautukset:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indeksoitu kuorma:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Keskimäärin käyttäjiä:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Keskimäärin tiedostoja:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Ei käynnissä"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Lisään tiedoston %s jaettaviin"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto, %i tuntematonta"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa, %i tuntematonta"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "VIRHE: Yritettiin jakaa %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Jaettua kansiota ei löytynyt, hypätään yli: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Käyttäjänimi"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Latausnopeus"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Lähetysnopeus"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Saatavilla olevat osat"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Lähetyksen tilanne"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Latauksen tilanne"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Alkuperä"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Paikallinen tiedoston nimi"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Jaettujen tiedostojen lista"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Hankitut osat"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Kansiopolku"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Lisää kommentti/luokitus"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Muuta kommenttia/luokitusta"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Uudelleennimeä"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lisää tiedostot kokoelmassa siirtolistalle"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopioi magnet-&URI leikepöydälle"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopioi eD2k-linkki työpöydälle (Lähde)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopioi eD2k-linkki leikepöydälle (Lähde) (Kryptaustiedoilla)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopioi eD2k-linkki leikepöydälle (Verkkonimi)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopioi eD2k-linkki leikepöydälle (Verkkonimi) (Kyptaustiedoilla)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopioi eD2k-linkki leikepöydälle (&AICH-tiedot)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopioi eD2k-linkki leikepöydälle (&AICH-tiedot)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Tarvitset HighID:een luodaksesi voimassa olevan lähdelinkin"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Tiedoston nimi etäpäässä"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Lähetetty data (Sessiossa (Yhteensä)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Otsikkotietoja yhteensä (Paketteja): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Tiedostopyyntöotsikkoja (Paketteja): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Lähdevaihdon otsikkoja (Paketteja): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Palvelimen otsikkoja (Paketteja): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad-otsikkoja (Paketteja): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Kryptauksen otsikkoja (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Lähetyksiä käynnissä: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Lähetyksiä odottamassa: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Onnistuneita lähetyksiä yhteensä: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Epäonnistuneita lähetyksiä yhteensä: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Keskimääräinen lähetysaika: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Ladattu data (Sessiossa (Yhteensä)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Lähteitä löytynyt: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Latauksia käynnissä (paloja): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Session jakosuhde lähetys:lataus (Yhteensä): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Keskimääräinen latausnopeus (Sessiossa): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Keskimääräinen lähetysnopeus (Sessiossa): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Suurin latausnopeus (Sessiossa): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Suurin lähetysnopeus (Sessiossa): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Uudelleenyhdistämisiä: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Aikaa ensimmäisestä siirrosta: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Yhdistetty palvelimeen: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktiivisia yhteyksiä (arvio): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Maksimimäärä yhteyksiä saavutettu: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Yhteyksiä keskimäärin (arvio): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Yhteyksiä enimmillään (arvio): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Asiakkaat"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Tuntematon: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Suodatettu: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Estetty: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Yhteensä: %i Tunnettuja: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Toimivia palvelimia: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Toimimattomia palvelimia: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Yhteensä: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Poistettuja palvelimia: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Suodatettuja palvelimia: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Käyttäjiä toimivilla palvelimilla: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Tiedostoja toimivilla palvelimilla: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Käyttäjiä yhteensä: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Tiedostoja yhteensä: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Palvelimien käyttö: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jaettuja tiedostoja: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Keskimääräinen tiedostokoko: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Käyttöjärjestelmä"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Ei vastaanotettu"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktiiviset yhteydet: (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Ei saatavissa"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Ei koskaan"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Komento '%s' prosessinumerolla '%d' on suoritettu paluukoodilla '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Suorita <str> ja poistu."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Virheellinen IP-muoto. Käytä xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Tälle komennolle on annettava parametri. Kelvollisia ovat: 'all', tiedostonimi, tai numero.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Käsittelee tarkisteen mukaan: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Käsittelee tiedostonimen mukaan: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Tälle komennolle on annettava parametri. Kelvollisia ovat: tiedostotarkiste.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Ei ole kelvollinen numero\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Tarkiste ei ole kelvollinen (pituuden on oltava tasan 32 merkkiä)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7225,7 +7136,7 @@ msgstr "Kirjoita '%s' saadaksesi lisää ohjeita.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7234,89 +7145,87 @@ msgstr "Kirjoita '%s' saadaksesi lisää ohjeita.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Kirjoita '%s' saadaksesi lisää ohjeita.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Latauksen koko: %i"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Pyyntö ei onnistunut, tuntematon virhe."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Toiminto onnistui."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Pyyntö epäonnistui virheeseen: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Asiakkaiden IP-suodatus on %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "POIS PÄÄLTÄ"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "PÄÄLLÄ"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Palvelimien IP-suodatus on %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Nykyinen IP-suodatustaso on %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Kaistarajoitukset: Ylös: %u KB/s, Alas: %u KB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Yhdistetty %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Yhdistän"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "palomuurattu"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7325,7 +7234,7 @@ msgstr ""
 "\n"
 "Lataus:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7334,7 +7243,7 @@ msgstr ""
 "\n"
 "Lähetys:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7343,7 +7252,7 @@ msgstr ""
 "\n"
 "Asiakkaita jonossa:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7352,46 +7261,46 @@ msgstr ""
 "\n"
 "Lähteitä yhteensä:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Osatiedosto]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Hakutuloksia: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Haun edistyminen: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Haun edistyminen ei ole tiedossa"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Palvelin lähetti tunnistamattoman vastauksen, komentosana = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Näytä tilannetiedot lyhyesti."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Näyttää yhteyden tilan, nykyiset lähetys-/latausnopeudet, jne.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Näytä täydet tilastotiedot."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7405,11 +7314,11 @@ msgstr ""
 "\n"
 "Esimerkki: 'statistics 5' näyttää vain viisi suosituinta versiota kustakin asiakastyypistä.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Sammuta aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7419,35 +7328,35 @@ msgstr ""
 "Tämä sulkee myös tekstikäyttöliittymän, koska se on käyttökelvoton ilman\n"
 "suoritettavaa ydintä.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Lataa uudelleen annetun kohteen."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Lataa uudelleen IP-suodatustaulukko."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Lataa nykyinen IP-suodatustaulukko uudelleen."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Päivittää IP-suodatustaulukon URLista."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Mikäli URL jätetään pois, käytetään URLia asetuksista."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Yhdistä verkkoon."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7459,35 +7368,35 @@ msgstr ""
 "kyseiselle palvelimelle. IP:n on oltava pisteillä erotettu IPv4-numero\n"
 "tai DNS-nimi."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Yhdistä vain eD2k:hon."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Yhdistä vain Kadiin."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Katkaise yhteys verkkoon."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Tämä katkaisee yhteyden kaikkiin yhdistettyihin verkkoihin.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Katkaise vain eD2k-yhteys."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Katkaise vain Kad-yhteys."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Lisää eD2k- tai magnet-linkin ytimelle."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7505,51 +7414,51 @@ msgstr ""
 "\n"
 "Magnet-linkin on sisällettävä eD2k-tarkiste ja tiedoston pituus.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Aseta haluamasi asetukset."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Aseta IP-suodatuksen asetukset."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Kytke IP-suodatus päälle sekä asiakkaille että palvelimille."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Kytke IP-suodatus pois päältä sekä asiakkailta että palvelimilta."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Salli/estä asiakkaiden IP-suodatus."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Kytke IP-suodatus päälle asiakkaille."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Kytke IP-suodatus pois päältä asiakkailta."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Salli/estä palvelinten IP-suodatus."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Kytke IP-suodatus päälle palvelimille."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Kytke IP-suodatus pois päältä palvelimilta."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Valitse IP-suodatuksen taso."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7557,74 +7466,74 @@ msgstr ""
 "Sallitut suodatustasot ovat välillä 0-255 oletusarvon (myös lähtöarvon)\n"
 "ollessa 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Aseta kaistankäytön rajoitukset."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Näille komennoille annettujen arvojen on oltava kilotavuja sekunnissa.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Aseta lähetyskaistan raja."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Näille komennoille annettujen arvojen on oltava kilotavuja sekunnissa.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Aseta latauskaistan raja."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Näille komennoille annettujen arvojen on oltava kilotavuja sekunnissa.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Näytä asetuksen arvo."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Hae IP-suodatuksen asetukset."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hae IP-suodatuksen tila sekä asiakkaille että palvelimille."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Hae IP-suodatuksen tila asiakkaille."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Hae IP-suodatuksen tila palvelimille."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Hae IP-suodatuksen taso."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Hae kaistankäytön rajat."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Suorittaa haun"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7643,44 +7552,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Suorittaa haun kaikkialta."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Suorittaa haun paikallisesti"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Suorittaa kad-haun"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Näyttää viimeisimmän haun tulokset."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Näyttää haun edistymisen."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Aloittaa tiedoston lataamisen"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7688,81 +7597,81 @@ msgstr ""
 "Tiedoston numero viimeisimmästä hausta on annettava.\n"
 "Esimerkki: 'download 12' aloittaa viimeisen haun tiedoston numero 12 latauksen.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Tauota lataus."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Jatka latausta."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Peruuta lataus."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Aseta latauksen tärkeys."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Aseta tärkeys lataukselle, joko Alhainen, Normaali, Korkea tai Automaattinen.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Aseta tärkeys alhaiseksi."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Aseta tärkeys normaaliksi."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Aseta tärkeys korkeaksi."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Aseta tärkeys automaattiseksi."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Näytä jonot/listaukset."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Näyttää lähetys/latausjonon, palvelinlistan tai jaettujen tiedostojen listan.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Näytä lähetysjono."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Näytä latausjono."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Näytä loki."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Näytä palvelinlista."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Nollaa loki."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Vanhentunut komento, käytä sen sijaan '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7771,261 +7680,258 @@ msgstr ""
 "Tämä on vanhentunut komento ja se voidaan poistaa tulevaisuudessa.\n"
 "Käytä sen sijaan '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstiasiakas"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Muunnetaan vanhat AICH-tarkistejoukot '%s' 64-bittisiksi '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "VAROITUS: Tiedostonimi '%s' ei kelpaa ja tiedosto uudelleennimettiin '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "VAROITUS: Tiedosto '%s' on jo olemassa, uusi tiedosto nimettiin '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Oletko varma että haluat perua ja poistaa kaikki tiedostot tässä luokassa?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Vaaditaan vahvistus"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Luokittelujen maksimimäärä on 99."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Liian monta luokkaa!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Kaikki muut"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Valitse suodatin"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Lisää luokka"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Muokkaa luokkaa"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Poista luokka"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Tarkistejoukkoa pyydettiin tuntemattomalle tiedostolle: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Jatketaan tiedoston %s lähetyksiä"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Keskeytetään tiedoston %s lähetys"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Komennon '%s' suoritus epäonnistui tapahtuman '%s' yhteydessä."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Lataus valmistunut"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Koko polku tiedostoon."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Tiedoston nimi ilman polkua."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Tiedoston e2dk-tarkiste."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Tiedoston koko tavuina."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Kumulatiivinen latausaika."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Uusi keskustelu aloitettu"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Viestin lähettäjä."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Levytila loppu"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Levyosio."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Virhe viimeistellessä"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Käsittelee tiedostoa numero %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Olet pyytänyt osatarkisteita (Vain tiedostoille jotka ovat > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Tiedostoa ei ole !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "\"aLinkCreator, aMule eD2k-linkkien tekijä"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Tervetuloa!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Syöteparametrit"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Tiedostosta Tarkiste"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Lisää Valinnaisia URLeja tälle tiedostolle"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Syötä tähän tiedosto josta haluat laskea eD2k-linkin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Syötä tähän url jonka haluat lisätä eD2k-linkkiin: Lisää / perään jotta aLinkCreator voi lisätä tiedoston nimen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Luo linkki osatarkisteilla"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Auttaa levittämään uusia ja harvinaisia tiedostoja nopeammin, kustannuksena linkin koon kasvu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4-Tiedostotarkiste"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k-tiedostotarkiste"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k-linkki"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Tallenna"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopioi leikepöydälle"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Avaa"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Avaa tiedosto laskeaksesi sen eD2k-linkin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopioi laskettu eD2k-linkki leikepöydälle"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Tallenna nimellä"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Tallenna laskettu eD2k-linkki tiedostoon"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Tietoja aLinkCreatorista"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Valitse tiedosto josta haluat laskea eD2k-linkin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Leikepöytää ei voitu avata"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Toistaiseksi ei mitään kopioitavaa !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Valitse tiedosto lasketulle eD2k-linkille"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Ei voitu avata "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Ole hyvä ja syötä ei-tyhjä tiedoston nimi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Toistaiseksi ei mitään tallennettavaa !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8045,167 +7951,159 @@ msgstr ""
 "\n"
 "Jaetaan GPL:n alaisena"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Laskee tarkistetta..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator on toiminnassa"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Lasken MD4-tarkistetta..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Lasken eD2k-tarkisteita..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Peruutettu !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Valmis %.2f sekunnissa"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Olet jo lisännyt tämän URLin !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Ole hyvä ja syötä ei-tyhjä URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ei voida avata %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i päivä(ä) %i tunti(a) %i minuutti(a) %i sekunti(a)"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uvrk %02ut %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02ut %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMulen Online-Tilastotiedot"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Suurin latausnopeus wxCasin käynnistämisestä lähtien"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Suurin latausnopeus edellisten wxCasin ajokertojen aikana"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Tyhjennä"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Järjestelmä"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Pysäytä Automaattinen Päivitys"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Tallenna Online-Tilastotietokuva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Tulosta Online-Tilastotietokuva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Asetus"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Tietoja wxCasista"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Aloita Automaattinen Päivitys"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automaattinen Päivitys pysäytetty"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automaattinen Päivitys aloitettu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Tallenna Tilastokuva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMulen Online-Tilastotiedot"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8213,11 +8111,11 @@ msgstr ""
 "Tulostamisessa oli ongelma.\n"
 "Kenties tulostin ei ole asennettu oikein?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Tulostus"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8235,403 +8133,392 @@ msgstr ""
 "\n"
 "Jaetaan GPL:n alaisena"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oi Oi, aMule ei ole käynnissä..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule on käynnissä"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule on käynnissä, mutta ei yhdistettynä"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule yhdistää..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oi Oi, aMulen tila on tuntematon..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " on ollut käynnissä "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " on pysäytetty !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ei ole yhdistetty !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " on yhdistämässä..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " on tekemässä jotain outoa, tarkista se !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " on yhdistetty: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "pois päältä"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " palvelimella "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " käyttäen "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Yhteensä Ladattu: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Lähetetty: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Istunnossa Ladattu: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Lataus: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " KB/s, Lähetys: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Jako: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " tiedosto(a), Asiakkaita jonossa: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Aika: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " hetkellä "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Järjestelmän Kuormituskeskiarvo (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Järjestelmä päällä: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Tiedoston amulesig.dat sisältävä kansio"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Syötä tähän kansio jossa on amulesig.dat-tiedostosi"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Päivitysväli sekunteina"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Luo tilastokuva joka päivityksen yhteydessä"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Syötä tähän kansio johon haluat tilastokuvan luotavan"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Lähetä tilastokuvasi toistuvasti FTP-palvelimelle"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP-osoite"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP-kansiopolku"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Syötä tähän FTP-palvelimen osoite"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Syötä tähän kansio FTP-palvelimella mihin tilastokuvasi tallennetaan"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Käyttäjänimi"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Syötä tähän käyttäjänimi jota käytät kirjautuessasi FTP-palvelimelle"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Syötä tähän salasana jota käytät kirjautuessasi FTP-palvelimelle"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP-päivityksien väli minuuteissa"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Tarkista oikeellisuus"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Kansio joka sisältää signeeraustiedostosi"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Kansio mihin luodaan tilastokuva"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Lataa mallin <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web-palvelimen HTTP-portti"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP-portti"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Täyden käyttöoikeuden salasana web-palvelimelle"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Vieraan salasana web-palvelimelle"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Salli vieraskäyttö"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Estä vieraskäyttö"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Hae/tallenna web-palvelimen asetukset etä-aMulesta/een"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMulen asetustiedoston polku. ÄLÄ KÄYTÄ SUORAAN!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Poista PHP-tulkki käytöstä (vanhentunut)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Uudelleenkoosta PHP-sivut joka pyynnöllä"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Web-Palvelin"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "web-asiakasyhteys hyväksytty\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "VIRHE: Web-asiakasyhteyttä ei voitu hyväksyä\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Pyyntö ei onnistunut, virhe: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indeksitiedostoa ei löydetty: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sessio vanhentunut - pyydetään kirjautumista\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessio kunnossa, kirjautuneena\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessio kunnossa, ei kirjautuneena\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ei avattua sessiota - tulee pyytämään kirjautumista\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessio luotu - pyytää kirjautumista\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Käsittelee pyyntöä [alkuperäinen]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Salasanaa ei annettu, kirjautumista ei sallita"
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Salasanatarkiste ei kelpaa\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Salasana hyväksytty\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Virheellinen salasana\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Et antanut salasanaa. Tyhjä salasana ei ole sallittu.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Uloskirjautumista pyydetty\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Käsittelee pyyntöä [uudelleenohjattu]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Yhdistäminen epäonnistui "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -26,19 +26,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "À propos d'aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Contrôle à distance d'aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot :"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -46,7 +46,7 @@ msgstr ""
 "Client P2P multiplateforme basé sur eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -54,76 +54,76 @@ msgstr ""
 "Copyright (c) 2003-2026 L'équipe aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Une partie d'aMule est basée sur \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia : Routage peer-to-peer basé sur la métrique XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Droits d'auteur (c) 2002-2011 Petar Maymounkov (petar@maymounkov.org)\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Site web :"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum :"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Documentation :"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Bugs :"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Cliquer pour vérifier s'il existe une version plus récente."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "Recherche de mises à jour…"
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "Vous utilisez la version la plus récente."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Une nouvelle version (%s) est disponible :"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "Impossible de vérifier les mises à jour. Veuillez réessayer plus tard."
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Ajouter un ami"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Vous devez entrer une IP et un port valides !"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Information"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Le hachage utilisateur spécifié est invalide !"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -137,47 +137,46 @@ msgstr ""
 "\n"
 "Installer l'intégration de bureau maintenant ?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "Ajouter aMule à votre menu d'applications ?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Installer"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Ne plus me demander"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Impossible d'installer l'intégration de bureau : la variable d'environnement APPDIR n'est pas définie. Cela signifie généralement que l'AppImage a été lancée d'une manière non standard."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "Échec de l'intégration d'aMule"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Impossible d'installer l'intégration de bureau : échec de la création de %s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Impossible d'installer l'intégration de bureau : échec de l'écriture de %s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Intégration AppImage : aMule a été ajouté à votre menu d'applications (%d raccourcis shell sous ~/.local/bin)."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -191,103 +190,100 @@ msgstr ""
 "\n"
 "Redémarrer aMule maintenant ?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule installé"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Redémarrer maintenant"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Plus tard"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Échec de l'ouverture du fichier ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que source pour un lien eD2k alors que vous avez un LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Et maintenant on quitte l'application principale…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Mise à mort de l'instance amuleweb avec le pid '%d' … "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Échec"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Interruption de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Arrêt de l'instance amuleapi avec le pid '%d'… "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit : Arrêt du noyau."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Fermeture d'aMule terminée."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Résultats du débogage de la mémoire pour la sortie d'aMule :"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Liaison du trafic pair à pair d'aMule à l'interface : %s (les mises à jour HTTP utilisent le chemin par défaut)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Rattacher tout le trafic réseau à l'interface : %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVERTISSEMENT : l'interface réseau configurée '%s' n'a pu être trouvé - le trafic ne lui est PAS lié et peut partir sur le chemin par défaut. Vérifiez le nom de l'interface dans les Préférences."
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVERTISSEMENT : la liaison à l'interface réseau '%s' nécessite des privilèges élevés et n'a PAS été appliquée - le trafic peut emprunter le chemin par défaut. Attribuez la capacité (par exemple 'sudo setcap cap_net_raw+ep' sur le binaire aMule) ou exécutez avec des privilèges suffisants."
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVERTISSEMENT : impossible de lier à l'interface réseau '%s' - le trafic peut emprunter le chemin par défaut."
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Votre localisation a été remise à la valeur par défaut à cause d'un changement dans la configuration. Désolé."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Infos"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -295,21 +291,20 @@ msgstr ""
 "\n"
 "Configuration EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Mot de passe renseigné et connexions externes activées."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Amorçage de réseau"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +312,48 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serveur web s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi s'exécutant avec le pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Vous avez demandé à exécuter amuleapi au démarrage, mais le binaire amuleapi ne peut être exécuté. Veuillez installer le paquet contenant le serveur API RESTd'aMule, ou compilez aMule depuis le code source avec -DBUILD_AMULEAPI=YES et installez-le."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossible de lier les ports à l'adresse spécifiée : %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Le port %u n'est pas disponible. Vous serez LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +368,48 @@ msgstr ""
 "\n"
 "Vérifiez votre réseau pour être sûr que le port est ouvert en sortie et en entrée."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Échec de la création du fichier OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Échec de la création du fichier aMule OnlineSig"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "La localisation choisie semble ne pas être installée sur votre machine. (Note : Je tente de la forcer quand même)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "C'est la première fois que vous lancez aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Cette version est une version de test, mise à jour quotidiennement, et\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nous ne fournissons aucune garantie que cela n'endommagera rien, brûlera votre maison,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou tuera votre chien. Mais ça *devrait* être à peu près sûr quand-même.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plus d'informations, de l'aide et de nouvelles versions peuvent être trouvées sur notre page web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, ou sur notre canal IRC : #aMule sur irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Ne vous gênez pas pour reporter tout bogue sur https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,222 +417,218 @@ msgstr ""
 "Le répertoire choisi pour les fichiers de signature en ligne est INVALIDE !\n"
 "La signature en ligne sera DÉSACTIVÉE jusqu'à ce que cela soit corrigé dans les préférences."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Erreur lors de la réserve d'espace pour le fichier '%s' : %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERREUR : impossible d'ouvrir le fichier journal"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVERTISSEMENT : le fichier journal est vide. Quelque chose ne va pas."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Le journal a été effacé"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "ServerMessage : %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saut du téléchargement de %s, car le fichier demandé n'est pas récent."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Échec du téléchargement de la liste des nœuds."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Échec de l'ouverture du fichier de vérification de version téléchargé"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Fichier de vérification de version corrompu"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Vous utilisez une version obsolète d'aMule !"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Votre version d'aMule est %i.%i.%i et la dernière version est %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "La dernière version peut toujours être trouvée sur https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVERTISSEMENT : votre version d'aMuled est obsolète : %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Votre version d'aMule est à jour."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Échec du téléchargement du fichier de vérification de version"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilisateurs : %s | Fichiers : %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilisateurs : E : %s K : %s | Fichiers : E : %s K : %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Aucun réseau sélectionné"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "avec un LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "avec un HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connecté à %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connexion à %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Déconnecté de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad démarré."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad arrêté."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Connecté à Kad (OK)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Connecté à Kad (pare-feu)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Déconnecté de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Le réseau Kad ne peut être utilisé si le port UDP est désactivé dans les préférences, pas de démarrage."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Le réseau Kad est désactivé dans les préférences, pas de connexion."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERREUR : le démon aMule ne peut être utilisé quand les connexions externes sont désactivées. Pour activer les Connexions Externes, utilisez soit un aMule normal, démarrez amuled avec l'option --ec-config ou passez la clé \"AcceptExternalConnections\" à 1 dans le fichier ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERREUR : Un mot de passe valide est requis pour utiliser les connexions externes, et le démon aMule ne peut pas être utilisé sans connexions externes. Pour exécuter le démon aMule, vous devez indiquer une valeur appropriée dans le champ \"ECPassword\" du fichier ~/.aMule/amule.conf. Lancez amuled avec l'option --ec-config pour configurer le mot de passe. Davantage d'informations sont disponibles sur https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled : OnInit - démarrage du timer"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Impossible de créer le fichier Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "Erreur : %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ceci est aMule %s basé sur eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Une nouvelle version est disponible"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -655,191 +643,184 @@ msgstr ""
 "\n"
 "Souhaiteriez-vous ouvrir la page de téléchargement ?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Pas de réseau"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Contrôle à distance d'aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Erreur Fatale : Échec de la création du minuteur noyau"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Connexion perdue"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "Annuler et quitter"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "Reconnexion… (tentative %d)"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "Prochaine tentative dans %d s…"
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -852,40 +833,40 @@ msgstr ""
 "\n"
 "L'interface est mise en pause jusqu'à ce que la connexion soit restaurée."
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Erreur Fatale : Échec de la création du minuteur d'interrogation"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Départ vers la boucle d'événement…"
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Connexion…"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Échec de la connexion. Veuillez vérifier l'hôte, le port et le mot de passe."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Gestionnaire d'événement GUI EC distant"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connexion échouée. Impossible de se connecter à %s : %d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Descendant"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "La tentative de reconnexion a dépassé le délai d'attente ; nouvelle tentative en cours."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -894,681 +875,658 @@ msgstr ""
 "Délai de connexion dépassé. Impossible de joindre %s:%d dans le temps imparti.\n"
 "Vérifiez l'hôte, le port et qu'aMule est en cours d'exécution avec les Connexions Externes activées."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "La connexion au noyau distant a été perdue. Tentative de reconnexion…"
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "La connexion au noyau distant a été rétablie."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentative de reconnexion %d : connexion à %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "La reconnexion n'a pu démarrer, nouvelle tentative sous peu."
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Prêt"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Tous"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "illisible"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "introuvable"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "Le noyau a rejeté ces répertoires partagés : %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Lien invalide ou déjà dans la liste."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on garde le répertoire '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Recherche d'un pote pour une connexion lowid"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fausse version d'eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Faux eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Faux eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basé sur eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Pseudo : %s ID : %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Demandé : %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiques des fichiers pour cette session : %d requête acceptée sur %d, %s transférés\n"
 msgstr[1] "Statistiques des fichiers pour cette session : %d requêtes acceptées sur %d, %s transférées\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiques des fichiers pour toutes les sessions : %d requête acceptée sur %d, %s transférés\n"
 msgstr[1] "Statistiques des fichiers pour toutes les sessions : %d requêtes acceptées sur %d, %s transférées\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Fichier demandé inconnu"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Message filtré de '%s' (IP : %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nouveau message de '%s' (IP : %s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés pour le répertoire inexistant '%s' -> ignoré"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "AVERTISSEMENT : %s n'a pas pu être ouvert."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVERTISSEMENT : Annulation de la liste des fichiers corrompus, elle contient des entêtes invalides."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Erreur d'E/S lors de la lecture du fichier %s : %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Erreur lors de la sauvegarde du fichier %s : %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Catégorie"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nouvelle Catégorie"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Choisissez un répertoire pour les fichiers entrants"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Vous devez indiquer un nom pour cette catégorie !"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Vous devez indiquer un chemin pour cette catégorie !"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Échec de la création du répertoire de réception pour cette catégorie. Veuillez indiquer un chemin valide !"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Début de la session de chat : %s (%s : %u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Connecté au Client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Connexion au Client ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Échec de la connexion au client / Connexion perdue ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Vous avez passé la vérification captcha et l'utilisateur a reçu votre message. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Votre réponse captcha était fausse et votre message a été ignoré. Vous pouvez demander un nouveau captcha par l'envoi d'un nouveau message. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Discussion"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Fermer l'onglet"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Fermer tous les onglets"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Fermer les autres onglets"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Ajouter aux amis"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Fichier de Crédits chargé, il y a %u client connu"
 msgstr[1] "Fichier de Crédits chargé, il y a %u clients connus"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Crédits expirés pour %u client !"
 msgstr[1] " - Crédits expirés pour %u clients !"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Pas de fichier 'cryptkey.dat' trouvé, création."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Détails du client"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Supporté"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Non supporté"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connecté"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f Ko/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Incomplet"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Mauvais garçon"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Vérification - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Non disponible"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés -> Accepté"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés -> Refusé"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de dossiers partagés -> Accepté"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de dossiers partagés -> Refusé"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés pour le répertoire '%s' -> accepté"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés pour le répertoire '%s' -> refusé"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "L'utilisateur %s (%u) partage le répertoire '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "L'utilisateur %s (%u) a envoyé une liste de fichier partagés non demandée."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "L'utilisateur %s (%u) a envoyé la liste des fichiers partagés pour le répertoire '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "L'utilisateur %s (%u) a terminé d'envoyer la liste des fichiers partagés"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "L'utilisateur %s (%u) a envoyé une liste de fichier partagés non voulue"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "L'utilisateur %s (%u) a refusé l'accès à la liste des répertoires/fichiers partagés"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Commentaires sur le fichier"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Évaluation"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Commentaire"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "Impossible de démarrer une recherche Kad"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Une recherche Kad ne peut pas être faite si Kad n'est pas lancé"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "Recherche Kad pour des commentaires en cours…"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Pas de commentaire"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u commentaire"
 msgstr[1] "%u commentaires"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Clients bannis %s pour l'envoi %s de données corrompues de %s total pour le fichier '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Échec du chargement des données des pays pour '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Basse]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [Normale]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Haute]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Haute"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Très haute"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Release"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Demande en cours"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Connexion via le serveur"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "File d'attente pleine"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En attente"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "En téléchargement"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Réception hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Parties inutiles"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Connexion impossible entre deux LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Trop de connexions"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Connexion par Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Trop de connexions Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Banni"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Erreur de Connexion"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "File d'attente distante pleine"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Ancien MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nouvel MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatible eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Serveur Local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Échange de Sources"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passif"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Lien"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Source Seeds"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Résultat de la recherche"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminé"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "En cours"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "ERREUR : Plus d'espace disque"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERREUR : Partmet non trouvé"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERREUR : Erreur E/S !"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERREUR : Échec !"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Mis en file d'attente"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Déjà en téléchargement"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Format de fichier temp inconnu ou mauvais."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Partie"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Reçu"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Vitesse"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progression"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Sources"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorité"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Statut"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Temps restant"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Vu complet pour la dernière fois"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Dernière réception"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Êtes-vous sûr de vouloir supprimer le fichier sélectionné ?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Êtes-vous sûr de vouloir supprimer les fichiers sélectionnés ?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1577,109 +1535,106 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stop"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pause"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Reprise"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "E&ffacer terminés"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Mettre tous les A4AF sur ce fichier immédiatement"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Mettre tous les A4AF sur ce fichier (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Mettre tous les A4AF sur n'importe quel autre fichier immédiatement"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Options avancées"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Prévisualisation"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Afficher les &Détails"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Afficher tous les commentaires"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copier le lien magnet dans le presse-papiers"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copier le &lien eD2k dans le presse-papiers"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copier le rapport dans le presse-papiers"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "dissocier"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Associer à une catégorie"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Ouvrir le fichier"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Entrez un nouveau nom pour ce fichier :"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Renommer"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f Mo/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H : %M : %S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Téléchargements (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "le gestionnaire par défaut de shell Windows"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1688,346 +1643,345 @@ msgstr ""
 "Pour éviter que cet avertissement n'apparaisse avec chaque prévisualisation,\n"
 "indiquez votre lecteur vidéo préféré dans les préférences (%s par défaut)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Aperçu"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERREUR : Échec de l'exécution du lecteur multimédia externe ! Commande : '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Enregistrement du fichier .part %u sur %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Tous les fichiers .part ont été enregistrés."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Chargement des fichiers temporaires depuis %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Chargement du fichier .part %u sur %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERREUR : Échec du chargement du fichier de récupération. Recherchez une solution de récupération du .part.met sur https://github.com/amule-org/amule/discussions."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Tous les fichiers .part ont été chargés."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Pas de fichiers .part trouvés"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u fichier .part trouvé"
 msgstr[1] "%u fichiers .part trouvés"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Le système de fichiers pour le répertoire Temp ne peut pas traiter des grands fichiers."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Le système de fichiers pour le répertoire Incoming ne peut pas traiter des grands fichiers."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Téléchargement de %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Vous êtes déjà en train de télécharger le fichier '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Vous avez déjà le fichier '%s' (demandé en tant que '%s')"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Vous avez déjà le fichier '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Vous êtes déjà en train de télécharger le fichier %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Impossible de convertir le lien magnet en eD2k : %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocole de lien inconnu : %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "Impossible d'ajouter %u lien (cf. le journal pour les détails)."
 msgstr[1] "Impossible d'ajouter %u liens (cf. le journal pour les détails)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Lien eD2k invalide ! ERREUR : %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Le client a envoyé un paquet après l'échec d'authentification."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Connexion externe fermée."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Les connexions externes sont désactivées car le mot de passe est vide !"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Les connexions externes sont désactivées dans le fichier de configuration"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nouvelle connexion externe acceptée"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERREUR : impossible d'accepter une nouvelle connexion externe"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connexion externe refusée car le mot de passe est vide dans les préférences !"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connexion au client : %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Version inconnue"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID de version de EC incorrecte, Il peut y avoir des incompatibilités entre les binaires. Utilisez un noyau et un client distant de la même version."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Vous ne pouvez pas connecter une version stable depuis une version de développement ! *pfff* un crash potentiel a été évité"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Version du protocole invalide."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "L'étiquette de la version du protocole est manquante."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authentification échouée : hachage spécifié comme mot de passe invalide."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Authentification échouée : mot de passe erroné."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Authentification échouée : mot de passe manquant."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Requête invalide, veuillez vous authentifier d'abord."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Accès autorisé."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Envoi du message d'erreur \"%s\" au client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative d'accès non autorisé de %s. Connexion fermée."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Échec de la commande du fichier .part à distance : hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hachage du fichier non trouvé : %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "ARGH ! Erreur de traitement de l'OpCode !"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Serveur non ajouté"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "serveur non trouvé : %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "il faut définir le serveur à supprimer"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Ami introuvable."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Client introuvable."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED nécessite EC_TAG_FRIEND ou bien EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Une recherche Web par une interface distante n'a aucun sens."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Recherche en cours. Résultats dans un moment !"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Pas de points pour le graphique."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Votre client n'est pas configuré pour ce niveau de détails."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Connexion externe : fermeture demandée"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Arrêt déjà en cours."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ConnExt : ajout du lien '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Échec de %d liens sur %d (invalides ou déjà sur la liste)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "Vérification d'une nouvelle version a été empêchée ; veuillez réessayer sous peu."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "La vérification de la version est indisponible sur ce démon."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Fichier non trouvé."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nom de fichier invalide."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Impossible de renommer le fichier."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad est désactivé dans les préférences."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Déjà connecté à eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Connexion à eD2k…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Déjà connecté à Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Connexion à Kad…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Tous les réseaux sont désactivés."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Déconnecté de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Déconnecté de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connexion externe : opcode reçu invalide : %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "opcode invalide (mauvaise version de protocole ?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extension '%s' inconnue pour la commande '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Commande '%s' inconnue\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2035,7 +1989,7 @@ msgstr ""
 "\n"
 "Cette commande ne prend pas d'argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2043,7 +1997,7 @@ msgstr ""
 "\n"
 "Cette commande nécessite un argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2051,7 +2005,7 @@ msgstr ""
 "\n"
 "Cette commande est incomplète, vous devez utiliser une des extensions ci-dessous.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2059,11 +2013,11 @@ msgstr ""
 "\n"
 "Extensions disponibles :\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Commandes disponibles :\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2074,17 +2028,17 @@ msgstr ""
 "Toutes les commandes sont insensibles à la casse.\n"
 "Tapez '%s <commande>' pour avoir des informations détaillées sur <commande>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Quitte l'application."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Montrer l'aide."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2092,7 +2046,7 @@ msgstr ""
 "Pour avoir de l'aide sur une commande, tapez 'help <commande>'.\n"
 "Pour avoir la liste complète des commandes, tapez 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2103,46 +2057,46 @@ msgstr ""
 "Utilisez '%s' pour la liste des commandes\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Erreur de syntaxe !"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Erreur durant le traitement de la commande - Cela ne devrait jamais arriver ! Rapportez le bogue, s'il vous plaît\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Cette commande ne devrait pas avoir de paramètres."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Cette commande nécessite un paramètre."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argument invalide."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Cette commande est incomplète."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Tapez '%s' pour avoir plus d'aide.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "C'est %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "C'est %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2150,7 +2104,7 @@ msgstr ""
 "\n"
 "Création du client en cours…\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2159,7 +2113,7 @@ msgstr ""
 "\n"
 "OK, fin de %s…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2173,331 +2127,326 @@ msgstr ""
 "\n"
 "Fin d'exécution…\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Montre ce texte d'aide."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Hôte où aMule tourne. (défaut : 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port d'aMule pour les connexions externes. (par défaut : 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Mot de passe pour les connexions externes."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Configuration lue depuis le fichier."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Ne pas afficher de sortie sur stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Mode bavard - montre aussi les messages de débogage."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Change la localisation du programme (langue)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Écrit les options de la ligne de commande dans le fichier de configuration."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Créé le fichier de configuration à partir du fichier de configuration d'aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Affiche la version du programme."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forcer la compression ZLIB quelle que soit l'adresse IP de destination (utile lorsque le serveur est accessible via un tunnel VPN qui se résout en une adresse IP du réseau local)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "Joindre une copie de toute la sortie de la console à ce fichier de journalisation (par défaut : <dossier-config>/amuleapi.log)."
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "Ne pas écrire un fichier de journalisation ; seulement afficher sur la console."
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Détails du fichier"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% effectué"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f Ko/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Bienvenue !"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Connexion au pote"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Type de la connexion :"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Réseaux"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Port TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP étendu (recherche Kad / globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activer UPnP pour la redirection de port du routeur"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Amorçage"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vous êtes déjà en train de télécharger le fichier %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "Lancer aMule automatiquement lorsque j'ouvre une session"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Enregistrer aMule pour les liens ed2k://"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Enregistrer aMule pour les liens magnet:"
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Dossier des fichiers de téléchargements temporaires"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour la lecture !"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour l'écriture !"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amis"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Afficher les &Détails"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Ajouter un ami"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Supprimer l'Ami"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Envoyer un &Message"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Voir les fichiers"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Établissement d'un Slot Ami"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Êtes-vous sûr de vouloir supprimer l'ami sélectionné ?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Êtes-vous sûr de vouloir supprimer les amis sélectionnés ?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2505,11 +2454,11 @@ msgstr ""
 "Vous n'êtes pas autorisé à établir plus d'un slot ami.\n"
 " Seul un slot a été attribué."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Sélection multiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2517,206 +2466,205 @@ msgstr ""
 "Vous n'êtes pas autorisé à établir plus d'un slot ami.\n"
 " Seul un slot a été attribué."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Envoyer un message à l'utilisateur"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Message à envoyer :"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Supprimer des amis"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Envoyer un message"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Échanger vers ce fichier"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En attente : %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Demander un autre fichier"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Attente d'un slot d'émission"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "En attente : %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Émission en cours"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Aucun"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Oui"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Téléchargement…"
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Téléchargement HTTP annulé"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "L'URL de téléchargement ne peut pas être vide"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Échec de la création de la requête HTTP pour %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Téléchargement HTTP : corps de réponse vide pour %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Impossible de déplacer le fichier téléchargé vers %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s téléchargé (%llu octets)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'URL %s a retourné : %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Échec du téléchargement HTTP pour %s : %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 non autorisé pour %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Le fichier GeoLite2-Country.mmdb existant a été migré vers %s"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2COuntry : MaxMind a été sélectionné en tant que source de GeoIP mais aucune clef de licence n'a été configurée. Ouvrez Préférences -> IP2Country, collez votre clef de licence MaxMind gratuit et cliquez sur « Mettre à jour maintenant »."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country : un lien (URL) personnalisé est sélectionné comme source de GeoIP, mais aucun lien n'est configuré. Ouvrez Préférences -> IP2Country et fournissez un lien qui pointe vers un mmdb (ou bien un .gz / .tar.gz qui en contiendrait un)."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country : échec de la résolution de'lURL de téléchargement GeoIP."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Télécharger un nouveau %s depuis %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Échec du téléchargement du fichier %s, annulation de la mise à jour."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Impossible de supprimer le fichier %s, abandon de la mise à jour."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Impossible de renommer le fichier %s, abandon de la mise à jour."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Mise à jour réussite de %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Erreur lors de la mise à jour de %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "Échec du téléchargement DB-IP pour le mois actuel - essai à nouveau avec l'URL du mois précédent."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Échec du téléchargement %s de %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Chargements des filtres IP 'ipfilter.dat' et 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Échec du chargement de fichier ipfilter.dat '%s', format inconnu."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Échec du chargement de fichier ipfilter.dat '%s', ne peut pas ouvrir le fichier."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u plage d'IP chargé depuis '%s'."
 msgstr[1] "%u plages d'IP chargés depuis '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u ligne mal-formée a été mise de côté."
 msgstr[1] "%u lignes mal-formées ont été mises de côté."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Impossible de renommer le nouveau fichier %s, abandon de la mise à jour."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP filter est prêt"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2724,860 +2672,828 @@ msgstr ""
 "Amorçage depuis\n"
 "les clients connus"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nœuds (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP invalide pour l'amorçage"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Port invalide pour l'amorçage"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Veuillez remplir tous les champs requis"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Message"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Êtes-vous sûr de vouloir télécharger un nouveau fichier nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Le faire supprimera les nœuds actuels et redémarrera la connexion à Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Continuer ?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia : le mot-clé recherché est trop court"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia : le mot-clé de la recherche est toujours dans la liste de recherche : "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Impossible de lire le fichier nodes.dat - trop vieux. Cette version (0) n'est plus supportée."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u contact Kad lu"
 msgstr[1] "%u contacts Kad lus"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Aucun contact trouvé, veuillez lancer l'amorçage, ou télécharger un fichier nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Seulement %d contact Kad disponible, nodes.dat non écrit"
 msgstr[1] "Seulement %d contacts Kad disponible, nodes.dat non écrit"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d contact Kad écrit"
 msgstr[1] "%d contacts Kad écrits"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Utilisateur Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : Kad n'est pas connecté"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : une recherche de note est déjà en cours d'exécution pour ce fichier"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : le fichier n'est pas dans la liste des partages, la file des téléchargements ou les résultats de recherche"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : une autre recherche Kad (par exemple une recherche de source) utilise déjà le hachage de ce fichier - veuillez réessayer sous peu"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "La recherche Kad pour '%s' n'a pu être démarrée : échec de PrepareLookup"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nom de fichier"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Taille du fichier"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Ratio de partage"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Demandé"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Accepté"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Sources complètes"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "AVERTISSEMENT : La liste de fichiers connus est corrompue, elle contient des entêtes invalides."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Échec du chargement de l'entrée dans la liste des fichiers connus, le fichier est peut être corrompu"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrée invalide dans la liste des fichiers connus, le fichier est peut être corrompu : "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Erreur inconnue %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Impossible d'obtenir la description d'erreur pour l'erreur %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hachage"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Finalisation"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Terminé"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "En pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroné"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "En attente"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Vous devez entrer un mot de passe non vide."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Mot de passe invalide, ce n'est pas un hachage MD5 !"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Erreur de connexion"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "Connexion externe perdue — fermeture du programme."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "La connexion EC a échoué. Réponse vide."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Connexion externe : Mauvaise réponse, échange raté. Connexion fermée."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Succès ! Connexion établie à aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Succès ! Connexion établie."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Connexion externe : accès refusé car : "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Connexion externe : Échange raté."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket : OK."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERREUR : Le port TCP n'a pas pu être mis en écoute."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERREUR : "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Fermer"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Couper"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copier"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Coller"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k : "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Connecté (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Connecté (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad : "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Connecté (derrière un pare-feu)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Serveur : "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "IP du serveur : "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Non connecté"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP : %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Port TCP : %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Port TCP : Non prêt"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Port UDP : %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Port UDP : Non prêt"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informations Client"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limite d'émission"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limite de téléchargement"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Afficher aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Cacher aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Quitter"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "Ko/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Pas de limite"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menu aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limites de vitesse :"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Émission : Aucune"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Émission : %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Réception : Aucune"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Réception : %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Vitesse de téléchargement : %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Vitesse d'émission : %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Pseudo : %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Aucun pseudo sélectionné !"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID Client : "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nom du serveur : "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP du serveur : "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Non connecté"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Signature En Ligne : Activée"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Signature En Ligne : Désactivée"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Temps de fonctionnement : %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Fichiers partagés : %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clients en attente : %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Reçu au total : %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Émis au total : %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "Coller des liens eD2k ou magnet ici"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "Ajouter des liens"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Cliquez ici pour ajouter le lien eD2k dans le contrôle de texte à votre file de téléchargement."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Les événements sont affichés ici. Pour une liste complète des évènements, reportez-vous à la fenêtre journal de l'onglet Serveur."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Chargement…"
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Nombre d'utilisateurs du serveur auquel vous êtes connecté…"
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Utilisateurs : 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Utilisateurs connectés au serveur actuel et une estimation du nombre total d'utilisateurs."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "E : 0.0 | R : 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Taux moyen d'émission et de réception actuelles. S'il est présent, le chiffre entre parenthèses indique la surcharge dût à la communication du client."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Affiche l'état de connexion et les transferts actifs. Des flèches rouges indiquent que vous n'êtes actuellement pas connecté, des flèches jaunes que vous êtes en LowID (pare-feu), et des flèches vertes que vous êtes en HighID (le type de connexion optimal)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Non connecté…"
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Serveur connecté."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Rechercher"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nom :"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Paramètres étendus"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrage"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Type de fichier"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Tous"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archives"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Images CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Images"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programmes"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Textes"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vidéos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extension"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Taille Minimum"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Octets"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "Ko"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "Mo"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "Go"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Taille Maximum"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtre :"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrer les résultats"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverser les résultats"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Masquer les fichiers connus"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Démarrer"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Plus"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Chaque clic interroge le pair le plus proche suivant pour obtenir plus de contacts (KADEMLIA_FIND_VALUE_MORE), faisant apparaître des correspondances de fichiers supplémentaires que la frontière alpha initiale de la recherche n'avait pas trouvées."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Arrêter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Réception"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Réinitialiser les Champs"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Résultats"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Effacer les téléchargements terminés"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Sources du fichier :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Général"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nom complet :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Fichier .met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hachage :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Taille du fichier :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfert"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Statut du fichier .part :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Vu complet pour la dernière fois :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Sources trouvées :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Sources en transfert :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Nombre de fichiers .part :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibles :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Taux de transfert :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Temps de téléchargement actif : "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transféré :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Taille reçue :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdus par corruption :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Gagné avec la compression :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paquets sauvés par l'I.C.H :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "Partage"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Demandes"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Demandes acceptées"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Données transférées"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Taux de partage"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Sources complètes"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "Partagé depuis"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "Dernier téléversement"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "Infos média"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Durée :"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Débit binaire :"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Codec :"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Artiste :"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titre :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Noms des fichiers"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Récupérer le nom"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Nettoyage"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Appliquer"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Commenter/Noter le fichier (Ce texte sera visible par tous les utilisateurs)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3585,570 +3501,568 @@ msgstr ""
 "Pour un film vous pouvez indiquer sa durée, l'histoire, la langue…\n"
 "et s'il s'agit d'un faux, vous pouvez prévenir les autres utilisateurs d'aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Qualité du fichier"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Non évalué"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Invalide / Corrompu / Contrefaçon"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Mauvais"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Assez bon"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bon"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excellent"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Choisissez une évaluation pour le fichier ou avertissez les autres utilisateurs qu'il est invalide…"
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "Obtenir depuis Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "En téléchargement, veuillez patienter…"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Taille inconnue"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informations Requises"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Adresse IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Renseignements complémentaires"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nom d'utilisateur :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Ajouter"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Moyenne de la session"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Vitesse d'émission"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Envois actifs"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistiques"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nom d'utilisateur :"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Logiciel client :"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Version du client :"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Adresse IP :"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID Utilisateur :"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP du serveur :"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nom du serveur :"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Brouillage :"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad :"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferts avec le client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Requête actuelle :"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Vitesse moyenne d'émission :"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Vitesse moyenne de réception :"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Envoyé (session) :"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Reçu (session) :"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Envoyé (total) :"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Reçu (total) :"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scores"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificateur R/E :"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identification sécurisée :"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Rang dans la file d'attente :"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Score de la file d'attente :"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Pseudo"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - La Mule multiplateforme"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Ceci est le nom que verront les autres utilisateurs lorsqu'ils se connecteront à vous."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Langue : "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Délai avant l'apparition des infobulles."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Ceci spécifie la langue utilisée dans les commandes."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Vérifier les nouvelles versions périodiquement"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Si vous activer ceci, aMule vérifiera si de nouvelles versions sont disponibles au démarrage et une fois par jour pendant son exécution"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Enregistre une entrée de lancement automatique auprès du système d'exploitation pour qu'aMule se lance à l'ouverture d'une session. Si vous déplacez le binaire d'aMule, lancez-le par la suite une fois manuellement pour que l'entrée soit actualisée."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Fait d'aMule le gestionnaire par défaut des liens ed2k:// pour qu'un clic sur un tel lien sur votre navigateur ou gestionnaire de fichiers l'ouvre ici."
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "aMule ne gère que les magnet compatibles avec eD2k (contenant xt=urn:ed2k:). Les magnet BitTorrent ne sont PAS pris en charge et un clic sur un tel lien échouera silencieusement. Si vous utilisez un client BitTorrent (Transmission, qBittorrent, etc.), laissez cela désactivé."
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Démarrer minimisé"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Activer ceci minimise immédiatement aMule lors de son lancement."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Confirmation en quittant"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Confirmation de fermeture d'aMule."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Activer l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Ceci Active/Désactive l'icône de barre des tâches."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Cacher la fenêtre de l'application lorsque le bouton Fermer est pressé"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Icône de réduction en zone de notification"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Activer ceci, va minimiser aMule dans la barre d'état système plutôt que dans la barre des tâches."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Afficher des notifications lorsque le téléchargement est terminé"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Si vous activez cette option, aMule affichera des notifications une fois le téléchargement terminé."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Délai d'affichage des info-bulles : "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "secondes"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Sélection du navigateur"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Ouvrir si possible dans un nouvel onglet"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Ouvrir, lorsque c'est possible, la page Web dans un nouvel onglet plutôt que dans une nouvelle page"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Lecteur vidéo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limites de la bande passante"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Attribution de slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ceci est le port eD2k standard et ne peut pas être activé."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pour les requêtes des serveurs (TCP+3) :"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ce port UDP est utilisé pour les requêtes eD2k étendues et pour le réseau Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port TCP UPnP (Facultatif) :"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Utilisateurs avancé uniquement : affecter tout le trafic d'aMule à une interface réseau unique, choisie depuis la liste ou bien par la saisie de son nom (par exemple tun0, eth0, en0) ou son index. Contrairement à la liaison à une adresse IP, cela empêche le trafic de fuiter par la route par défaut - utile avec un VPN. Ne nécessite pas de privilèges élevés."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Sources maximales par fichier téléchargé :"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Se connecter automatiquement au démarrage"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconnecter en cas de déconnexion"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Supprimer les serveurs inactifs après"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Les serveurs statiques ne sont jamais enlevés, même lorsqu'ils sont injoignables."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "essais"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Mise à jour de la liste des serveurs dès la connexion à un serveur"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Mise à jour de la liste des serveurs dès la connexion d'un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Utiliser le système de priorité"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Utiliser la vérification du LowID à la connexion"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Connexion sûre"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Se connecter automatiquement seulement sur les serveurs statiques"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Mettre les serveurs ajoutés manuellement en priorité haute"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Ajouter les fichiers à télécharger en mode Pause"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Ajouter les fichiers à télécharger en priorité automatique"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Essayer de télécharger la première et la dernière partie en premier"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Mode « endgame » : basculer vers les sources plus rapides pour les blocs finaux"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Démarrer le prochain fichier en pause lorsqu'un fichier se termine"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "De la même catégorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Dans l'ordre alphabétique"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Réserver de l'espace disque pour les nouveaux fichiers"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Réserve de l'espace du disque pour les nouveaux fichiers, réduisant ainsi la fragmentation"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppe les téléchargements lorsque l'espace disponible est atteint "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Sélectionnez ceci si vous souhaitez qu'aMule vérifie votre espace disque"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Entrez ici l'espace disque minimum désiré."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Sauver 10 sources pour les fichiers rares (< 20 sources)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Émission"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Ajouter les nouveaux fichiers partagés en priorité automatique"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Activer"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avancée se fie aux hachages (non recommandé)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "Extraction de métadonnées de média"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extraire la durée / le débit binaire / le codec depuis les fichiers audio et vidéo partagés"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Lorsque cette option est activée, aMule exécute ffprobe sur chaque fichier média partagé pour remplir les colonnes Durée / Débit binaire / Codec que les autres clients voient quand ils trouvent le fichier lors d'une recherche. Nécessite que ffmpeg (le binaire ffprobe) soit installé."
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "Emplacement de ffprobe :"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Chemin complet vers le binaire ffprobe. Laisser vide pour qu'aMule le détecte automatiquement au démarrage."
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "Détecter"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4156,684 +4070,682 @@ msgstr ""
 "Les téléchargements terminés sont stockés ici. Tous les fichiers de ce répertoire sont automatiquement partagés avec les autres pairs.\n"
 "Si ce répertoire contient également des fichiers que vous ne souhaitez pas partager, indiquez un sous-répertoire réservé à aMule."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Dossiers partagés"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Les répertoires partagés par le noyau. Entrer un chemin pour en ajouter un.)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Le chemin absolu d'un répertoire sur la machine du noyau, par exemple /home/utilisateur/shared"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "Récursif"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Partager chaque sous-répertoire sous celui-ci, y compris ceux qui seront créés ultérieurement."
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clic droit sur l'icône du répertoire pour un partage récursif)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Partager les fichiers cachés"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Analyser automatiquement à nouveau les répertoires partagés pour rechercher des modifications"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Suivre les liens symboliques dans les répertoires partagés"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "Exclure les fichiers correspondant à :"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Motifs de caractères génériques séparés par '|', par exemple .DS_Store|Thumbs.db|*.tmp. Les fichiers dont le nom correspond ne seront pas partagés. La correspondance est insensible à la casse."
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "Les motifs sont des expressions régulières"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Lorsque l'option est activée, la totalité du champ est une expression régulière ('|' indique une alternative). Lorsque l'option est désactivée, il s'agit d'une liste de caractères génériques séparés par des '|'."
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Délais de rafraîchissement : 5 s"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Temps pour la courbe de la moyenne : 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Échelle du graphique des connexions : 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Échelle des graphiques de réception :"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Couleurs : "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fond"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Quadrillage"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Téléchargement actuel"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Téléchargement moyen total"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Téléchargement moyen sur la session"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Envoi actuel"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Envoi moyen total"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Connexions actives"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nœuds Kad actuels"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nœuds Kad total"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Arbre"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Nombre de versions client affichées (0=illimité)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! AVERTISSEMENT !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Nombre maximum de nouvelles connexions / 5 secs"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "Recherche concurrentes de sources Kad"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalle entre les nouvelles recherches de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalle entre les nouvelles demandes de sources Kad (en minutes)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Taille du fichier de tampon : 240000 octets"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Utiliser MMAP : « memory-mapped file access », c'est-à-dire accès aux fichiers mappés dans la mémoire (utilise moins de mémoire)"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Fait correspondre les fichiers partiels dans la mémoire au lieu de les mettre en tampon sur la pile, baissant l'empreinte mémoire du processus. Peut réduire la vitesse de téléchargement sur certains disques ; idéal pour les hôtes disposant de peu de mémoire ou pour ceux qui téléversent beaucoup."
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Taille de la file d'attente d'envoi : 5000 clients"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Désactiver la mise en veille programmé de l'ordinateur"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Thème à utiliser : "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Afficher le \"Gestionnaire rapide de liens eD2k \" dans chaque fenêtre."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Afficher des infos supplémentaires sur les onglets des catégories"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Afficher la version de l'application dans le titre"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Afficher les taux de transfert dans la barre de titre"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Avant le nom de l'application"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Après le nom de l'application"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Afficher la surcharge de la bande passante"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientation de la barre d'outils verticale"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Tri des colonnes en temps réel (réorganisation automatique des lignes à mesure que leurs valeurs changent)"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Fichiers à télécharger en file d'attente"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Afficher le pourcentage de progression"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Interdire l'accès invité"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Mot de passe invité pour le serveur web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "Démarrer le serveur web au démarrage (obsolète)"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4845,11 +4757,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4865,11 +4777,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4879,504 +4791,504 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Désactivé [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "octet"
 msgstr[1] "octets"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "ko"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "To"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "octet/sec"
 msgstr[1] "octets/sec"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "Mo/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "s"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "heures"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "jours"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "tous"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "tous les autres"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incomplet"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Arrêté"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vidéo"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archive"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Texte"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Actif"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Utilisation du répertoire de config : %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Attente de la mort du processus de conversion du fichier .part…"
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importation %s : %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lecture du répertoire temporaire"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Récupération des informations de base depuis le téléchargement dans un fichier"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Création du fichier de destination"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Chargement des données depuis un ancien fichier de téléchargement (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Sauvegarde du bloc de données dans un nouveau fichier de téléchargement unique (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Récupérations des informations du fichier de téléchargement source"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Ajout du téléchargement et sauvegarde du nouveau fichier .part"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importer les fichiers .part"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "État"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hachage du fichier"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disque : %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Choisissez un dossier où chercher les téléchargements temporaires ! (les sous-dossiers seront inclus)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Voulez-vous que les fichiers sources d'une importation de téléchargement réussie soient supprimées ?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Supprimer les sources ?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "Erreur : Impossible de créer le fichier .part"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Tentative de chargement de la sauvegarde du fichier met depuis %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERREUR : Échec de l'ouverture du fichier part.met : %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERREUR : Le fichier part.met est de taille nulle : %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERREUR : Version du fichier part.met invalide : %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Erreur : %s (%s) est corrompu (mauvaises étiquettes : %s), impossible de charger le fichier."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERREUR : %s (%s) est corrompue (tagcount erroné), impossible de charger le fichier."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Tentative de récupération des infos du fichier…"
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Récupération du fichier anonyme - Essai de récupération sous le nom RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Récupération de toutes les infos du fichier :D - Essayons de les utiliser…"
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Impossible de récupérer les infos du fichier :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Échec de l'ouverture de %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVERTISSEMENT : %s a pu être corrompu (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERREUR lors de la sauvegarde du fichier .part : %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Erreur d'E/S lors de la sauvegarde du fichier .part : "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "0/inconnu octet écrit sur « %s » -- le fichier .part.met existant sera préservé."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Échec de la sauvegarde du fichier part.met.seeds pour %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i source seed sauvegardé pour le fichier .part : %s (%s)"
 msgstr[1] "%i source seeds sauvegardés pour le fichier .part : %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Impossible de lire le fichier seeds pour le fichier partiel %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erreur lors de la lecture du fichier seeds du fichier .part (%s - %s) : %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Une partie corrompue trouvée (%d) dans %d parties du fichier %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Une partie corrompue trouvée (%d) dans %d partie du .part %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Partie complète (%i) trouvée dans %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Ré-hachage de %s terminé"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erreur inattendue lors de la finalisation de %s. Fichier mis en pause"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Téléchargement terminé : %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5385,306 +5297,306 @@ msgstr ""
 "Téléchargement suivant terminé :\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Fichier supprimé : %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVERTISSEMENT : Impossible de calculer le hachage de la partie téléchargée. Ensemble de hachage incomplet pour '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERREUR : Impossible de calculer le hachage de la partie téléchargée - Ensemble de hachage incomplet pour (%s). Ceci ne devrait jamais arriver"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "La partie %u de «%s » est marqué comme complétée mais le fichier partiel est plus petit qu'attendu (possède %llu octets, nécessite %llu octets) ; réouverture de la fenêtre de téléchargement."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF lors du hachage du fichier .part téléchargé %u avec une longueur %u (max %u) du fichier .part '%s' avec une longueur %u : %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVERTISSEMENT : Pas assez d'espace disque disponible ! Mise en pause du fichier : %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "La partie téléchargée %i est corrompue dans le fichier : %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH : Partie corrompue %i récupérée pour %s -> Octets sauvés : %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "En cours d'allocation"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espace disque insuffisant"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Téléchargé"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "Letton"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Connexion"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Répertoires"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Sécurité"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Contrôles à distance"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Signature en ligne"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avancé"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Événements"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Débogage"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5694,15 +5606,15 @@ msgstr ""
 "    %PARTFILE - chemin complet vers le fichier\n"
 "    %PARTNAME - nom du fichier seulement"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "L'icône de la barre système nécessite libayatana-appindicator3 au moment de la compilation."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponible sous Wayland : le protocole n'informe pas lorsqu'une fenêtre est minimisée, cette option ne peut donc intercepter le bouton de minimisation du système. Solution de contournement : lancez aMule avec `GDK_BACKEND=x11` pour utiliser XWayland à la place."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5718,35 +5630,35 @@ msgstr ""
 "aMule fonctionnera bien en ne modifiant pas\n"
 "ces réglages."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Échec à la connexion de Cfg au widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis Cfg vers le widget avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Type de proxy auquel vous êtes connecté"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Échec du transfert de données depuis le widget vers Cfg avec l'ID %d et la clé %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Mot de passe administrateur"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5754,39 +5666,39 @@ msgstr ""
 "aMule doit être redémarré pour activer ces changements : \n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Port TCP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Port UDP changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- La liaison de Interface réseau modifiée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Port de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Consentement de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de connexion externe changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Support du brouillage de protocole changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- les réglages amuleapi modifiés.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5794,7 +5706,7 @@ msgstr ""
 "Votre liste de serveur pour la mise à jour automatique est vide.\n"
 "'Mise à jour automatique au démarrage de la liste des serveurs' va être désactivée."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5802,32 +5714,32 @@ msgstr ""
 "Vous avez activé les connexions externes mais vous n'avez pas spécifié de mot de passe valide.\n"
 "Les connexions externes ne pourront pas être activées tant qu'un mot de passe valide n'est pas spécifié."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Langue changée.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Dossier temporaire changé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Réseau ED2K activé.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Le motif d'exclusion de fichiers partagés n'est pas une expression régulière valide. Le filtre a été laissé désactivé."
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5835,7 +5747,7 @@ msgstr ""
 "Les réseaux eD2k et Kad sont désactivés.\n"
 "Vous ne pourrez pas vous connecter tant que vous n'activerez pas au moins l'un des deux."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5843,7 +5755,7 @@ msgstr ""
 "Kad ne démarrera pas si votre port UDP est désactivé.\n"
 "Activez le port UDP ou désactivez Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5853,68 +5765,68 @@ msgstr ""
 "Vous DEVEZ redémarrer aMule maintenant.\n"
 "Si vous ne le faites pas, ne vous plaignez pas si des bogues surviennent.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule pour un lancement automatique à l'ouverture d'une session. Le dépôt de lancement automatique est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Échec de l'effacement de l'entrée du lancement automatique à l'ouverture d'une session."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Lancement automatique"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "Enregistrer le gestionnaire d'URL"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule ne gère que les magnet compatibles avec eD2k. Si vous remplacez le gestionnaire de magnet actuel (%s), les liens magnet BitTorrent cesseront de fonctionner - aMule ne peut télécharger du contenu BitTorrent. Continuer ?"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Une autre application gère les liens (%s) par défaut. La remplacer par aMule ?"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Échec de l'enregistrement d'aMule en tant que gestionnaire des URL. Le dépôt d'enregistrement est peut-être en lecture seule."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "Impossible de supprimer l'enregistrement du gestionnaire d'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Le serveur web et aMule API nécessitent l'activation des connexions externes."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Le serveur web d'aMule est obsolète. Envisagez d'utiliser aMule API à sa place."
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5924,64 +5836,64 @@ msgstr ""
 "Entrez s'il vous plaît au moins une URL qui pointe sur un fichier server.met valide.\n"
 "Cliquez sur le bouton \"Liste\" à coté de cette case pour entrer une URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Fichiers temporaires"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Fichiers réceptionnés"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Signatures En Ligne"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Choisir un dossier pour %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Exclurait %u fichier sur %u fichier partagé"
 msgstr[1] "Exclurait %u fichiers sur %u fichiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Chercher un lecteur vidéo"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Choisir un navigateur"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "Sélectionner le binaire ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Exécutable%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe n'a pas été trouvé sur PATH ou dans les emplacement standards d'installation. Installez ffmpeg (qui fournit ffprobe) ou bien utilisez Parcourir pour choisir un binaire manuellement."
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "Réinitialiser les réglages sur cette page à leurs valeurs par défaut ?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "Réinitialiser aux valeurs par défaut"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Éditer la liste des serveurs"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5989,114 +5901,114 @@ msgstr ""
 "Ajoutez ci-dessous des URL pour télécharger des fichiers server.met.\n"
 "Seulement une URL par ligne."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "Échec de la mise à jour IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "Données fournies par MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "Source personnalisée"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "Données fournies par DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "État : %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "État : %s - %s chargé"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "État : échec du chargement - cliquez sur « Mettre à jour maintenant » pour actualiser."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "État : introuvable - cliquez sur « Mettre à jour maintenant » pour télécharger."
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Délais de rafraîchissement : %d seconde"
 msgstr[1] "Délais de rafraîchissement : %d secondes"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Temps pour le graphe des moyennes : %d minute"
 msgstr[1] "Temps pour le graphe des moyennes : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Échelle du graphique des connexions : %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Taille du tampon de fichiers : %d octet"
 msgstr[1] "Taille du tampon de fichiers : %d octets"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Taille de la fille d'attente d'émission : %d client"
 msgstr[1] "Taille de la fille d'attente d'émission : %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalle de rafraîchissement de la connexion serveur : %d minute"
 msgstr[1] "Intervalle de rafraîchissement de la connexion serveur : %d minutes"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalle de rafraîchissement de la connexion serveur : Désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "désactivé"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exécuter la commande lors de l'événement '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Activer l'exécution de la commande sur le noyau"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Commande du noyau :"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Activer l'exécution de la commande sur l'interface graphique"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Commande de l'interface graphique :"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Les variables suivantes seront remplacées :"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6104,1082 +6016,1081 @@ msgstr ""
 "Les répertoires suivants semblent être des répertoires système ou des emplacements sensibles.\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Les partager récursivement publiera chaque fichier contenu dans les sous répertoires sur les réseaux eD2k/Kad. Êtes-vous sûr de vouloir faire cela ?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Analyse des sous-répertoires…"
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Mise à jour des dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u répertoires analysés…"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Dossier partagé"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erreur de recherche"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La taille minimum doit être inférieur à la taille maximum. Taille maximum ignorée."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Avertissement dans la recherche"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "La recherche eD2k ne peut être établie si eD2k n'est pas connecté"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Pas de mot-clé pour la recherche Kad - abandon"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erreur imprévue lors de la tentative de recherche Kad : "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Recherche Kad : résultats étendus demandés à un pair supplémentaire."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Recherche Kad : plus aucun pair à recontacter pour plus de résultats (limite atteinte ou aucune réponse pour l'instant)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID du fichier"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Durée"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Débit binaire"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Télécharger dans la catégorie"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtenir %s pour ce fichier"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Chercher les fichiers liés (eD2k, serveur local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marquer comme fichier connu"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copier le lien eD2k dans le presse-papiers"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Vous n'êtes actuellement pas connecté à un serveur prenant en charge la fonction de recherche de fichiers associés"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Annulé"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nouveau"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Échec de la connexion à tous les serveurs statiques brouillés listés. Nouvel essai sans brouillage."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Échec de la connexion aux serveurs brouillés listés. Nouvel essai sans brouillage."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Échec de la connexion à tous les serveurs statiques listés. Nouvel essai."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Échec de la connexion aux serveurs listés. Nouvel essai."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Le réseau e2Dk est désactivé dans les préférences, pas de connexion."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Aucun serveur valide auquel se connecter n'a été trouvé dans la liste des serveurs"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Connecté à %s (%s : %i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Connexion établie sur : %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Erreur fatale lors de la tentative de connexion. La connexion Internet est probablement coupée"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Connexion à %s (%s : %i) perdue"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) semble être indisponible."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s : %i) semble être plein."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Nouvelle tentative de connexion automatique au serveur dans %d seconde"
 msgstr[1] "Nouvelle tentative de connexion automatique au serveur dans %d secondes"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Échec de la connexion à %s (%s : %i)."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERREUR : Socket invalide lors de la vérification du délai"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Délai d'attente de la connexion à %s (%s : %i) dépassé."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Réception d'un résultat DNS en retard, on jette."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Chargement du fichier server.met : %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Le fichier server.net est introuvable !"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Échec du chargement de fichier server.met '%s', format inconnu."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Échec de l'ouverture du fichier server.met !"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Le fichier server.met est corrompu, une étiquette invalide de version invalide à été trouvé : 0x%x, taille %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i serveur trouvé dans server.met"
 msgstr[1] "%i serveurs trouvés dans server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d serveur ajouté"
 msgstr[1] "%d serveurs ajoutés"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Erreur : le fichier 'server.met' est corrompu : "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Erreur d'E/S lors de la lecture de 'server.met' : "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serveur non ajouté : [%s : %d] n'a pas un port valide."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serveur non ajouté : l'IP de [%s : %d] a été filtrée ou est invalide."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serveur non ajouté : un serveur avec une IP : Port [%s : %d] correspondant a été trouvée dans la liste."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Serveur ajouté : serveur à [%s : %d] utilisant le nom '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Vous êtes connecté au serveur que vous tentez de supprimer. Déconnectez-vous d'abord s'il vous plaît."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Échec de l'ouverture de '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Échec de l'enregistrement de server.met !"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL invalide"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Téléchargement terminé de la liste de serveur depuis %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Aucune entrée trouvée d'adresses de liste de serveurs dans 'addresses.dat'. Veuillez coller une liste de serveurs valide dans ce fichier afin de mettre à jour automatiquement votre liste de serveurs"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Démarre le téléchargement de la liste de serveur depuis %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "AVERTISSEMENT : URL invalide indiquée pour la mise à jour automatique des serveurs : %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Pas d'URL valide pour la mise à jour automatique des serveurs dans adresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Échec du téléchargement de la liste des serveurs depuis %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Le serveur local est filtré par les filtres IP, reconnexion à un autre serveur !"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom du serveur"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresse"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Description"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Temps de réponse"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statique"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "Indicateurs TCP"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "Indicateurs UDP"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Vous êtes connecté au serveur que vous tentez de supprimer. Déconnectez-vous d'abord s'il vous plaît . Le serveur n'a PAS été supprimé."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nom inconnu)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Êtes-vous sûr de vouloir supprimer le serveur statique %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serveurs (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Serveur"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connexion au serveur"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marquer le serveur comme statique"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marquer le serveur comme non statique"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marquer les serveurs comme statiques"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marquer les serveurs comme non statiques"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Supprimer le serveur"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Supprimer les serveurs"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Supprimer tous les serveurs"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copier les liens eD2k dans le presse-papiers"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconnexion au serveur"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Êtes-vous sûr de vouloir supprimer tous les serveurs ?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Êtes-vous sûr de vouloir supprimer le serveur sélectionné ?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Êtes-vous sûr de vouloir supprimer les serveurs sélectionnés ?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERREUR : %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVERTISSEMENT : %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "Le serveur %s (%s) a rejeté notre identifiant (aucune identité de client attribuée). Déconnexion."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Nouvel ID client : %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVERTISSEMENT : Vous avez reçu un Low-ID !"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tLa raison la plus probable est que vous êtes derrière un pare-feu ou un routeur."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPour plus d'informations, consultez https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Info serveur inconnue reçue ! - trop court"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d nouveau serveur reçu"
 msgstr[1] "%d nouveaux serveurs reçus"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Sauvegarde de la liste des serveurs terminée."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Le serveur a rejeté la dernière commande"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Faux paquet reçu depuis le serveur : %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Erreur non-prise en compte lors du traitement du paquet reçu du serveur : %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Ne peut créer de processus pour la résolution DNS pour se connecter à %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "L'IP du serveur %s (%s) est filtrée. Pas de connexion."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "utilisation du brouillage de protocole."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Connexion à %s (%s - %s : %i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Ne peut résoudre le nom DNS pour le serveur %s : Impossible de se connecter !"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "Journal d'aMuleGUI"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serveur non ajouté : Pas d'IP ni de nom d'hôte donné."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serveur non ajouté : Port du serveur invalide."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "État eD2k :"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Type de la connexion :"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Connecté"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Statut de Kademlia :"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Exécution en mode LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "En marche"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID du client Kademlia :"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Statut :"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "État de la connexion :"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Derrière un pare-feu - Ouvrez le port TCP %d sur votre routeur ou pare-feu"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "État de la connexion UDP :"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Derrière un pare-feu - Ouvrez le port UDP %d sur votre routeur ou pare-feu"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "État du pare-feu : "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Pas de pote requis - port TCP ouvert"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Pas de pote requis - port UDP ouvert"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Pas de pote"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Connexion au pote"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connecté au pote à %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Sources indexées :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Mots clés indexés :"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notes indexées :"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Charge indexée :"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Nombre moyen d'utilisateurs :"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Nombre moyen de fichiers :"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "À l'arrêt"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Ajout du fichier %s aux partages"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i fichier partagé connu trouvé"
 msgstr[1] "%i fichiers partagés connus trouvés"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i fichier partagé connu trouvé, %i inconnu"
 msgstr[1] "%i fichiers partagés connus trouvés, %i inconnus"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "%i fichier exclu du partage par le filtre"
 msgstr[1] "%i fichiers exclus du partage par le filtre"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERREUR : Tentative de partage %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Répertoire partagé non trouvé, on passe : %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nom d'Utilisateur"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Vitesse de Réception"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Vitesse d'Émission"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Parties Disponibles"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "État de l'émission"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "État de la réception"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nom du fichier local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Partage de la liste des fichiers"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Parties obtenues"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Chemin du répertoire"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Ajouter un Commentaire/Note"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Éditer un Commentaire/Note"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Renommer"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "Vérifier les données locales"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Ajouter des fichiers de la collection à la liste de transferts"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copier le &lien magnet dans le presse-papiers"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copier le lien eD2k dans le presse-papiers (&Source)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copier le lien eD2k dans le presse-papiers (Source) (Avec &options de chiffrage)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copier le lien eD2k dans le presse-papiers (Nom d'&hôte)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copier le lien eD2k dans le presse-papiers (Nom d'hôte) (Avec options de &chiffrage)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copier le lien eD2k dans le presse-papiers (Info &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copier le lien eD2k dans le presse-papiers (Info &AICH + Source)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "La vérification des données locles sur PartFile n'est actuellement pas prise en charge : %s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Vous devez être en HighID pour créer un lien valide"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom du fichier à distance"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Données Émises (Session (Total)) : %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Surcharge Totale (Paquets) : %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Surcharge Requête Fichier (Paquets) : %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Surcharge Échange de Source (Paquets) : %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Surcharge Serveur (Paquets) : %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Surcharge Kad (Paquets) : %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Surcharge Crypt (UDP) : %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Envois Actifs : %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Envois en Attente : %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Sessions d'envois réussies au total : %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Sessions d'envois qui ont échoué au total : %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Temps d'envois moyen : %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Données Reçues (Session (Total)) : %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Sources Trouvées : %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Téléchargements Actifs (parties) : %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Rapport UL : DL pour la Session (Total) : %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Vitesse moyenne de réception (Session) : %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Vitesse moyenne d'envoi (Session) : %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Vitesse maximale de réception (Session) : %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Vitesse maximale d'émission (Session) : %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconnexions : %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Temps depuis le premier transfert : %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Connecté au serveur depuis : %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Connexions actives (estimation) : %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Limite max de connexion atteinte : %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Moyenne de connexions (estimation) : %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pics de connexions (estimation) : %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clients"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Inconnu : %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtré : %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Banni : %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total : %i Connus : %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Serveurs en fonctionnement : %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Serveurs non-connectés : %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total : %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Serveurs supprimés : %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Serveurs filtrés : %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Utilisateurs sur les serveurs en fonctionnement : %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Fichiers sur les serveurs en fonctionnement : %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Total des utilisateurs : %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Total des fichiers : %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Occupation du Serveur : %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Nombre de Fichiers Partagés : %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Taille totale des Fichiers Partagés : %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Taille moyenne des fichiers : %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Système d'Exploitation"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Non reçu"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Connexions actives (1 : %u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Non disponible"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Jamais"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "La commande '%s' avec le PID '%d' s'est terminée avec le code '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Exécute <str> et quitte."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Format d'IP invalide. Utiliser xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Cette commande nécessite un argument. Arguments valides : 'all', nom de fichier ou un nombre.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Traitement par hachage : "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Traitement par nom de fichier : "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Cette commande nécessite un argument. Arguments valides : un hachage de fichier.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Nombre invalide\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Ce n'est pas un hachage valide (la longueur devrait être exactement 32 caractères)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7189,7 +7100,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7199,7 +7110,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7207,82 +7118,80 @@ msgstr ""
 "Aucun type de recherche défini.\n"
 "Tapez « help search » pour obtenir davantage d'aide.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Télécharger le fichier : %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "La requête a échoué avec une erreur inconnue."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "L'opération s'est déroulée avec succès."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "La requête a échoué avec l'erreur suivante : %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Statut du filtrage IP pour les clients : %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Arrêt"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Marche"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Le filtrage IP pour les serveurs est %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Le niveau actuel d'IPFilter est %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limites de la bande passante : E : %u ko/s, R : %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "La rotation de sources pour « endgame » est %s.\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Recherche démarrée (id %u).\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Connecté à %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Connexion en cours"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "derrière un pare-feu"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7291,7 +7200,7 @@ msgstr ""
 "\n"
 "Réception : \t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7300,7 +7209,7 @@ msgstr ""
 "\n"
 "Émission : \t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7309,7 +7218,7 @@ msgstr ""
 "\n"
 "Clients dans la file d'attente : \t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7318,46 +7227,46 @@ msgstr ""
 "\n"
 "Nombre total de sources : \t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Fichier .part]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "Recherche expirée ou ID inconnue. Démarrez une nouvelle recherche.\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Nombres de résultats de la recherche : %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "État d'avancement de la recherche : %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progrès de la recherche indisponibles"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Réponse inconnue reçue du serveur, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Montrer de courtes informations sur le statut."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Montrer le statut de la connexion, vitesses d'émission/réception, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Montrer l'arbre des statistiques complet."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7371,11 +7280,11 @@ msgstr ""
 "\n"
 "Exemple : 'statistics 5' montrera seulement les 5 premières versions pour chaque type de client.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Fermer aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7385,35 +7294,35 @@ msgstr ""
 "Ceci coupera aussi le client texte, puisqu'il est\n"
 "inutilisable sans noyau actif.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recharge l'objet donné."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recharge la liste des fichiers partagés."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recharge la table de filtrage d'IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Recharge la table actuelle de filtrage d'IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Mise à jour de la table de filtrage d'IP depuis l'URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Si l'URL est omise l'URL des préférences est utilisée."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Se connecter au réseau."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7425,35 +7334,35 @@ msgstr ""
 "seulement à ce serveur. L'IP doit être une IPv4 décimal,\n"
 "ou un nom DNS pouvant être résolu."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Se connecter à eD2k uniquement."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Se connecter à Kad uniquement."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Se déconnecter du réseau."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Ceci vous déconnectera de tous les réseaux auxquels vous êtes actuellement connecté.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Se déconnecter de eD2k uniquement."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Se déconnecter de Kad uniquement."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Ajoute un lien eD2k ou magnet au noyau."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7471,51 +7380,51 @@ msgstr ""
 "\n"
 "Le lien magnet devra contenir le hachage eD2k et la taille du fichier.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Définir une valeur de préférence."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Définir les préférences de filtrage d'IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activer le filtrage IP pour les clients et les serveurs."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Désactiver le filtrage IP pour les clients et les serveurs."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activer/Désactiver le filtrage IP pour les clients."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activer le filtrage IP pour les clients."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Désactiver le filtrage IP pour les clients."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activer/Désactiver le filtrage IP pour les serveurs."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activer le filtrage IP pour les serveurs."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Désactiver le filtrage IP pour les serveurs."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Choisir le niveau de filtrage IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7523,71 +7432,71 @@ msgstr ""
 "Les niveaux de filtrage valides sont compris entre 0 et 255, la valeur par défaut (initiale)\n"
 "est 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Définir les limites de bande passante."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "La valeur passée à ces commandes doit être en kilo-octets/s.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Définir la limite de bande passante en émission."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "La valeur en question doit être en kilo-octets/s.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Définir la limite de bande passante en réception."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "Activer ou désactiver la rotation de sources pour « endgame »."
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "La valeur donnée doit être 1/ON (activer) ou bien 0/OFF (désactiver).\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obtenir et afficher une valeur de préférence."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obtenir les préférences de filtrage IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obtenir le statut du filtrage d'IP pour les clients et les serveurs."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obtenir le statut du filtrage d'IP pour les clients seulement."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obtenir le statut du filtrage d'IP pour les serveurs seulement."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Obtenir le niveau de filtrage IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obtenir les limites de bande passante."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "Obtenir l'état de rotation de sources « endgame »."
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Effectuer une recherche."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7621,23 +7530,23 @@ msgstr ""
 "Exemple : 'search global linux iso --type Iso --min-size 100M' retourne\n"
 "des résultats pour le type de fichier Iso d'au moins 100 Mio pour « linux iso ».\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Effectuer une recherche globale."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Effectuer une recherche locale"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Effectuer une recherche Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "Montrer les résultats d'une recherche."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7645,11 +7554,11 @@ msgstr ""
 "Retourner les résultats d'une recherche.\n"
 "Accepte éventuellement un identifiant de recherche (issu de 'search …') ; en l'absence d'identifiant, renvoie les résultats de la recherche lancée le plus récemment.\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Affiche la progression de la recherche."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7657,11 +7566,11 @@ msgstr ""
 "Afficher la progression d'une recherche.\n"
 "Prend éventuellement un identifiant ; sans identifiant, affiche la progression de la recherche lancée le plus récemment.\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Démarrer le téléchargement d'un fichier"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7669,80 +7578,80 @@ msgstr ""
 "Le rang du fichier de la dernière recherche doit être donné.\n"
 "Exemple : 'download 12' va télécharger le douzième fichier de la précédente recherche.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Mettre le téléchargement en pause."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Reprendre le téléchargement."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Annuler le téléchargement."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Régler la priorité de téléchargement."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Passer la priorité d'un téléchargement en Basse, Normale, Haute, ou Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Passer en priorité basse."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Passer en priorité normale."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Passer en priorité haute."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Passer en priorité auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Montrer les files d'attente/listes."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Montrer la file d'attente des envois/réceptions, la liste des serveurs ou la liste des fichiers partagés.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Montrer la file d'attente des envois."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Montrer la file d'attente des réceptions."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Montrer le journal."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Montrer la liste des serveurs."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Afficher la liste des fichiers partagés."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Effacer le journal."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Commande obsolète, utilisez '%s' à la place."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7751,261 +7660,258 @@ msgstr ""
 "C'est une commande est obsolète, et pourrait être supprimée dans le futur.\n"
 "Utilisez '%s' à la place.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "client texte aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversion des anciens hashsets AICH en '%s' vers 64b en '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "Vérification des données locales (%s) : résultat OK pour %s"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "Vérification des données locales (%s) : ERREURS TROUVÉES ! %s Blocs défaillants : MD4 : %s. %s%s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVERTISSEMENT : Le nom de fichier '%s' est invalide et a été renommé en '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVERTISSEMENT : Le fichier '%s' existe déjà, le nouveau fichier a été renommé en '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Êtes-vous sûre de vouloir annuler et supprimer tous les fichiers de cette catégorie ?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Confirmation requise"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Seulement 99 catégories sont prises en charge."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Trop de catégories !"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Tous les autres"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Sélectionner un filtre"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Ajouter une catégorie"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Éditer une catégorie"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Supprimer une catégorie"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Requête d'un hashset pour le fichier inconnu : %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Reprise des envois du fichier : %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Pause des envois du fichier : %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Échec de l'exécution de la commande `%s' lors de l'événement `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Téléchargement terminé"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Le chemin complet vers le fichier."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Le nom du fichier sans la partie répertoire."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Le hachage eD2k du fichier."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "La taille du fichier en octets."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Durée d'activité de téléchargement cumulée."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nouvelle session de chat démarrée"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Expéditeur du message."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Espace insuffisant"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partition du disque."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Erreur à la complétion"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Traitement du fichier numéro %u : %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Vous avez demandé les hachages partiels (Seulement utilisés pour des fichiers dont les tailles sont > 9.5 Mo)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fichier inexistant !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, le créateur de liens d'aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Bienvenue !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Paramètres d'entrée"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fichier à hacher"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Ajouter des URLs optionnelles pour ce fichier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Indiquez ici le fichier pour qui vous voulez calculer le lien eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Indiquez ici l'URL que vous voulez ajouter au lien eD2k : Ajoutez / à la fin pour indiquer à aLinkCreator d'ajouter le nom du fichier actuel"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Créer le lien avec les hachages partiels"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Aide à retrouver les fichiers rares et nouveaux au prix d'un lien de plus grande longueur"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hachage MD4 du fichier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Hachage eD2k du fichier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Lien eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse-papiers"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Ouvrir un fichier pour calculer son lien eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copie du lien eD2k calculé dans le presse-papiers"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Enregistrer sous"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Conversion du lien eD2k calculé en fichier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "À propos d'aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Sélectionnez le fichier auquel vous souhaitez calculer le lien eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Impossible d'ouvrir le presse-papiers"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Rien à copier pour l'instant !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Sélectionnez le fichier vers votre lien eD2k calculé"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Impossible d'ouvrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Veuillez entrer un nom de fichier non vide"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Rien à sauvegarder pour l'instant !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8025,167 +7931,159 @@ msgstr ""
 "\n"
 "Distribué sous licence GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hachage en cours…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator fonctionne pour vous"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calcul du hachage MD4…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calcul des hachages eD2k…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Annulé !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Effectué en %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Vous avez déjà ajouté cette URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Entrez une URL non vide s'il vous plaît"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Impossible d'ouvrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Dépassement de mémoire lors du calcul du hachage eD2k !"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i jour(s) %i heure(s) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02u J %02u h %02u min %02u s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02u h %02u min %02u s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02u min %02u s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02u La session a expirées"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f o"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f Ko"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f Mo"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f Go"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f To"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, statistiques en ligne d'aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Vitesse de réception Max atteinte depuis de démarrage de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Vitesse de réception Max atteinte lors des précédentes exécutions de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Système"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Arrêter le rafraîchissement automatique"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Sauvegarder l'image des statistiques en ligne"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimer une image des statistiques en ligne"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Préférences"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "À propos de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Démarrer le rafraîchissement automatique"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Rafraîchissement automatique stoppé"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Rafraîchissement automatique démarré"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Sauvegarder l'image des statistiques en ligne"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Statistiques en ligne d'aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8193,11 +8091,11 @@ msgstr ""
 "L'impression a rencontré un problème.\n"
 "Peut-être votre imprimante n'est-elle pas configurée correctement ?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Impression en cours"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8215,375 +8113,364 @@ msgstr ""
 "\n"
 "Distribué sous licence GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule n'est pas lancé…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule fonctionne"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule est lancé, mais est déconnecté"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule se connecte…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, l'état d'aMule est inconnu…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " tourne depuis "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " est arrêté !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " n'est pas connecté !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " se connecte…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " est en train de faire des trucs bizarres, à vérifier !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " est connecté à "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "éteint"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " est sur "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " avec "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Réception totale : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Émission : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Réception durant la session : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Réception : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " Ko/s, Émission : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Partage : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fichier(s), clients en attente : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Temps : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " sur "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Charge moyenne du système (1-5-15 min) : "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Le système fonctionne depuis : "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Répertoire contenant le fichier amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Entrer ici le répertoire contenant le fichier amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervalle de rafraîchissement en secondes"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Générer une image des statistiques en ligne à chaque rafraîchissement"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Entrer ici le répertoire où générer l'image des statistiques en ligne"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Envoi périodique de l'image des statistiques en ligne sur un serveur FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL du FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Chemin du FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Entrer ici l'URL du serveur FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Entrer ici le répertoire du serveur FTP où envoyer l'image des statistiques en ligne"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Utilisateur"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Entrer ici l'identifiant pour se connecter au serveur FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Entrer ici le mot de passe pour se connecter au serveur FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalle d'envoi de l'image des statistiques en ligne en minutes"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Valider"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Répertoire contenant le fichier de signature"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Répertoire où générer l'image des statistiques en ligne"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Charge le template <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Port HTTP du serveur Web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Utiliser la redirection de port UPnP sur le port du serveur web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Port UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Utiliser la compression gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Mot de passe d'accès total pour le serveur web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Mot de passe invité pour le serveur web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Autoriser l'accès invité"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Interdire l'accès invité"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Charger/sauvegarder les paramètres du serveur web depuis/vers un aMule distant"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Chemin du fichier de configuration d'aMule. NE PAS UTILISER DIRECTEMENT !"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Désactiver l'interpréteur PHP (obsolète)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompiler les pages PHP à chaque requête"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Serveur Web d'aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "connexion du client web acceptée\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERREUR : impossible d'accepter la connexion au client web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "La requête a échoué avec le message d'erreur suivant : %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Fichier d'index non trouvé : "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "La session a expiré - demande de l'identifiant\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Session correcte, identifié\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Session correcte, non identifié\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Pas de session ouverte - l'identifiant va être demandé\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Session crée - demande de l'identifiant\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Requête en cours [originale] : "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "Refus de lire `pass` depuis la chaîne de requête URL\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Pas de mot de passe indiqué, il ne sera pas possible de se connecter."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Vérification du mot de passe\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hachage du mot de passe invalide\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Mot de passe correct\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Mauvais mot de passe\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Vous n'avez pas entré de mot de passe. Les mots de passe vides ne sont pas autorisés.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Déconnexion demandée\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Requête en cours [redirigée] : "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (obligatoire)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Raccourci de bureau"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "Lancer aMule lorsque j'ouvre une session"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Désinstaller"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Enlever les données d'utilisateur (configuration, serveurs ED2K, nœuds Kad, fichiers partiels)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "Fichiers de l'application aMule (obligatoires)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Créer un raccourci aMule sur le bureau."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Lancer aMule automatiquement lorsque l'utilisateur actuel ouvre une session (réglage par utilisateur)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Enlever les fichiers de l'application aMule, les raccourcis du menu de démarrage / du bureau, l'élément de clef d'exécution de du démarrage automatique, les enregistrements des schémas d'URL et l'élément d'ajout/suppression de programmes (obligatoire)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Effacer de manière permanente %APPDATA%\\aMule pour l'utilisateur actuel (aMule.conf, la liste des serveurs ED2K, les nœuds Kad, les filtres d'IP, la liste d'amis). Laissez décochée pour conserver vos réglages."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8591,7 +8478,7 @@ msgstr ""
 "aMule semble être en cours d'exécution depuis $INSTDIR.\r\n"
 "Veuillez fermer aMule (et aMuleD / aMuleGUI) et réessayer."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8599,11 +8486,11 @@ msgstr ""
 "Le démon aMule (amuled.exe) semble être en cours d'exécution depuis $INSTDIR.\r\n"
 "Veuillez le fermer et réessayer."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Suppression de l'installation précédente d'aMule sur $0…"
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8611,11 +8498,11 @@ msgstr ""
 "Échec de la suppression de l'installation précédente d'aMule sur $0.\r\n"
 "Veuillez fermer tous les processus aMule en cours d'exécution et réessayer, ou désinstallez d'abord manuellement la version précédente."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer l'installateur."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -35,20 +35,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "control remoto de aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Instantánea:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -56,7 +56,7 @@ msgstr ""
 "Cliente «Multi-Plataforma» p2p baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -65,79 +65,79 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule está baseado en \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encamiñamento entre pares baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Páxina web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Foro:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Comprobar se hai unha nova versión ao iniciar"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Conectando a Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Non dispoñible"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Engadir un amigo"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Tes que introducir unha IP e porto válidos!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Información"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "O hash de usuario especificado non é válido!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
@@ -150,47 +150,46 @@ msgstr ""
 "\r\n"
 "Quere instalar os atallos?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "Engadir aMule ao menú de aplicacións?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Continuar"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Agora non"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Non preguntar de novo"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Non se puido integrar co escritorio: a variable APPDIR está baleira. Isto pode pasar ao executar a AppImage dun xeito raro."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "Non se puido integrar aMule"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Non se puido integrar co escritorio: non se puido crear %s. Comprobe os permisos de escritura do cartafol persoal."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Non se puido integrar co escritorio: non se puido modificar %s. Comprobe os permisos de escritura do cartafol persoal."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, fuzzy, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integración de AppImage: Engadiuse aMule no menú de aplicacións."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -204,103 +203,100 @@ msgstr ""
 "\n"
 "Reiniciar agora aMule?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "Instalouse aMule"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Reiniciar agora"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Máis tarde"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Non se puido abrir o ficheiro con ligazóns eD2k."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2k tendo ID baixa."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Saíndo da aplicación principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Erro"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Rematando o proceso de amuleweb co pid «%d» ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Obrigando ao proceso de amuleweb con pid «%d» a pecharse ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Ao Sairen(OnExit): Apagando o núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Apagado completado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuración da memoria ao sair de aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O idioma cambiouse ao predeterminado do sistema debido a un troco na configuración."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Información"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -308,20 +304,19 @@ msgstr ""
 "\n"
 "Configuración CE"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -329,53 +324,50 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web executándose co pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "No se puideron vincular os portos á dirección especificada: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u non está dispoñible . Terá IDBAIXA\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -390,48 +382,48 @@ msgstr ""
 "\n"
 "Comprobe a súa rede para asegurarse de que o porto está aberto para a entrada e saída."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Non se puido crear o ficheiro OnlineSig de aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado semella non estar instalado. (Nota: Intentarase usalo a pesar diso)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que iniciou aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta versión é unha versión en proba, actualizada diariamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non lle aseguramos que non se rompa algo, lle prenda lume a súa casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou mate ao seu can. Pero non debería pasar nada.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Pode atopar máis información, axuda e novas actualizacións na nosa páxina,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "en https://amule-org.github.io, ou na nosa canle IRC #aMule en irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Pode avisar de calquera problema en https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -439,223 +431,219 @@ msgstr ""
 "O cartafol que especificou para as Sinaturas En Liña non é válido!\n"
 "A Sinatura En Liña permanecerá desactivada ata que se arranxe a configuración."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Fallou a reserva do espazo no disco duro para o ficheiro «%s»: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: non se pode abrir o ficheiro do rexistro"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de rexistro está baleiro. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "O rexistro foi borrado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensaxe do servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Saltouse a descarga de %s, por que o ficheiro pedido é máis antigo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Non se puido descargar a lista de nodos."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Non se puido abrir o ficheiro de comprobación da versión descargado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Ficheiro de comprobación da versión corrupto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Está usando unha versión de aMule desactualizada!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A súa versión de aMule é %i.%i.%i e a última versión é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A súa versión de aMule está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "A súa copia de aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Non se puido descargar o ficheiro de comprobación de versión"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuarios: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuarios: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Sen redes seleccionadas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "con IDBaixa"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "con IDAlta"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desconectouse do eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Iniciado Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Parado Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a Kad (devasa)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Non se pode usar a rede Kad se o porto UDP está desactivado nas preferencias. Non se iniciou."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desactivada nas preferencias. Non se iniciou."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERRO: o daemon de aMule non se pode usar cando están desactivadas as conexións externas. Para activar as Conexións Externas, use un aMule normal, inicie amuled coa opción --ec-config ou poña a clave «AcceptExternalConnections» a 1 no ficheiro ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERRO: É necesario un contrasinal válido para usar conexións externas, e o daemon de aMule non se pode usar sen elas. Para executar o daemon de aMule indique un valor axeitado no campo «ECPassword» do ficheiro ~/.aMule/amule.conf. Execute amuled co parámetro --ec-config para definir o contrasinal. Pode atopar máis información en https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - iniciando temporizador"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Non se puido crear o ficheiro Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é aMule %s baseado en eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -665,192 +653,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Sen rede"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Control remoto de aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Erro fatal: Non se puido crear o temporizador (Core Timer)"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Conectar ao amule remoto"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Conexión perdida"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Preguntar antes de saír"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -859,41 +840,41 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Erro fatal: Non se puido crear o temporizador (Poll Timer)"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Entrando no bucle de eventos..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Conectando..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Interface para a manipulación de eventos CE remotos"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Fallou a conexión. Non se puido conectar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Desconectando"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "O intento de conexión %s (%s:%i) tardou demasiado."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -902,685 +883,662 @@ msgstr ""
 "A conexión caducou. Non se puido chegar ata %s:%d nun prazo razoable.\n"
 "Comprobe o destino, o porto e que aMule teña activas as conexións externas."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Conectar á rede."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Fallou a conexión. Non se puido conectar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Listo"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Todo"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Non dispoñible"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Ficheiro non atopado."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ligazón inválida ou xa presente na lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantendo o directorio «%s»."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando colega para unha conexión IDBaixa"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (eMule falso versión %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule falso)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule falso)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcume: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pedido: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas do ficheiro para esta sesión: Aceptada %d de %d peticións; transferida %s\n"
 msgstr[1] "Estatísticas do ficheiro para esta sesión: Aceptadas %d de %d peticións; transferidas %s\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas do ficheiro para todas as sesións: Aceptada %d de %d peticións; transferida %s\n"
 msgstr[1] "Estatísticas do ficheiro para todas as sesións: Aceptadas %d de %d peticións; transferidas %s\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Pedido ficheiro descoñecido"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensaxe filtrada de «%s» (IP: %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensaxe de «%s» (IP: %s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O usuario %s (%u) pediu a súa lista de ficheiros compartidos do directorio inexistente «%s» -> Ignorouse"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "AVISO: non se puido abrir %s."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVISO: A lista de ficheiros cancelados corrompeuse, a cabeceira non é correcta."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Erro de E/S ao ler o ficheiro %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Non se puido gardar o ficheiro %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nova categoría"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Escolla un cartafol para os ficheiros entrantes"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Debe especificar un nome para a categoría!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Debe especificar unha ruta para a categoría!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Non se puido crear o directorio de entrada para a categoría. Indique unha ruta correcta!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Conversa iniciada: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Conectado ao Cliente ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Conectando ao Cliente ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Erro ao conectar ao cliente / Conexión perdida ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Resolveu o captcha e o usuario recibiu a súa mensaxe. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Non resolveu o captcha e a súa mensaxe foi ignorada. Podes volver a intentalo enviando unha nova mensaxe ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Conversa"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Pechar lapela"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Pechar todas as lapelas"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Pechar as outras lapelas"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Engadir amigo"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Ficheiro de créditos cargado, coñécese o cliente %u"
 msgstr[1] "Ficheiro de créditos cargado, coñécense os clientes %u"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Expiraron os créditos do cliente %u!"
 msgstr[1] " - Expiraron os créditos dos clientes %u!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Non se atopou o ficheiro «cryptkey.dat», creándoo."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalles do cliente"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaixa"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAlta"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Permitido"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Non permitido"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Incompleto"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Rapaz malo"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Non dispoñible"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "O usuario %s (%u) solicitou a súa lista de ficheiros compartidos -> Aceptado"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "O usuario %s (%u) solicitou a súa lista de ficheiros compartidos -> Denegado"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "O usuario %s (%u) solicitou a súa lista de directorios compartidos -> Aceptado"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "O usuario %s (%u) solicitou a súa lista de directorios compartidos -> Denegado"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "O usuario %s (%u) solicitou a súa lista de ficheiros compartidos do directorio %s -> aceptado"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "O usuario %s (%u) solicitou a súa lista de ficheiros compartidos do directorio %s -> denegado"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "O usuario %s (%u) comparte o directorio «%s»"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "O usuario %s (%u) enviou unha lista de cartafoles compartidos non desexada."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "O usuario %s (%u) enviou a súa lista de ficheiros compartidos para o directorio «%s»"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "O usuario %s (%u) rematou de enviar a súa lista de ficheiros compartidos"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "O usuario %s (%u) enviou unha lista de ficheiros compartidos non desexada"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "O usuario %s (%u) denegou o acceso á lista de ficheiros e directorios compartidos"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentarios do ficheiro"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do ficheiro"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentario"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Non se pode buscar en Kad se non está activo"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Buscando colega para unha conexión IDBaixa"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Sen comentarios"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentario"
 msgstr[1] "%u comentarios"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "O cliente %s foi suspendido por enviar %s información corrupta do total %s do ficheiro «%s»"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Non se puido cargar información do país para «%s»."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ba]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Al]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Moi alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Lanzamento"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Preguntando"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Conectando vía servidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Cola chea"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Recibindo conxunto de hashes"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Partes innecesarias"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Non se poden conectar IDBaixas entre si"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Demasiadas conexións"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Conectando vía Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Demasiadas conexións Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Vetado"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Erro de conexión"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Cola remota chea"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Vello MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Novo MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatible con eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Servidor local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Intercambio de fontes"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasivo"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Ligazón"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Sementes da fonte"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultados da busca"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "En progreso"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "ERRO: Non queda espazo no disco"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERRO: Non se atopou o partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERRO: Erro de E/S!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERRO: Non se puido realizar a acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "En cola"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Xa se está descargando"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formato de ficheiro temporal incorrecto ou descoñecido."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Estado"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tempo restante"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Última vez que se vira completo"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Última recepción"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Seguro que quere borrar o ficheiro seleccionado?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Seguro que quere borrar os ficheiros seleccionados?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1589,109 +1547,106 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automático"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Deter"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Parar"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "Continua&r"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Limpeza completada"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Pasar todas as A4AF a este ficheiro"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Pasar todas as A4AF a este ficheiro (Automaticamente)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Pasar todas as A4AF a calquera outro ficheiro"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opcións extendidas"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Amosar &detalles do ficheiro"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Ver todos os comentarios"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiar a URI magnética ao portapapeis"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copiar &ligazón eD2k ao portapapeis"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar comentarios ao portapapeis"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "anular a asignación"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Asignar á categoría"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Abrir o ficheir&o"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Introducir un novo nome para este ficheiro:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Cambiar o nome do ficheiro"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1700,346 +1655,345 @@ msgstr ""
 "Para evitar a aparición deste aviso en cada vista previa,\n"
 "establece o teu reprodutor de vídeo nos axustes (%s é o predeterminado)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Previsualizar ficheiro"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Non se puido executar o reprodutor multimedia externo! Orde: «%s»"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Gardando parte %u de %u do ficheiro"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Gardáronse todas as partes do ficheiro."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Cargando ficheiros temporais dende %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Cargando parte %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERRO: Non se puido cargar o ficheiro da copia de seguridade. Busque en https://github.com/amule-org/amule/discussions para atopar unha solución e recuperar os ficheiros part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Todas as partes do ficheiro cargadas."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Non se atoparon ficheiros parciais"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Atopado %u ficheiro partido"
 msgstr[1] "Atopados %u ficheiros partidos"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "O sistema de ficheiros do directorio temporal non permite ficheiros grandes."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "O sistema de ficheiros do directorio de descarga non permite ficheiros grandes."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Descargando %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "O ficheiro «%s» xa se está descargando"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "O ficheiro «%s» xa está descargado"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "O ficheiro «%s» xa está descargado"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "O ficheiro %s xa se está descargando"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Non se puido converter a ligazón magnet a eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocolo da ligazón descoñecido: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "Non se puido engadir a ligazón %u (consulte o rexistro)."
 msgstr[1] "Non se puideron engadir as ligazóns %u (consulte o rexistro)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligazón eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou un paquete despois de que fallara a identificación."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Conexión externa pechada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Conexións externas desactivadas no ficheiro de configuración"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nova conexión externa aceptada"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: non se puido aceptar unha nova conexión externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexións externas desactivadas por mor dun contrasinal baleiro nas preferencias!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Conectando ao cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versión descoñecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "CE incorrecto na ID de versión, os programas non son compatibles. Use a mesma versión para o núcleo e para o remoto."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non se pode conectar a una versión estable dende una versión de desenvolvemento calquera! Evitada posible fallo do programa"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versión do protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Marcador da versión do protocolo inexistente."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Fallou a identificación: o resumo criptográfico (hash) usado coma contrasinal CE é inválido."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Fallou a identificación: contrasinal erróneo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Fallou a identificación: falta o contrasinal."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Petición inválida, primeiro identifíquese."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Acceso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviando mensaxe «%s» ao cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Intento de acceso non autorizado dende %s. Conexión pechada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Fallou a orde PartFile remota: FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash non atopado: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Erro ao procesar o OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Servidor non engadido"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor non atopado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "necesita definir o servidor que quere eliminar"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Non se atopou o amigo."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Non se atopou o ficheiro."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED precisa de EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ten sentido usar WebSearch dende unha interface remota."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Busca en progreso. Obterá os resultado nun intre!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Sen puntos para a gráfica."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "O seu cliente non está configurado para este nivel de detalle."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Conexión externa: apagado solicitado"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Xa se está apagando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexión externa: engadinda ligazón «%s»."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Fallaron %d de %d ligazóns (por non valer ou xa estar na lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Ficheiro non atopado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Imposible cambiarlle o nome ao ficheiro."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desactivado nas preferencias."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Xa está conectado ao eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Conectando ao eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Xa está conectado a Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Conectando a Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Tódalas redes están desactivadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desconectado do eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desconectado de Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexión externa: recibido código de operación inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode inválido (versión do protocolo inválida?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensión «%s» descoñecida para a orde «%s».\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Orde descoñecido «%s».\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2047,7 +2001,7 @@ msgstr ""
 "\n"
 "Esta orde non pode ter un parámetro.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2055,7 +2009,7 @@ msgstr ""
 "\n"
 "Esta orde deber ter un parámetro.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2063,7 +2017,7 @@ msgstr ""
 "\n"
 "Esta orde está incompleta, debe usar unha das extensión amosadas abaixo.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2071,11 +2025,11 @@ msgstr ""
 "\n"
 "Extensións dispoñibles:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Orde dispoñibles:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2086,17 +2040,17 @@ msgstr ""
 "As ordes non diferencian entre maiúsculas e minúsculas\n"
 "Escriba «%s <orde>» para obter información exhaustiva da <orde>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Sae da aplicación."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Amosar axuda."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2104,7 +2058,7 @@ msgstr ""
 "Para obter axuda sobre unha orde, escriba «help <orde>».\n"
 "Para obter a lista completa de ordes, escriba «help».\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2115,46 +2069,46 @@ msgstr ""
 "Use «%s» para amosar a lista de ordes\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Erro de sintaxe!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Ocorreu un problema ao procesar a orde - isto non debería pasar! Avise do problema\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Esta orde non debería ter ningún parámetro."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Esta orde debe ter algún parámetro."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Parámetro inválido."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Esta orde está incompleta."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Escriba «%s» para obter máis axuda.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Isto é %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Isto é %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2162,7 +2116,7 @@ msgstr ""
 "\n"
 "Creando cliente...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2171,7 +2125,7 @@ msgstr ""
 "\n"
 "Vale, saíndo de %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2185,331 +2139,326 @@ msgstr ""
 "\n"
 "Saíndo...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Amosar este texto de axuda."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Anfitrión onde se está executando aMule. (por omisión: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porto de aMule para conexión externa. (por omisión: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Contrasinal para conexión externa."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Ler configuración do ficheiro."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Non imprimir nada á saída normativizada (stdout)."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Explanarse - mostrar ademais as mensaxes de depuración."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Establecer o idioma do programa."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Escribir opcións da liña de ordes ao ficheiro de configuración."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un ficheiro de configuración baseándose no ficheiro de configuración de aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Amosar versión de programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalles do ficheiro"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% feito"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Benvido!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Conectado a colega"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Estado de conexión:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Redes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Porto TCP normativizado "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP ampliado (Kad / busca global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para configurar os portos no encamiñador"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "O ficheiro %s xa se está descargando"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Actualizar automáticamente a lista de servidores no arranque"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "Arrancar aMule automaticamente ao iniciar sesión"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navegador"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Cartafol para ficheiros de descarga temporais"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Non se puido obter a lista de amigos do ficheiro «emfriends.met»!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amigos"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Ver &Detalles"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Engadir un amigo"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Borrar amigo"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Enviar &Mensaxe"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ver ficheiros"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Establecer Oco para un Amigo"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Está seguro de que quere borrar a amizade seleccionada?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Está seguro de que quere borrar as amizades seleccionados?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2517,11 +2466,11 @@ msgstr ""
 "Non está permitindo establecer máis dun espazo de amigo.\n"
 " Só se asignou un espazo."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selección múltiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2529,206 +2478,205 @@ msgstr ""
 "Non está permitindo establecer máis dun espazo de amigo.\n"
 " Só se asignou un espazo."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Enviar mensaxe ao usuario"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensaxes a enviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Borrar da lista de amigos"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Enviar mensaxe"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este ficheiro"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En lista de espera: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Preguntando por outro ficheiro"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Agardando ocasión para o envío"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "En cola: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ningún"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Si"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Descarga HTTP cancelada"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "A URL para descargar non pode estar baleira"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Non se puido crear unha petición HTTP para %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Descarga HTTP: corpo da resposta baleiro para %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Non se puido mover o ficheiro descargado a %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descargado %s (%llu octetos)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "A URL %s devolveu: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Non se puido descargar %s mediante HTTP: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "Recibiuse un HTTP 401 (non permitido) para %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Descargue un %s novo dende %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "A descarga de %s fallou, cancelouse a actualización."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Non se puido eliminar o ficheiro %s, cancelando actualización."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Non se lle puido cambiar o nome ao ficheiro %s, cancelando a descarga."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s actualizado con éxito"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Fallou a actualización de %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Non se puido descargar %s dende %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Cargando os filtros de IP en «ipfilter.dat» e «ipfilter_static.dat»."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Non se puido cargar o ficheiro ipfilter.dat (%s), atopouse un formato descoñecido."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Non se puido cargar o ficheiro ipfilter.dat (%s), non se puido abrir o ficheiro."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Cargado rango de IP %u dende «%s»."
 msgstr[1] "Cargados rangos de IP %u dende «%s»."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u liña malformada foi descartada."
 msgstr[1] "%u liñas malformadas foron descartadas."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Non se lle puido cambiar o nome ao ficheiro %s, cancelando actualización."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "O filtro de IP está listo"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2736,869 +2684,837 @@ msgstr ""
 "Arrancando dende cero a partir de \n"
 "clientes coñecidos"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ip inválida para o arranque"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Porto inválido para o arranque"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Enche todos os campos requiridos"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mensaxe"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Quere descargar un ficheiro nodes.dat novo?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Se fai isto borrará os nodos actuais e reiniciarase a conexión Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Continuar?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: palabra de busca demasiado curta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: A palabra buscada xa está na lista de buscas: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Non se puido ler o ficheiro nodes.dat, é demasiado vello. Esta versión (0) xa non é compatible."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Lido %u contacto Kad"
 msgstr[1] "Lidos %u contactos Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Non se atoparon contactos, por favor realice un arranque autónomo ou descargue un ficheiro nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Só %d contacto Kad dispoñíbel, non se escribiu o nodes.dat"
 msgstr[1] "Só %d contactos Kad dispoñíbeis, non se escribiu o nodes.dat"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Escribiuse %d contacto Kad"
 msgstr[1] "Escribíronse %d contactos Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Red Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nome de ficheiro"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tamaño do ficheiro"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Relación enviado/descargado"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Solicitado"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fontes completas"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "AVISO: A lista de ficheiros coñecidos corrompeuse por mor dunha cabeceira inválida."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Non se puido cargar o campo da lista de ficheiros coñecidos. Pode ser que se corrompera o ficheiro"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Campo inválido na lista de ficheiros coñecidos, Pode ser que se corrompera o ficheiro: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Erro descoñecido %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Non se puido obter unha descrición do erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Creando o hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Rematando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Rematado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Agardando"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Debe especificar un contrasinal non baleiro."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Contrasinal inválido, sen un hash MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Erro de conexión"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Conexión externa pechada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Fallou a conexión CE. Resposta baleira."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Conexión externa: Mala resposta do servidor, fallou o saúdo. Conexión pechada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Éxito! Conexión establecida a aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Éxito! Conexión establecida."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Conexión externa: Acceso denegado debido a: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Conexión externa: Fallou o saúdo."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Correcto."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERRO: Non se puido escoitar no porto TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERRO: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVISO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Pechar"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Conectado (ID Baixa)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Conectado (ID Alta)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Conectado (tras devasa)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Servidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "IP do servidor: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Non conectado"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Porto TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Porto TCP: Sen preparar"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Porto UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Porto UDP: Sen preparar"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Información do cliente"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Límite de envío"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Límite de descarga"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostrar aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Ocultar aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Saír"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menú aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Límites de velocidade:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "EV: Ningunha"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "EV: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DE: Ningunha"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DE: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocidade de descarga: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocidade de envío: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Alcume: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Non seleccionou un alcume!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID do cliente: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nome do servidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP de servidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Non conectado"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Sinatura En liña: Activada"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Sinatura En liña: Desactivada"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Tempo de execución: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Ficheiros compartidos: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clientes na cola: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total DE: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total EV: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Engadir unha ligazón eD2k ou unha ligazón magnet ó núcleo."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Engadir amigo"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Preme aquí para engadir a ligazón eD2k no cadro á cola das descargas."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Os eventos amósanse aquí. Para unha lista completa de eventos consulte o rexistro da lapela de servidores."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Cargando ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Número de usuarios conectado ao mesmo servidor ca ti ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Usuarios: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Usuarios conectados ao servidor actual e unha estimación do número total de usuarios."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Enviado: 0.0 | Descargado: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Índice actual de envíos e descargas. Se está activado os números entre corchetes indican os datos gastados na comunicación do cliente."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Amosa o estado de conexión e as transferencias activas. As frechas vermellas indican que non está conectado, as frechas amarelas indican que ten ID-Baixa (detrás dunha devasa) e as frechas verdes indican que ten ID-Alta (o tipo de conexión óptima)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Non conectado ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Servidor actualmente conectado."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Buscar"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parámetros de filtrado"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrado"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipo de ficheiro"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Calquera"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arquivos"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Copia de CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Imaxes"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programas"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Textos"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vídeos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensión"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Tamaño mínimo"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Octetos"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Tamaño máximo"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Dispoñibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtrado:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Resultados do filtro"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverter resultado"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Agochar ficheiros coñecidos"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Comezar"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Máis"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Solicitar que os clientes Kad contactados estendan a busca. Cada pulsación solicita os contactos do cliente máis preto (KADEMLIA_FIND_VALUE_MORE), amosando máis ficheiros coincidentes que pode ser que non apareceran na fronteira alfa da busca inicial."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Deter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descargar"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Borrar campos"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Limpar descargas completadas"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes do ficheiro:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Xeral"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nome completo :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Ficheiro .met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Resumo criptográfico (Hash) :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tamaño do ficheiro:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferir"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Estado do ficheiro parcial:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Visto completo por última vez:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fontes atopadas:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Enviando fontes :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Número de partes:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Dispoñible :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Tempo coa descarga activa: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferido :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamaño total :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Xestión Intelixente da Corrupción"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdido por corrupción:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Gañado por compresión:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paquetes salvados pola X.I.C. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Compartindo: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Peticións"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Peticións aceptadas"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Datos transferidos"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Media de datos compartidos"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fontes completas"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Enviado: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Título :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nome do ficheiro"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Tomar"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Limpar"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Aceptar"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Engadir un comentario/cualificación sobre o ficheiro (todos os usuarios poderán velo)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3606,574 +3522,572 @@ msgstr ""
 "Para unha película vostede pode dicir que é largo, a súa historia, o idioma ...\n"
 "e se é un ficheiro falso, pode advertir ós outros usuarios do aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Calidade do ficheiro"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Inválido / Corrupto / Falsificación"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Pobre"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Aceptable"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Boa"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excelente"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Avalíe o ficheiro ou advirtalle a outros usuarios se non é válido ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Desconectado de Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Descargando, agarde un intre ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Tamaño descoñecido"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Información requerida"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Enderezo IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Porto :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nome de usuario :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Engadir"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Media de sesión"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidade de envío"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Descargas activas"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Árbore de estadísticas"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nome de usuario:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software do cliente :"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versión do cliente :"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Enderezo IP :"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID do usuario :"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP do servidor :"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nome do servidor :"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Ofuscación:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferencias ao cliente"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Peticións actuais:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Taxa media de envío:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Índice medio de descarga :"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Enviado (sesión):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Descargado (sesión):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Enviado (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Descargado (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador DE/EV :"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identidade segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Posición na cola:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Puntuación na cola:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Alcume"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - A Mula multi-plataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Este é o nome que os outros usuarios verán cando se conecten a vostede."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "O retardo antes de mostrar as mensaxes emerxentes."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Isto especifica a linguaxe empregada nas interfaces."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Comprobar se hai unha nova versión ao iniciar"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Activar isto fará que aMule comprobe se hai unha nova versión ao iniciarse"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Crea unha configuración de usuario para que o sistema operativo inicie aMule ao entrar. Se polo que sexa móvese o programa aMule, execúteo unha primeira vez a man para actualizar a configuración."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Iniciar minimizado"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Activando isto aMule minimizarase tras iniciarse."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Preguntar antes de saír"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Obrigar a aMule a pedir confirmación antes de saír."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Activar icona na bandexa"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Isto Activa/Desactiva a icona da bandexa do sistema (ou barra de tarefas)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Pechar a fiestra da aplicación cando se prema o botón de pechar"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizar na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Activando isto aMule minimizarase na bandexa do sistema, no canto de na barra de tarefas."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Amosar unha notificación ao rematar a descarga"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Activando isto aMule avisaralle cando remate a descarga."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Retardo da información sobre as ferramentas: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selección de navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Abrir nunha nova lapela se é posible"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir as páxinas web nunha nova solapa, en lugar de nunha nova xanela"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Reprodutor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Límites de ancho de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Asignación de ocos"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto eD2k normativizado e non se pode desactivar."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para peticións do servidor (TCP+3)"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP úsase para peticións eD2k ampliadas e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP para UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Límite de fontes por ficheiro descargado:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Conectar automaticamente ao iniciarse"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Volver a conectarse ao perder a conexión"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Eliminar servidores caídos tras"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "intentos"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores ao conectarse a un servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores cando un cliente se conecte"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Control intelixente da IDBaixa ao conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Conexión segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectar automaticamente só a servidores fixos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Asignar alta prioridade aos servidores engadidos manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Poñer en pausa os ficheiros engadidos á lista de descargas"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Engadir os novos ficheiros compartidos con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Tentar descargar antes o primeiro e último anaco do ficheiro"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Comezar co seguinte ficheiro que estea pausado cando remate o ficheiro actual"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Da mesma categoría"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "En orde alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Reservar espazo no disco para os novos ficheiros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Reserva o tamaño do ficheiro no disco para reducir a fragmentación"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar descargas canto o espazo libre no disco acade "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione esta opción se quere que aMule comprobe o espazo libre no disco"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Introduza o espazo mínimo de disco desexado."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Gardar 10 fontes en ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Enviado"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Engadir novas descargas con prioridade Automática"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Xestión Intelixente de Corrupcións (X.I.C, I.C.H en inglés)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Activada"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "O X.I.C. avanzado confía en cada hash (non recomendado)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4181,693 +4095,691 @@ msgstr ""
 "Aquí gárdanse as descargas completas. Automaticamente compartiranse todos os ficheiros do cartafol co resto de parceiros.\n"
 "Se o cartafol tamén conten ficheiros privados, apunte a ruta a un cartafol só para aMule."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Preme co botón dereito na icona do cartafol para compartir recursivamente)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Compartir ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Revisar automaticamente se hai cambios nos cartafoles compartidos"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficas"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Intervalo de actualización: 5 segs"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo de media do gráfico: 100 minutos"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do gráfico das conexións: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de descargas:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de envíos:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fondo"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Enreixado"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Descarga actual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Media das descargas en execución"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Media de descargas na sesión"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Subida actual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Media de subida en execución"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Conexións activas"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade na bandexa do sistema"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nodos Kad actuais"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nodo Kad executándose"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Árbore"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Cantas versións do cliente a amosar (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "ADVERTENCIA !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Novas conexións máx. / 5 segs"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamaño do búfer de ficheiro: 240 000 octetos"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamaño cola de espera: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualización de conexión ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Impedir que o ordenador entre en modo espera"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Tema a usar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Amosar «Xestor rápido de ligazóns eD2k» en cada xanela."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar información engadida nas lapelas das categorías"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Amosar a versión da aplicación no título"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferencia no título"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Antes do nome da aplicación"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Despois do nome da aplicación"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Amosar ancho de banda malgastado"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Barra de ferramentas en orientación vertical"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Cola de Descargas"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Amosar porcentaxe de progreso"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Amosar barra de progreso"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Denegar acceso de invitado"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Contrasinal de invitado para o servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4875,11 +4787,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4889,518 +4801,518 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Desactivado [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "octeto"
 msgstr[1] "octetos"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "octeto/seg"
 msgstr[1] "octetos/seg"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "segundos"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minutos"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "horas"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "días"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "todo"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "todo o demais"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Parado"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeo"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arquivo"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Texto"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Activo"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Usando directorio de configuración: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando que o fío remate de converter os ficheiros partidos..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importando %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lendo o cartafol temporal"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Obtendo información básica do ficheiro con información da descarga"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Creando ficheiro de destino"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Cargando datos dunha descarga previa (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Gardando o bloque de datos dun novo ficheiro de descarga (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Obtendo información do ficheiro de descarga fonte"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Engadindo descarga e gardando novo ficheiro parcial"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importar ficheiros parcial"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estado"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash do ficheiro"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disco: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Escolla un cartafol para buscar descargas temporais! (subcartafois incluídos)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Borrar os ficheiros orixinais dunha descarga importada sen fallos?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Borrar fontes?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERRO: Non se puido crear o ficheiro partido"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Tentando cargar a copia de seguranza do ficheiro met dende %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERRO: Non se puido abrir o ficheiro part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERRO: o ficheiro part.met ten tamaño 0: %s ===> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERRO: Versión do part.met inválida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Erro: %s (%s) está corrupto (etiquetas erróneas: %s), imposible cargar o ficheiro."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERRO: %s (%s) está corrupto (conta de etiquetas errónea), imposible cargar o ficheiro."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Tentando recuperar información de ficheiro..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Recuperando ficheiro sen nome - recuperareino como RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperada toda a información dispoñible do ficheiro :D - Tentando empregala..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Imposible recuperar información de ficheiro :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Non se pode abrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVISO: %s pode estar corrupto (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERRO ao gardar o ficheiro parcial: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Ocorreu un fallo de E/S ao gardar o ficheiro parcial: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "Escribíronse 0 de a saber cantos octetos de «%s» -- manterase o .part.met actual."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Non se puido gardar o ficheiro part.met.seeds por %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Gardada %i semente fonte para o ficheiro parcial: %s (%s)"
 msgstr[1] "Gardadas %i sementes fonte para o ficheiro parcial: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Non se puido ler o ficheiro coas sementes para o ficheiro parcial %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Non se puido ler o ficheiro coas semente do ficheiro parcial (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Parte corrupta atopada (%d) en %d ficheiro parcial %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Parte corrupta atopada (%d) en %d ficheiros parcial %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Parte (%i) completada atopada en %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Rematouse a recreación do hash %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Ocorreu un erro inesperado mentres se completaba %s. Ficheiro pausado"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Rematouse a descarga: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5409,307 +5321,307 @@ msgstr ""
 "Rematouse a descarga:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Eliminando ficheiro: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: Non se puido crear o hash da parte descargada, o conxunto de hashes de «%s» está incompleto"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Non se puido crear o hash da parte descargada, o conxunto de hash de «%s» está incompleto. Isto non debería ocorrer en absoluto"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de «%s» aparece como completada, pero o ficheiro parcial é máis pequeno do que debería (temos %llu octetos, precisamos %llu); intentando outra vez a descarga."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Chegouse ao fin de ficheiro mentres se facía o hash da parte %u descargada con lonxitude %u (máx. %u) do ficheiro partido «%s» con lonxitude %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Non hai suficiente espazo libre no disco! Parando ficheiro: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Part descargado %i é corrupto no ficheiro: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "XIC: Part corrupto recuperado %i para %s -> Octetos gardados: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Reservando"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espazo no disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Conexión"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Seguranza"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Sinatura En liña"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Depuración"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5719,15 +5631,15 @@ msgstr ""
 "    %PARTFILE - ruta completa do ficheiro\n"
 "    %PARTNAME - nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Para poder engadir unha icona precisa ter libayatana-appindicator3 durante a compilación."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non dispoñible en Wayland: o protocolo non pode avisar se se minimiza unha xanela, polo que non se pode interceptar o botón de minimizar. Como alternativa, execute aMule con «GDK_BACKEND=x11» para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5743,35 +5655,35 @@ msgstr ""
 "aMule funcionará ben sen que cambie ningún\n"
 "destes parámetros."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Non se puido conectar a configuración ao compoñente coa ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Non se puido transferir información dende a configuración ao compoñente con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao que se está a conectar"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Non se puido transferir información entre o compoñente e a configuración con ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Comprobando contrasinal\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5779,41 +5691,41 @@ msgstr ""
 "aMule debe ser reiniciado para activar estes trocos:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Cambiado o porto da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Cambiada a aceptación da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Cambiada interface da conexión externa.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Cambiada opción da ofuscación do protocolo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5821,7 +5733,7 @@ msgstr ""
 "A túa lista de servidores para auto-actualizar está baleira.\n"
 "Desactivarase a actualización no inicio."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5829,33 +5741,33 @@ msgstr ""
 "Permítense conexións externas pero non se especificou un contrasinal.\n"
 "As conexións externas non poden ser activadas ate que se especifique un contrasinal válido."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Idioma cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Cartafol temporal cambiado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede eD2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versión do protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5863,7 +5775,7 @@ msgstr ""
 "Tanto eD2k e Kad están desactivados.\n"
 "Non poderás conectarte ate activar algún dous."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5871,7 +5783,7 @@ msgstr ""
 "Kad non se iniciará se non está activado o porto UDP.\n"
 "Active o porto UDP ou desactive Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5881,71 +5793,71 @@ msgstr ""
 "Debe reiniciar o aMule agora.\n"
 "Se non o reinicia agora, ature coas consecuencias.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Arrancar ao inicio"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Non se puido configurar para que aMule arranque ao iniciar sesión. Pode ser que a configuración non permita modificacións."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the URL handler registration."
 msgstr "Non se puido quitar o arranque ao inicio da configuración."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Establecido o contrasinal e habilitadas conexións externas."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5955,66 +5867,66 @@ msgstr ""
 "Introduza polo menos unha URL dun ficheiro server.met.\n"
 "Prema no botón «Listar» para introducir unha URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Ficheiros temporais"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Ficheiros entrantes"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Sinaturas En Liña"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolla un cartafol para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Atopar o reprodutor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccione o navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executable%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predeterminado"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editar a lista dos servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6022,115 +5934,115 @@ msgstr ""
 "Engadir aquí unha URL para descargar unha lista server.met.\n"
 "Só unha url nesta liña."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Período de actualización: %d segundo"
 msgstr[1] "Período de actualización: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo medio de gráfico: %d min"
 msgstr[1] "Tempo medio de gráfico: %d min"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala gráfica das conexións: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamaño do búfer dos ficheiros: %d octeto"
 msgstr[1] "Tamaño do búfer dos ficheiros: %d octetos"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamaño da cola de subida: %d cliente"
 msgstr[1] "Tamaño da cola de subida: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualización da conexión ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualización da conexión ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualización da conexión ao servidor. Desactivada"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar unha orde no evento «%s»"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Activar execución de ordes no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Orde do núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Activar execución de ordes na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Orde da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variables serán substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6138,1089 +6050,1088 @@ msgstr ""
 "Estas carpetas semellan parte do sistema, ou que poden ser confidenciais:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan debaixo nas redes eD2k e Kad. Comprobe todo ben antes de continuar."
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Buscando subdirectorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Actualizando os cartafoles compartidos"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Buscáronse %u directorios..."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Aviso na busca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Non se poido realizar unha procura no eD2k se non se está conectado o eD2k"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Ren palabras clave para a busca Kad - interrumpindo"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ocorreu un erro inesperado tentando buscar en Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Busca de Kad: solicitóuselle ampliar a busca a un parceiro."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Busca de Kad: non quedan parceiros sen preguntar por máis resultados (acadouse o límite, ou inda non hai respostas)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "IDFicheiro"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Non evaluada"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, busca local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marcar o ficheiro como coñecido"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar a ligazón eD2k ó portapapeis"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está conectado ao servidor que tenta borrar. Por favor desconéctese primeiro."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Novo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Non se puido conectar a todos os servidores ofuscados listados. Tentándoo de novo sen ofuscación."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Non se puido conectar a todos os servidores ofuscados listados. Tentándoo de novo sen ofuscación."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Erro ao conectar a todos os servidores. Tentándoo de novo."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Erro ao conectar a todos os servidores. Tentándoo de novo."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolo eD2k inhabilitado nos axustes, non se conectou."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Non se atoparon servidores válidos para conectar na lista dos servidores"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Conectado a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Conexión establecida a: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Ocorreu un erro fatal ao conectar. A conexión a internet podería estar desactivada"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Conexión perdida con %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) parece estar caído."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheo."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Tentarase conectar automaticamente ao servidor en %d segundo"
 msgstr[1] "Tentarase conectar automaticamente ao servidor en %d segundos"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Non se puido conectar a %s (%s:%i)."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERRO: Conector inválido durante comprobación tras expirar o tempo"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "O intento de conexión %s (%s:%i) tardou demasiado."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Recibido resultado tardío da busca DNS, descartando."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Cargando ficheiro server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Ficheiro server.met non atopado!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Non se puido cargar o ficheiro server.met «%s», atopouse un formato descoñecido."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Non se puido abrir o server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "O ficheiro server.met está corrupto. Atopouse unha marca de versión inválida: 0x%x, tamaño %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i servidor atopado no server.met"
 msgstr[1] "%i servidores atopados no server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d servidor engadido"
 msgstr[1] "%d servidores engadidos"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Erro: o ficheiro «server.met» corrompeuse: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Ocorreu un erro de E/S ao ler o ficheiro «server.met»: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Servidor non engadido: [%s:%d] non especifica un porto válido."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Servidor non engadido: A IP de [%s:%d] está filtrada ou é inválida."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Servidor non engadido: Servidor con IP:Porto [%s:%d] coincidente atopado na lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Servidor engadido: Servidor [%s:%d] empregando o nome «%s»."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Está conectado ao servidor que tenta borrar. Por favor desconéctese primeiro."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Non se puido abrir «%s»"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Non se puido gardar o ficheiro server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL inválida"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Finalizouse a descarga da lista dos servidores dende %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Non se encontrou unha entrada de dirección no «addresses.dat». Por favor, pega unha lista de servidores válida neste ficheiro para poder actualizar de forma automática a lista de servidores"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Descargando lista dos servidores de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "AVISO: especificada unha URL inválida para a actualización automática de servidores : %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "O ficheiro addresses.dat non contén unha URL válida para a descarga automática do server.met"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Non se puido descargar a lista de servidores dende %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "O servidor local está filtrado por IPFilters, conectando a un servidor diferente!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do servidor"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Enderezo"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Porto"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descrición"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Retardo"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Usuarios"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Estático"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Está conectado ao servidor que tenta borrar. Por favor desconéctese primeiro. O servidor NON foi borrado."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nome descoñecido)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Seguro de que quere borrar o servidor estático %s?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Servidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectarse ao servidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marcar servidor como estático"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marcar servidor como non estático"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar servidores como estáticos"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar servidores como non estáticos"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Borrar servidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Borrar servidores"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Borrar todos os servidores"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copia as ligazóns eD2k ó portapapeis"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Tentar conectarse ao servidor de novo"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Está seguro de que quere borrar todos os servidores?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Está seguro de que quere borrar o servidor seleccionado?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Está seguro de que quere borrar os servidores seleccionados?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERRO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVISO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "A nova IDCliente é %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ATENCIÓN: Recibiu ID-Baixa!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tIsto sucede porque vostede se atopa detrás dunha devasa ou dun encamiñador."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPara máis información, por favor consulte https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Recibida información descoñecida do servidor! - resposta demasiado corta"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Recibido %d novo servidor"
 msgstr[1] "Recibidos %d novos servidores"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Completado o gardado da lista de servidores."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "O servidor rexeitou a última orde"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "O servidor enviou un paquete erróneo: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Ocorreu un erro ao procesar o paquete do servidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Non se puido crear o fío para resolver o DNS e conectarse a %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Filtrouse a IP de servidor %s (%s).  Non se conectará."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "usando ofuscación do protocolo."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Conectando a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Non se puido aclarar a DNS para o servidor %s: Imposible conectar!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Rexistro de aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Servidor non engadido: Non se especificou ningunha IP nin o nome de servidor."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor non engadido: Porto do servidor inválido."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Estado do eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Estado de conexión:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Conectado"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Estado Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Executando en modo LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Executando"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID do cliente Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estado de conexión:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Devasa atopada - abra o porto TCP %d no seu encamiñador ou devasa"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estado da conexión UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Devasa atopada - abra o porto UDP %d no seu encamiñador ou devasa"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estado da devasa: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Non se precisa colega - porto TCP aberto"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Non se precisa colega - porto UDP aberto"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Sen colegas"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Conectado a colega"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectado a colega en %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fontes catalogadas:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Palabras clave catalogadas:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notas catalogadas:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Carga catalogada:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Media de usuarios:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Media de ficheiros:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Non executando"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Engadindo ficheiro %s aos ficheiros compartidos"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Atopado %i ficheiro compartidos, %i descoñecido"
 msgstr[1] "Atopados %i ficheiros compartidos, %i descoñecidos"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERRO: Intentouse compartir %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Directorio compartido non atopado, saltando: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nome de usuario"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de envío"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Partes dispoñibles"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Estado do envío"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Estado de descarga"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Orixe"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nome local do ficheiro"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Lista de ficheiros compartidos"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Partes obtidas"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Ruta do directorio"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Engadir Comentario/Calificación"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editar Comentario/Calificación"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Cambiar o nome"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Engadir os ficheiros na colección á lista de transferencia"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiar a &URI magnética ao portapapeis"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiar ligazón eD2k ó portapapei&s (Fonte)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiar ligazón eD2k ó portapapeis (Fonte) (&Con opcións de cifrado)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiar ligazón eD2k ó portapapeis (&Nome do anfitrión)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiar ligazón eD2k ó portapapeis (Nome do anfitrión) (Con opcións d&e cifrado)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiar ligazón eD2k ó portapapeis (información do XICA [&AICH])"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiar ligazón eD2k ó portapapeis (información do XICA [&AICH] e fontes)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Precísase ter IDAlta para crear unha ligazón á fonte válido"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome remoto do ficheiro"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Datos enviados (Sesión (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Sobrecarga total (Paquetes ): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Sobrecarga nas peticións de ficheiro (Paquetes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Sobrecarga no intercambio de fontes (Paquetes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Sobrecarga nos servidores (Paquetes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Sobrecarga no Kad (Paquetes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Sobrecarga na encriptación (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Envíos activos: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Envíos agardando: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Sesión de envíos totais rematados: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de sesións de envío erradas: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tempo medio de envío: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Datos descargados (Sesión (Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fontes atopadas: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Descargas activas (pedazos): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Índice EV:DE da Sesión (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Velocidade media de baixada (Sesión): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Velocidade media de envío (Sesión): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Velocidade máxima de baixada (Sesión): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Velocidade máxima de envío (Sesión): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconexións: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tempo dende a primeira transferencia: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Inicio da conexión co servidor: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Conexións activas (estimadas): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Límite máximo de conexións acadado: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Media de conexións (estimado): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexións (estimado): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clientes"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Descoñecidos: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrados: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Vetados: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total:%i Coñecidos: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servidores activos: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servidores caídos: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servidores borrados: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servidores filtrados: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Usuarios en servidores activos: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Ficheiros nos servidores activos: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Usuarios totais: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Ficheiros totais: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupación do servidor: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de ficheiros compartidos: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Tamaño total dos ficheiros compartidos: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Tamaño medio de ficheiro: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema operativo"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Non recibido"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Conexións activas (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Non dispoñible"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nunca"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Comando «%s» con pid «%d» rematou con código de estado «%d»."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> e sae."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formato de IP inválido. Use xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Esta orde precisa dun parámetro. Parámetros válidos: «all», nome dun ficheiro ou un número.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Procesando por hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Procesando por nome de ficheiro: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Esta orde precisa dun parámetro. Parámetros válidos: un hash do ficheiro.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Non é un número válido\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Hash inválido (a lonxitude debería ser exactamente 32 caracteres)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7230,7 +7141,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7240,7 +7151,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7248,82 +7159,80 @@ msgstr ""
 "Tipo de busca non especificado.\n"
 "Escriba «help search» para obter máis axuda.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Descargar ficheiro: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "A petición fallou cun erro descoñecido."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "A operación tivo éxito."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "A petición fallou co seguinte erro: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "O filtrado de IP para clientes está %s\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Apagada"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Acendida"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "O filtrado de IP para servidores está %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "O nivel de filtrado de IP actual está %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Límites de ancho de banda: Subida: %u kB/s, Baixada: %u kB/s\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Conectado a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Conectando"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "tras unha devasa"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "correcto"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7332,7 +7241,7 @@ msgstr ""
 "\n"
 "Descargado: \t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7341,7 +7250,7 @@ msgstr ""
 "\n"
 "Enviado:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7350,7 +7259,7 @@ msgstr ""
 "\n"
 "Clientes en cola:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7359,46 +7268,46 @@ msgstr ""
 "\n"
 "Fontes totais:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartFile]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados na busca: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progreso da busca: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progreso da busca non dispoñible"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Recibida unha resposta descoñecida desde o servidor, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Mostrar información resumida do estado."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Mostrar estado de conexión, velocidade envío/descarga actual, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Mostrar árbore de estadísticas completa."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7412,11 +7321,11 @@ msgstr ""
 "\n"
 "Exemplo: «statistics 5» mostrará só as 5 versións que máis se repitan de calquer cliente.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Apagar o aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7426,35 +7335,35 @@ msgstr ""
 "Isto apagará tamén o cliente en modo texto, xa que non se pode\n"
 "empregar sen un núcleo en funcionamento.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recargar o obxecto dado."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recarga a lista de ficheiros compartidos."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recargar a táboa de filtrado de IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Recargar a táboa de filtrado IP actual."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Recargar a táboa de filtrado de IP dende URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Se se omite a URL usarase a especificada na configuración."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Conectar á rede."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7466,35 +7375,35 @@ msgstr ""
 "conectar a ese servidor soamente. A IP debe ser un enderezo IPv4,\n"
 "ou un nome DNS válido."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Conectar só a eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Conectar só a Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desconectar da rede."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Isto desconectaralle de todas as redes nas que está actualmente conectado.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desconectar só do eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desconectar só de Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Engadir unha ligazón eD2k ou unha ligazón magnet ó núcleo."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7512,51 +7421,51 @@ msgstr ""
 "\n"
 "A ligazón magnet debe conter o hash eD2k e a lonxitude do ficheiro.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Establecer un valor de preferencia."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Establecer opcións do filtrado de IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activar o filtrado de IP para clientes e servidores."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Desactivar o filtrado de IP para clientes e servidores."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activar/Desactivar filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activar filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Desactivar filtrado de IP para clientes."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activar/Desactivar filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activar filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Desactivar filtrado de IP para servidores."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Seleccionar nivel de filtrado de IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7564,73 +7473,73 @@ msgstr ""
 "Os niveis de filtrado válidos son un número de entre 0 e 255, e o valor por omisión (inicial)\n"
 "é 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Establecer límite de ancho de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "O valor dado a estas ordes ha de ser en kilobytes/s\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Establecer límite de ancho de banda na subida."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "O valor dado a estas ordes ha ser en kilobytes/sec.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Establece o límite de ancho de banda na descarga."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "O valor dado a estas ordes ha ser en kilobytes/sec.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obter e mostrar un valor das preferencias."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obter opcións de filtrado de IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obter o estado do filtro de IP para clientes e servidores."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obter o estado do filtro de IP só para clientes."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obter o estado do filtro de IP só para servidores."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Seleccionar nivel de filtrado de IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obter límite de ancho de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Facer unha busca."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7664,44 +7573,44 @@ msgstr ""
 "Por exemplo: «search global linux iso --type Iso --min-size 100M» devolverá os\n"
 "resultados para «linux iso», de tipo Iso e de máis de 100 MiB.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Executar unha busca global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Executar unha busca local"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Executar unha busca de kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Mostrar os resultados da última busca."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Mostrar o progreso dunha procura."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Comezar descargando un ficheiro"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7709,80 +7618,80 @@ msgstr ""
 "Tense que dar o número dun ficheiro da última busca.\n"
 "Exemplo: «download 12» iniciará a descarga do ficheiro co número 12 da busca a busca anterior.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Parar descarga."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Continuar descarga."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Cancelar descarga."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Establecer a prioridade da descarga."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Establecer a prioridade dunha descarga a Baixa, Normal, Alta ou Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Establecer a prioridade a baixa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Establecer a prioridade a normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Establecer a prioridade a alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Establecer a prioridade a auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Mostrar colas/listas."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Mostrar cola subida/descarga, lista de servidores ou lista de ficheiro compartidos.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostrar cola de subida."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostrar cola de descarga."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostrar rexistro."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostrar lista de servidores."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Recarga a lista de ficheiros compartidos."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Reiniciar rexistro."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Orde obsoleta, empregue «%s» no seu lugar."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7791,261 +7700,258 @@ msgstr ""
 "Esta orde quedou obsoleta e probablemente sexa eliminada nun futuro.\n"
 "Empregue «%s» no seu lugar.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Texto do cliente de aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convertendo conxuntos hash XICA[AICH] antigos en «%s» a 64b en «%s»."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVISO: O nome do ficheiro «%s» é inválido e foi cambiado a «%s»."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVISO: O ficheiro «%s» xa existe, o ficheiro novo foi chamado «%s»."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Está seguro de que quere cancelar e borrar todos os ficheiros desta categoría?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Precísase confirmación"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Só se permiten 99 categorías."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Demasiadas categorías!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "O resto"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Seleccione o filtro na vista"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Engadir categoría"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editar categoría"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Borrar categoría"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Pediuse un hashset para un ficheiro descoñecido: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Continuando enviando o ficheiro: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Interrompendo o envío do ficheiro: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Non se puido executar a orde `%s» no evento `%s»."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Descarga rematada"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "A ruta completa ao ficheiro."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "O nome do ficheiro sen a ruta."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "O hash eD2k do ficheiro."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "O tamaño do ficheiro en octetos."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tempo de actividade de descarga acumulado."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Comezada nova sesión da conversa"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remitente."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Sen espazo"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partición do disco."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Ocorreu un erro ao rematar"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Procesando número de ficheiro %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Pediu hashes das partes (Só usado en ficheiros > 9,5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Non existe o ficheiro !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, o creador de ligazóns eD2k do aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Benvido!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parámetros de entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Ficheiro do que facer un resumo criptográfico [Hash]"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Engadir URLs opcionais para este ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Introduza o ficheiro do cal desexa calcular a ligazón eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Introduza aquí a URL da cal desexa calcular a ligazón eD2k: Engada o carácter «/» ó final para permitirlle ao aLinkCreator engadir o nome do ficheiro actual"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Crear ligazón con hashes das partes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Axuda a espallar ficheiros novos e raros máis rápido, pero coa desvantaxe de ter unha ligazón máis grande"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Ficheiro Hash MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Hash do ficheiro eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "ligazón eD2K"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Gardar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiar ao portapapeis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Abrir un ficheiro para calcular a súa ligazón eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiar a ligazón eD2k calculada ó portapapeis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Gardar como"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Gardar a ligazón eD2k calculada nun ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Sobre o aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Selecciona o ficheiro do cal desexe calcular a ligazón eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Non se pode abrir o portapapeis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Non hai ren para copiar!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleccione o ficheiro para a ligazón eD2k calculada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Non se pode abrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Non introduza un nome de ficheiro baleiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Non hai ren para gardar!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8065,167 +7971,159 @@ msgstr ""
 "\n"
 "Distribuído baixo a licenza GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Facendo resumo criptográfico..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator traballa por tí"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calculando hash MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calculando hash eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Cancelado !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Rematou en %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Xa engadiras esta URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Non introduza unha URL baleira"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Non se pode abrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Esgotouse a memoria mentres se calculaba o hash eD2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i día(s) %i hora(s) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Estatísticas aMule en liña"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Máximo índice de DE desde que wxCas está executándose"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Máximo índice DE absoluto durante execucións anteriores de wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Restablecer"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Deter auto recargar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Gardar imaxe das estadísticas en liña"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimir imaxe das estadísticas en liña"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Preferencias"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Sobre wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Iniciar actualización automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Actualización automática detida"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Actualización automática iniciada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Gardar imaxe das estadísticas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estatísticas de aMule en liña"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8233,11 +8131,11 @@ msgstr ""
 "Houbo un problema imprimindo.\n"
 "Tal vez a súa impresora actual non está configurada?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8255,404 +8153,393 @@ msgstr ""
 "\n"
 "Distribuído baixo GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Vaites, non se está executando aMule..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule está iniciado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule estase executando, pero está desconectado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule estase a conectar..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Vaites, non se puido coñecer o estado de aMule..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " leva executándose "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " está detido !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " non está conectado!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " está conectandose..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " pasou algo estraño, compróbeo !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " está conectado a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "apagado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " conectado "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " con "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Total descargado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Enviado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Descargado na sesión: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Descargado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Enviado: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Compartindo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " ficheiro(s), Clientes en cola: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tempo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " en "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Media de carga do sistema (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Tempo de execución do sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Directorio que contén o ficheiro amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Introduza aquí o cartafol onde está o seu ficheiro amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervalo de actualización en segundos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Xerar un ficheiro de estadísticas sempre que se actualice"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Introduza aquí o directorio onde quere xerar a imaxe das estadísticas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Subir de cando en vez unha imaxe das estadísticas a un servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL do servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Ruta FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Introduza aquí a URL do seu servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Introduza aquí o directorio onde poñer a imaxe das estadísticas no servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Usuario"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Introduza aquí o nome de Usuario para conectarse ao servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Introduza aquí o contrasinal de Usuario para conectarse ao servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalo de actualización do FTP en minutos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "O cartafol que contén o seu ficheiro de sinatura"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Cartafol onde se xerará a imaxe das estatísticas"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Cargar modelo <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Porto HTTP do servidor Web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Uso da redirección de portos UPnP no porto do servidor web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Porto UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usar compresión gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Contrasinal de administrador para o servidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Contrasinal de invitado para o servidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permitir acceso de invitado"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Denegar acceso de invitado"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Cargar/gardar a configuración do servidor web dende/a un aMule remoto"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Ruta do ficheiro de configuración de aMule. NON USAR DIRECTAMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Desactivar intérprete PHP (obsoleto)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompilar as páxinas PHP en cada petición"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Servidor web de aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "conexión do cliente web aceptada\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERRO: non se poden aceptar conexións do cliente web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "A petición fallou co seguinte erro: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Ficheiro do rexistro non atopado: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesión expirada - pedindo conectarse \n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesión aceptada, conectado\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesión aceptada, non conectado\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ningunha sesión aberta - pedirase unha conexión\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sesión creada - pedindo conectarse\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Procesando petición [orixinal]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Non se especificou contrasinal, non se permite a entrada."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Comprobando contrasinal\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Cómputo do contrasinal inválido\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Contrasinal aceptado\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Contrasinal erróneo\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Non introduciu ningún contrasinal. Non se pode usar un contrasinal en branco.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Solicitada desconexión\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Procesando solicitude [redirixida]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "Start aMule when I log in"
 msgstr "Arrancar aMule automaticamente ao iniciar sesión"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "Uninstall"
 msgstr "Continuar"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Non se puido integrar aMule"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -21,26 +21,26 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "אודות wxCas"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "אימיול שלט רחוק"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "צילום:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,77 +49,77 @@ msgstr ""
 "זכוייות יוצרים (C) 2003-2019 צוות אימיול \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "קאדימליה: תקשורת עמית לעמית מנותבת המבוסס על ה XOR המטרי.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "מתחבר לקאד..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "לא זמין"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "הוסף חבר"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "הזנת כתובת IP ומבואה תקינים!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "מידע"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "גיבוב-המשתמש הספציפי אינו תקף!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -128,48 +128,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "התחברות נכשלה "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -178,177 +177,170 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "פתיחת הקובץ %s·(%s נכשלה"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "נכשל"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "הורדה הסתיימה"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "מידע"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "אישרור יצאיה"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "אזהרה"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "אימיול פועל"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -358,271 +350,267 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "תרגיש חופשי לדוואח על כל שגיאה ל https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "שגיאה: לא יכול לפתוח קובץ יומן."
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "היומן אופס."
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "עם מ\"ז נמוך (LowID)"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "עם מ\"ז גבוהה (HighID)"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "קאד התחיל."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "קאד נעצר."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "קאד מחובר (בסדר)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "מנותק מקאד."
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "אי אפשר להשתמש ברשת הקאד אם מוואת UDP מבוטלת בהעדפות, לא התחיל."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "קאד מבוטל בהעדפות, לא מתחבר."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "אירעה שגיאה: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "העדפות"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -632,194 +620,187 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "אֵימיול"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "שגיאה סופנית: יצירת קוצב-זמן נכשלה"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "התחבר לאימיול מרוחק"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "החיבור אבד."
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -828,1220 +809,1193 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "שגיאה סופנית: יצירת קוצב-זמן נכשלה"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "מנסה לשחזר את המידע של הקובץ"
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "מתחבר"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "פג הזמן עבור ניסיון ההתחברות ל %s·(%s:%i)"
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "התחבר לרשת."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "הכול"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "לא זמין"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "קובץ לא נמצא."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "לא ידוע"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr "(חיקוי אימיול בגרסת %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr "(חיקוי אימיול)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "אקס-מיול (חיקוי אימיול)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.איקס (מבוסס על אימיול בגרסת 0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "כינוי:%s מ\"ז: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "בוּקַש: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "בקשה עבור קובץ לא ידוע"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "סוננה הודעה מ '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "הודעה חדשה מ '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך בתקייה %s -> נדחה"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "אזהרה: לא ניתן לפתוח את הקובץ known.met."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "אזהרה: רשימת הקבצים-המכורים פגומה, מכילה כותר פגום."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "שגיאת קריאה/כתיבה תוך כדי הקובץ known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "שגיאה במהלך שמירת הקובץ known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "קטיגוריה"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "הוסף לחברים"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "מ\"ז נמוך (LowID)"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "מ\"ז גבוה (HighID)"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "מחובר"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "מנותק"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך -> אושר"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך -> נדחה"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "המשתמש %s (%u) ביקש את רשימת התקיות המשותפים שלך -> אושר"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "המשתמש %s (%u) ביקש את רשימת התקיות המשותפים שלך -> נדחה"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך בתקיה %s -> אושר"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך בתקייה %s -> נדחה"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "משתמש %s·(%u) משתף את התקייה %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "משתמש %s·(%u) שלח רשימת תקיות משותף בלי שהתבקש."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "משתמש %s (%u) שלח רשימה של קבצים משותפים עבור הספריה %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "משתמש %s (%u) סיים לשלוח את רשימת הקבצים המשותפים"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "משתמש %s·(%u) שלח רשימה של קבצים משותפים מבלי שהתבקש"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "משתמש %s (%u) שלל גישה לרשימת הקבצים/תקיות שלו"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "הערות על הקובץ"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "שם משתמש"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "דרוג"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "הערה"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "לא יכול להתבצע חיפוש באמצעות קאד אם קאד לא פועל"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "אין הערות"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u הערה"
 msgstr[1] "%u הערה"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "CIP2Country::CIP2Country(): לא הצליח לטעון מידע עבור המדינה מ "
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "אוטומטי [נמוך]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "אוטומטי [לא]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "אוטומטי [גבוה]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "גבוה"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "מאוד גבוה"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "שחרור"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "מבקש"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "מתחבר דרך השרת"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "התור מלא"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "על התור"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "מוריד מהרשת"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "מקבל קבוצת גיבובים"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "אין חלקים נדרשים"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "לא יכול לחבר מ\"ז נמוך (LowID) למ\"ז נמוך (LowID)"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "יותר מדי חיבורים"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "מחתבר באמצעות קאד"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "יותר מדי חיבורי קאד"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "חסום"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "שגיאת התחברות"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "התור המרוחק מלא"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "חמורML ישן"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "חמורML חדש"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "תואם אִימיול"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "שרת מקומי"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "קאד"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "החלפת מקורות"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "פאסיבי"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "קישור"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "מזריעי מקורות"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "הסתיים"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "בתהליך"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "נגמר המקום"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "נכנס לתור"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "כבר מוריד"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "פורמט הקובץ הזמני לא מוכר או  פגום"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "הועברו"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "מהירות"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "התקדמות"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "מקורות"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "עדיפות"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "מצב"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "זמן שנשאר"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "פעם אחרונה שנראה שלם"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "פעם אחרונה שנתקבל"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "האם אתה בטוח שברצונך למחוק את הקובץ שנבחר?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "האם אתה בטוח שברצונל ךמחוק את הקבצים שנבחרו?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "אוטמטי"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&עצור"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&השהה"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&המשך"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "נ&קה מה שהסתיים"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "החלף כל A4AF לקובץ הזה עכשיו"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "החלף כל A4AF לקובץ הזה (אוטומטי)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "החלף את כל ה A4AF לכל קובץ אחר, עכשיו"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "אפשרויות מורחבות"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "תקדימון"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "הראה &פרטי קבצים"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "הראה את כל ההערות"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "העתק מגנט URI ללוח"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "העתק משוב ללוח"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "לא מיוחס"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "ייחס לקטיגוריה"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&תפתח את הקובץ"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "הכנס שם חדש עבור קובץ זה"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "שינוי שם לקובץ"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f מ\"ב"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d·%H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "הורדות (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "תקדימון לקובץ"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "שגיאה: הרצת נגן הסרטים נכשלה! הפקודה: '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "טוען מידע מקובץ הורדות ישן (%u·מ·%u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "לא נמצא קובץ-חלקים."
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "נמצא %u קובץ-חלקים"
 msgstr[1] "נמצא %u קובץ-חלקים"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "מוריד %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "אתה כבר מנסה להוריד את הקובץ '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "כבר יש לך את הקובץ '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "כבר יש לך את הקובץ '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "פרוטקול לא ידוע עבור קישור: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "גישה חיצונית מנוטרלת מאחר שהסיסמא ריקה!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "גישה מרוחקת מנוטרלת בקובץ ההגדרות"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "גישה מרחוק נכשלה עקב סיסמא ריקה בהעדפות!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "מחבר לקוח:%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "גירסה לא ידועה"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "גירסת EC לא נכונה, יתכן ויש אי התאמה בינארית. השתמש בליבה ובלקוח חיצוני מאותו תצלום (גירסה)."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "אתה לא להתחבר לגרסה ששוחררה מSVN (כלי לניהול גרסאות תוכנה) ! *נאנח* ייתכן והתרסקות של התוכנה נמנעה"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "חסר התווית של גרסת הפרוטוקול."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "זיהוי נכשל"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "בקשה לא תקפה, כדאי שקודם תאמת."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "גישה אושרה."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "ניסיון גישה שאינו מורשה. החיבור נסגר."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "פקודת קובץ-חלקים מרוחקת מכשלה: גיבוב הקובץ לא נמצא: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "גיבוב הקובץ לא מצא: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "אופס! שגיאה בעיבוד קוד-פעולה!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "השרת לא התווסף"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "לא נמצא השרת: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "צריך להגדיר שרת כדי להסירו"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "לא הגיוני לבצע חיפוש-רשתי מתוך ממשק מרוחק."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "חיפוש פועל כרגע. ייבא מחדש תוצאות בעוד רגע!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "אין נקודות עבור הגרף."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "הלקוח שלך אינו מוגדר עבור הרמה הזאת של פרטים."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "כבר בתהליך כיבוי."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "חיבור-חיצוני: מוסיף קישור '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "קובץ לא נמצא."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "שם קובץ לא תכף."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "לא מצליח לשנות את השם של הקובץ."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "קאד מנוטרל בתוך ההעדפות."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "כבר מחובר לקאד."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "מתחבר לקאד..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "מתנתק מקאד."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "קוד-פעולה לא תקף (גרסת פרוטקול שגויה?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2049,23 +2003,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2073,59 +2027,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2134,331 +2088,326 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "פרטי הקובץ"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% הושלם"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f ק\"ב/ש"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "ברוכים הבאים!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "מחובר לחבר"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "מצב חיבור:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "רשתות"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "קבצים זמניים"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "דפדף"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "חברים"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "הצג &פרטים"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "הוסף חבר"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "הסר חבר"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "שלך &הודעה"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "הצג קבצים"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "הוקמה משבצת \"חבר\""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "האם אתה בטוח שאתה רוצה להסיר את החבר שבחרת?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "האם אתה בטוח שאתה רוצה להסיר את החברים שבחרת?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2466,11 +2415,11 @@ msgstr ""
 "אתה לא רשאי להגידר יותר ממשצת \"חבר\" אחת.\n"
 "רק משבצת אחת הוגדרה."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "בחירה מרובה."
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2479,2347 +2428,2310 @@ msgstr ""
 "אתה לא רשאי להגידר יותר ממשצת \"חבר\" אחת.\n"
 "רק משבצת אחת הוגדרה."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "שלח הודעה למשתמש"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "הודה שתשלח:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "הסר מחברים"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "שלך הודעה"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "החלף לקובץ זה"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR:·%u·(%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "התקבלה בקשה עבור קובץ אחר"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "העלאות בהמתנה: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "על התור"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "ההעלאות"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "כן"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "מוריד מהרשת..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "מוריד %s"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "הורדות (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "פתיחת הקובץ %s·(%s נכשלה"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "פתיחת הקובץ %s·(%s נכשלה"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "טוען את מסנני ה IP 'ipfilter.dat' ואת 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "טעינת קובץ מסננים עם סיומת '.dat' '%s', נכשלה. פורמט הקובץ לא ידוע."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "טעינת קובץ מסננים עם סיומת '.dat' '%s', נכשלה. לא ניתן לפתוח את הקובץ."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "טוען %u טווח - IP מ '%s'."
 msgstr[1] "טוען %u טווח - IP מ '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "נזרקה השורה המעוותת %u"
 msgstr[1] "נזרקה השורה המעוותת %u"
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "צמתים (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "כתובת IP לא חוקית על מנת לבצע אתחול"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "מבואה לא תקפה על מנת לבצע אתחול"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "אנא מלא את כל השדות כפי שנדרש"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "הודעה"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "האם את בטוח שברצונח להוריד קובץ nodes.dat חדש?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "ביצוע פעולה זו תסיר את כל הצמתים הקחחצחם ןתאתחל את חיבור הקאדימליה."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "להמשיך?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "קאדימליה: מילת חיפוש קצרה מדי"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, fuzzy, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "קרא %u יוצרי קשר ל קאד"
 msgstr[1] "קרא %u יוצרי קשר ל קאד"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "קאד התחיל."
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "שם הקובץ"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "גירסה לא ידועה"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "אזהרה: לא ניתן לפתוח את קובץ הסקין '%s' לקריאה"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "מגבב"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "מסיים"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "סיים"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "הושהה"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "שגוי"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "ממתין"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "אתה חייב לציין סיסמא שאינה רקה."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "סיסמא לא תקינה היא איננה מגובבת בפורמט MD5"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "החיבור נכשל"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "ExternalConn: (התחברות חיצונית) תשובה לא טובה מהשרת. החיבור נסגר. ."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "הצלחה!נפתח חיבור ל aMule."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "הצלחה!נפתח חיבור ."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "סגור"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "גזור"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "העתק"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "הדבק"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "נקה"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "בחר הכל"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "מחובר"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "מחובר"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " קאד: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "קאד מחובר (מאחורי חומת אש)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "שרת"
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "כתובת IP של השרת:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "לא מחובר"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "יציאה"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "ק\"ב/ש"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "מהירות הורדה"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "מהירות-העלאה"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "מנותק"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "זמן פעולה: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "מוסיף קישור ed2k או מגנט לליבה."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "הוסף לחברים"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "ארועים מופיעים כאן. בשביל רשימת האירועים המלאה, הסתכלו ביומן שבלשונית השרתים."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "טוען ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "מספר המשתמשים בשרת שאיליו התחברת ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "משתמשים: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "משתמשים שמחוברים לשרת הנוכחי ומספר מעורך של כלל המשתמשים."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "מעלה:0.0 | מוריד 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "הממוצע הנוכחי של קצב העלאה וההורדה. אם זה מאופשר, המספר שבסוגריים מסמנים את התקורה של התקשורת של הלקוח."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "מציג את מצב החיבורים וההעברות הפעילות. חץ אדום מסמן שאתה כרגע לחא מחובר, חץ צהוב מסמל שיש לך מ\"ז נמוך (LowID) (חסום חומתאש) וחץ ירוק מסמן שיש לך מ\"ז גבוהה (HighID) (תצורת החיבור האופטימלית)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "לא מחובר ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "שרת מחובר נוכחי."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "חיפוש"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "שם:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "סוג/טיפוס"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "מקומי"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "גלובלי"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "פרמטרים מורחבים"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "מסנן"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "סוג קובץ"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "כל דבר"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "ארכיבים"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "אודיו"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "אימג' של סי.די."
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "תמונות"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "תוכניות"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "טקסט"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "סרטים"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "סיומת"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "גודל מנימלי"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "בתים"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "ק\"ב"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "מ\"ב"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "ג\"ב"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "גודל מקסימלי"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "זמינות"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "מסנן:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "תוצאות מסנן"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "הפוך תוצאות"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "החבא קבצים מוכרים"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "התחל"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "עוד"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "עצור"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "הורדה"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "אפס שדות"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "תוצאות"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "מנקה הורדות שהושלמו"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "מקורות שנמצאו :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "ל\"ת"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "כללי"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "שם מלא :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "קובץ-met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "גיבוב :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "גודל קובץ :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "מעביר"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "מצב קובץ-חלקים :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "נראה שלם בפעם האחרונה :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "מקורות שנמצאו :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "מעביר מקורות :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "ספירת קובץ-חלקים :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "זמין :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "זמן הורדה פעיל: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "הועבר :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "כמות שהושלמה :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "תפעול מתוחכם של פגמים"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "אבד עקב פגם :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "רווח באמצעות כיווץ :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "חבילות שנשמרו ע\"י I.C.H.·:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "משתף: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "בקשות"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "בקשות שהתקבלו"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "מידע שנשנלח"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "יחס שיתוף"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "מקורות שלמים"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", הועלה: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "לא מדורג"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "שמות קבצים"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "השתלטות"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "ניקוי"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "ישם"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "תגיב/תדרג קובץ (הטקבט יהיה זמין לכל המשתמשים)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "איכות הקובץ"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "לא מדורג"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "לא תקף / פגום / מזויף"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "דל"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "ממוצע"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "טוב"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "מצויין"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "תבחר את דרוג הקובץ או תתריע למשתמשים אם הקובץ אינו תקף ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "מנותק מקאד."
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "רענן"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "מוריד, אנא המתן ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "גודל לא ידוע"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "נדרש מידע"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "כתובת IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "מבואה :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "מידע נוסף"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "שם משתמש :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "הוסף"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "מהירות-העלאה"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "עץ סטטיסטיקה"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "שם משתמש:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "גיבוב קובץ:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "תוכנת לקוח:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "גרסת לקוח:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "כתובת IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "מ\"ז משתמש:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "כתובת IP של השרת:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "שם שרת:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "העברות ללקוח"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "בקשה נוכחית:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "קצב העלאה ממוצע:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "קצב הורדה ממוצע:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "הועלה (הרצה נוכחית):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "ירד (הרצה נוכחית):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "הועלה (סה\"כ):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "ירד (סה\"כ):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "ציונים"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "נכנס לתור"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "ההעלאות"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "הסר"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "מנע גישה מאורחים"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4827,11 +4739,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4841,853 +4753,853 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "נוטרל [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "בית"
 msgstr[1] "בית"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "ק\"ב"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "ט\"ב"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "קילו"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "מגה"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "גיגה"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "טרה"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "בייט/שניה"
 msgstr[1] "בייט/שניה"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "שניות"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "דקות"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "שעות"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "ימים"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "הכול"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "כל האחרים"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "חלקי"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "נעצר"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "ווידאו"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "ארכיב"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "טקסט"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "פןעל"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "מייבא %s:·%s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "מחלץ מידע בסיסי מקובץ מידע ההורדות"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "יוצר קובץ יעד"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "טוען מידע מקובץ הורדות ישן (%u·מ·%u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "שומר את בלוק המידע לתוך קובץ הורדות יחיד (%u·מ·%u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "מחלץ את מידע הקובץ-המורד מהמקור"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "מוסיף הורדה ושומר קובץ-חלקים"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "ייבא קבצי-חלקים"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "מצב"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "גיבוב-קובץ"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (דיסק: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "נא לבחור תקייה לחפש קבצים זמניים שהורדו! (תתי תיקיות יכללו בחיפוש)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "האם אתה רוצה שקבצי המקורות של הורדות מוצלחות שיובאו, ימחקו?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "הסר מקור?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "שגיאה: יצירת קובץ-החלקים נכשלה)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "מנסה לטעון גיבוי של קובץ ה met מ %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "שגיאה: %s (%s) פגום (מספר-תווית שגוי) לא יכול לטעון קובץ."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "מנסה לשחזר את המידע של הקובץ"
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "משחזר קובץ ללא שם - אנסה לשחזר את זה בתור RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "כל המידע הנגיש על הקבצים שוחזר :-) - מנסה להשתמש בזה..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "לא ניתן לשחזר את המידע אודות הקובץ :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "פתיחת הקובץ %s·(%s נכשלה"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "שגיאה במהלך השמירה של קובץ-החלקים %s (%s·==>·%s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "שגיאה במהלך השמירה של קובץ-החלקים %s (%s·==>·%s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "שמירת part.met.seeds נכשלה עבור הקובץ %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "נשמרו %i מקורות הזרעה עהור קובץ-החלקים: %s (%s)"
 msgstr[1] "נשמרו %i מקורות הזרעה עהור קובץ-החלקים: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "נשמרו %i מקורות הזרעה עהור קובץ-החלקים: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "שגיאה בקריאת קובץ ההזרעה של קובץ החלקים (%s·-·%s):·%s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "נמצא חלק שהושלם (%i) בתוך %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "הסתיים הגיבוב מחדש של %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "הסתיימה ההורדה של: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "הסתיימה ההורדה של: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "מוחק את הקובץ: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "אזהרה. אין מספיק שטח דיסק פנוי! משהה את הקובץ %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "החלק %i שירד מתוך הקובץ %s פגום"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: תוקן החלק הפגום %i עבור %s -< בתים שנמשרו: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "חיבור"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "מלונים"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "שרתים"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "קבצים"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "אבטחה"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "פרוקסי"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "שליטה מרחוק"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "ארועים"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "ניפוי שגיאות"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5697,35 +5609,35 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "בודק סיסמא\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5733,51 +5645,51 @@ msgstr ""
 "אימיול חייב להיות מאותחל מחדש על מנת לאפשר את השינויים הללו:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- מבואת TCP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "חיבור חיצוני נסגר."
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5785,40 +5697,40 @@ msgstr ""
 "אתה אפשרת חיבוריים חיצוניים אבל לא הזנת סיסמא תקיפה.\n"
 "חיבורים חיצוניים לא יאופשרו אלא אם כן תוזן סיסמא תקיפה."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- השפה שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- הפסרייה הזמנית שונתה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "כל הרשתות מנוטרלות."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "גרסת פרוטוקל לא תקפה."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5826,7 +5738,7 @@ msgstr ""
 "קאד לא יתחיל אם מבואת ה UDB מנוטרלת.\n"
 "תאפשר את מבואת ה UDP או שתנטרל את קאד."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5836,69 +5748,69 @@ msgstr ""
 "אתה חייב לאתחל את אימיול עכשיו!\n"
 "אם לא תאתחל את אימיול עכשיו אל תתלונן אם משהו רע יקרה.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "גישה חיצונית חדשה התקבלה"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5908,66 +5820,66 @@ msgstr ""
 "בבקשה תכניס לפחות כתובת URL אחת שתצביע לקובץ server.met תקף.\n"
 "לחץ על הכפתור \"רשימה\" שליד הצ'קבוקס הזה כדי להכניס בתובת URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "קבצים זמניים"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "קבצים נכנסים"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "חתימה מקוונת"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "בחר תיקייה עבור %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "חפש נגן סרטים"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "בחר דפדפן"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "קובץ הרצה %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5975,1225 +5887,1224 @@ msgstr ""
 "הוסף כאן כתובות URL שמהם ניתן להוריד קבצי server.met.\n"
 "רק כתובת אחת בכל שורה."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "מקורות שלמים"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "סטאטוס:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "השהיית עדון: %d שניות"
 msgstr[1] "השהיית עדון: %d שניות"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "זמן עבור גרף הממוצע: %d דקות"
 msgstr[1] "זמן עבור גרף הממוצע: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "סקאלאת גרף החיבורים: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "גודל זיכרון זמני לקובץ: %d בתים"
 msgstr[1] "גודל זיכרון זמני לקובץ: %d בתים"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "גודל תור ההאלעות: %d לקוחות"
 msgstr[1] "גודל תור ההאלעות: %d לקוחות"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "רענון חיבור לשרת כל: %d דקות"
 msgstr[1] "רענון חיבור לשרת כל: %d דקות"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "רענון חיבור לשרת: מנוטרל"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "נוטרל [%s]"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "בצע פקודה בעת ארוע '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "אפשר הרצת פקודות על הליבה"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "פקודת ליבה:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "אפשר ביצוע פקודות על ממשק גרפי"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "פקודת ממשק גרפי:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "המשתנים הבאים יוחלפו:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "קורא את הספרייה הזמנית"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "קבצים משותפים"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "ראשי"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "שגיאה לא צפויה בעת ניסיון ביצוע חיפוש ב קאד: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "מ\"ז של קובץ"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "לא מדורג"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "הורדה בקטיגוריה"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "סמן בתור קובץ מוכר"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "ביטול"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "החיבור לשרתים המבלבלים שברשימה כשל, מבצע מעבר נוסף ללא השרתים המבלבלים"
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "החיבור לשרתים המבלבלים שברשימה כשל, מבצע מעבר נוסף ללא השרתים המבלבלים"
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "ההתחברות לכל השרתים הרשומים כשלה, מבצע מעבר נוסף."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "ההתחברות לכל השרתים הרשומים כשלה, מבצע מעבר נוסף."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "מחובר ל %s·(%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "חיבור הוקם ל: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "כשל חמור בעת הניסיון להתחבר. יתכן והתקשורת למרשתת לא מקוונת."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "אבד התקשורת ל %s·(%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "נראה כאלו ש %s·(%s:%i) מת."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "נראה כאלו ש %s·(%s:%i) מלא."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
 msgstr[1] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "ההתחברות ל %s·(%s:%i) כשלה"
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "פג הזמן עבור ניסיון ההתחברות ל %s·(%s:%i)"
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "שגיאת קריאה/כתיבה תוך כדי הקובץ known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "נכשל בפתיחת '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "הסתיימה ההורדה של: %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "שם שרת"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "כתובת"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "מבואה"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "תיאור"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "פינג"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "משתמשים"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "קבוע"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "גירסא"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "אתה מחובר לשרת אותו אתה מנסה למחוק. בבקשה קודםתתנתק. השרת לא נמחק!"
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(שם לא ידוע)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "האם אתה בטוח שאתה רוצה למחוק את השרת הקבוע %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "שרתים (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "שרת"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "מחובר לשרת"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "סמן שרת בתור קבוע"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "סמן שרת בתור לא קבוע"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "סמן שרתים בתור קבועים"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "סמן שרתים בתור כאלה שאינם קבועים"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "הסר שרת"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "הסר שרתים"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "הסר את כל השרתים"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "התחבר מחדש לשרת"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "האם אתה בטוח שאתה מעוניין למחוק את כל השרתים?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "האם אתה בטוח שאתה מעוניין למחוק את כל השרת המסומן?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "האם אתה בטוח שאתה מעוניין למחוק את כל השרתים המסומנים?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "מ\"ז החדש ללקוח הוא %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "אזהרה: קיבלת מ\"ז נמוך (Low-ID)!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t רוב הסיכויים שזה מאחר ואתה נמצא מאחור חומתאש או נתב."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "התקבל מידע על שרת, שהמידע לא ידוע! - קצר מדי"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "התקבל %d שרת חדש"
 msgstr[1] "התקבל %d שרת חדש"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "שמירת רשימת השרתים הסתיימה."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "השרת דחה את הפקודה האחרונה."
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "חבילה מדומה התקבלב משרת: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "שגיה לא מטופלת בעת עיבוד החבילה שתקלה מהשרת: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "לא יכול ליצור תהליכון לפענוח ה DNS כדי להתחבר ל %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "כתובת ה IP ak var, %s·(%s) מסוננת,  לא מתחבר."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "משתמש בערפול פרוטקול."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "מחבר ל %s·(%s·-·%s:%i)·%s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "לא יכול לפענח כתובת השרת של %s באמצעות DNS: לא יכול להתחבר!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "אֵימיול "
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "שרת לא התווסף: לא צויין שם שרת או כתובת אי.פי."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "שרת לא התווסף: צוינה מבואה לא תקפה."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "מ\"ז"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "מצב חיבור:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "מחובר"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "סטטוס קאדימליה:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "פועל על %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "פועל"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "סטטוס קאדימליה:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "סטאטוס:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "מצב חיבור:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "מצב חיבור:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "מצב חומת אש: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "אין חבר"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "מחובר לחבר"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "מחובר לחבר"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "מקורות שנמצאו :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "קובץ האינדקס לא נמצא"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "ממוצע משתמשים:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "ממוצע קבצים:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "לא פועל"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
 msgstr[1] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "לא נמצא השרת: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "שם משתמש"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "מהירות הורדה"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "מהירות-העלאה"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "זמין :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "ההעלאות"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Download Status"
 msgstr "הורדות"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "שם קובץ"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "קבצים משותפים"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "חלקים שהושגו"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "נתיב תיקייה"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "הוסף תגובה/דירוג"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "ערוך תגובה/דירוג"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "שנה שם"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "הוסף קבצים שבאסופה לרשימת המשלוח"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "העתק מגנט &URI ללוח"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "העתק קישור ED2k ללוח (מידע &AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "אתה צריך מ\"ז גבוה (HighID) כדי לחןר קישור-מקור תקף"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "שם קובץ"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "מידע שהועלה (התחברות נוכחית(סכום כולל)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "סכום כולל של התקורה (חבילות): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "תקורת בקשות קבצים (חבילות): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "תקורת החלפת מקורות (חבילות): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "תקורת השרת (חבילות): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "תקורת קאד (חבילות): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "האלעות פעילות: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "העלאות בהמתנה: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "סכום כולל של האלעות מוצלחות: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "סכות כולל של העלאות שנשכשלו: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "זמן האלעה ממוצע: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "הורדת מידע (התחברות נוכחית (סכום כולל)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "מקורות שנמצאו: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "הורדות פעילות (נתחים): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "יחס העלאה:הורדה בהתחברות נוכחית (סכום כולל): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "התחברויות מחדש: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "זמן מאז העברה הראשונה: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "מחובר לשרת מאז: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "חיבורים פעילים (משוער): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "גבול מקסימלי של התחברויות הושג: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "חיבורים בממוצע (משוער): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "שיא החיבורים (משוער): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "לקוחות"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "גודל לא ידוע"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "מסוננים"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "חסום"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "סכום כולל: %i מוכר: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "שרתים פעילים: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "שרתים שנכשלו: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "סכום כולל: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "שרתים שנמחקו: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "שרתים שסוננו: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "משתמשים על שרתים פעילים: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "קבצים על שרתים פעילים: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "סכום כולל של משתמשים: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "סכום כולל של קבצים: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "תעסוקת שרתים: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "מספר קבצים משותפים: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "גודל כולל של קבצים משותפים: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "מערכת הפעלה"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "לא התקבל"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "כישורים פעילים (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "לא זמין"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "אף פעם"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "פקודת '%s עם pid '%d' סיים עם קוד סטטוס '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "הרץ <str> וצא."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "פורמט IP לא חוקי. התמש ב xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "הפקודה הזאת דורשת ארגומנט. ארגומנט חוקי יכול להיות: 'all' שם קובץ או מספר.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "מעבד על פי גיבוב: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "מעבד על פי שם קובץ: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "פקודה זאת דורשת ארגומנט. ארגומנט חוקי: גיבוב של קובץ.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "לא מספר חוקי\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "לא גיבוב חוקי (האורך חייב להיות בדיוק 32 תווים)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7201,7 +7112,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7209,88 +7120,86 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "הורדות (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "הבקשה נכשלה עם שגיאה לא ידועה"
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "הפעולה הסתיימה בהצלחה."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "הבקשה נכשלה עם השגיאה הבאה: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "סינון IP עבור לקוחות הוא %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "מכובה"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "דלוק"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "סינון IP עבור שרתים הוא %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "רמת סינום IP נוכחית היא %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "מחובר ל %s·%s·%s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "מתחבר עכשיו"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "חסום-חומתאש"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "בסדר"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7299,7 +7208,7 @@ msgstr ""
 "\n"
 "הורדה:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7308,7 +7217,7 @@ msgstr ""
 "\n"
 "העלאה:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7317,7 +7226,7 @@ msgstr ""
 "\n"
 "לקוחות בתור:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7326,46 +7235,46 @@ msgstr ""
 "\n"
 "סה\"כ מקורות:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[קובץ-חלקים]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "מספר תוצאות חיפוש: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "התקבלה תשובה לא מוכרת מהשרת, קוד-פעולה = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "הראה מידעה על מצב בקיצור."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "הראה מצב חיבורים, מהירות הורדה/האלכה נוכחיים וכו'.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "הראה את עץ הסטטיסטיקה המלא."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7379,51 +7288,51 @@ msgstr ""
 "\n"
 "דוגמא: 'statistics·5' יראה רק את חמשת הגרסאות הראשונים עבור כל סוג לקוח.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "טוען מחדש את האובייקט הנתון."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "טוען מחדש את טבלת סינון ה IP מהקובץ."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "בחר את אמת סינון הIP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "טוען מחדש את טבלת סינון ה IP מהקובץ."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "התחבר לרשת."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7435,36 +7344,36 @@ msgstr ""
 "שרת זה בלבד. ה IP חייב להיות ארבעה מספרים מופרדים בנקודות בפורמט IPv4, \n"
 "או שם שרת שניתן להמירו ל IP."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "התחבר רק לקאד."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "התנתק מהרשת."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "פעולה זו תנתק את כל הרשתות המחוברות.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "התנתק רק מ קאד."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "מוסיף קישור ed2k או מגנט לליבה."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7475,52 +7384,52 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "הגדר ערך מועדף."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "הגדר העדפת מסנן IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "הדלק סינון IP הן עבור הלקוחות והן עבור השרתים."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "כבה סינון IP הן עבור הלקוחות והן עבור השרתים."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "אפשר/נטרל סינון IP עבור לקוחות."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "הדלק סינון IP עבור לקוחות."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "כבה סינון IP עבור לקוחות."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "אפשר/נטרל סינון IP עבור שרתים."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "הדלק סינון IP עבור שרתים."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "כבה סינון IP עבור שרתים."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "בחר את אמת סינון הIP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7528,79 +7437,79 @@ msgstr ""
 "רמות סינון תקפים המ בתווך של 0-255, ברירת המחדשל (ערך התחלתי)\n"
 "הוא 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "קבע תיחום רוחב פס."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "הערך שמועבר לפקודות אלו חייב להיות ביחידות של ק\"ב/ש.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "קבע מגבלת רוחב פס בהעלאה."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "הערך שמועבר לפקודות אלו חייב להיות ביחידות של ק\"ב/ש.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "קבע מגבלת רוחב פס בהורדה."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "הערך שמועבר לפקודות אלו חייב להיות ביחידות של ק\"ב/ש.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "שלוף ותציג ערך של העדפה."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "שלוף העדפה עבור סינון IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "שלוף העדפה עבור סינון IP עבור השרתים והלקוחות."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "שלוף העדפה עבור סינון IP רק עבור הלקוחות."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "שלוף העדפה עבור סינון IP רק עבור השרתים."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "בחר את אמת סינון הIP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "שלוף הגבלת רוחב הפס."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "הרץ חיפוש בקאדימליה"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7619,48 +7528,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "הרץ חיפוש גלובלי."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "הרץ חיפוש מקומי"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "הרץ חיפוש בקאדימליה"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "הראה את התוצאות של החיפוש האחרון."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "מראה את התקדמות החיפוש."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "התחל בהורדת קובץ"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7668,82 +7577,82 @@ msgstr ""
 "מספר הקובץ מהחיפוש האחרון חייב להמסר.\n"
 "דוגמה: 'download·12'· יתחיל להוריד את קובץ מספר 12 מהחיפוש האחרון.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "השהה הורדה."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "המשך הורדה."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "בטל הורדה."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "קבע את העדיפות של ההורדה."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "קבע את עדיפות ההורדה ל נמוך, נורמלי, גבוה או אוטומטי.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "קבע את העדיפות ל 'נמוך'."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "קבע את העדיפות ל 'נורמלי'."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "קבע את העדיפות ל 'גבוה'."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "קבע את העדיפות ל 'אוטומטי'."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "הראה תורים/רשימות."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "הראה תורים של הרודות/העלאות, רשימת שרתים או רשימת קבצים משותפים.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "הראה צור העלאות"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "הראה את תור ההורדות."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "הראה יומן."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "הראה את רשימת השרתים."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "אפס את הימון."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7752,262 +7661,259 @@ msgstr ""
 "זאת פקודה מיושנת ועלולה להתבטל בעתיד.\n"
 "השתמש ב '%s' במקומה.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "לקוח טסטואלי של אֵימיול"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "ממיר את קבוצת הגיבובים בפורמט AICH עבור '%s' ל 64b עבור '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "אזהרה: שם הקובץ '%s' אינו חוקי והוא נקרא מחדש בשם '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "אזהרה: הקובץ '%s' כבר קיים. שם הקובץ החדש שונה ל '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "האם אתה בטוח שברצונך לבטל ולמחוק את כל הקבצים שבקטגוריה זו?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "זקוק לאישור."
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "יותר מדי חיבורים"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "כל האחרים"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "בחר מסנן תצוגה"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "הוסף קטיגוריה"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "ערוך קטיגוריה"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "הסר קטיגוריה"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "התבקשה קבוצת הגיבובים של קובץ לא ידוע: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "ממשיך את העלאה של קובץ: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "משהה את העלאה של קובץ: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "הורדה הסתיימה"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "הנתיב המלא לקובץ"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "שם הקובץ ללא הנתיב."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "גודל הקובץ בבתים."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "זמן מצטבר של פעולת הורדה."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "צ'אט חדש החל."
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "שולח ההודעה"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "נגמר המקום"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "מחיצת דיסק."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "שגיאה בעת הסיום."
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "מעבד קובץ מס. %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "ביקשת גיבובים עבור חלקים (בשימוש רק עבור קבצים > 9.5 מ\"ב"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "קובץ %s אינו קיים!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "ברוכים הבאים!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "פרמטרים להזנה"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "גיבוב קובץ"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "צור קישור עם חלקי הגיבובים"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "עזור להפיץ קבצים חדשים ונדירים יותר מהר, במחיר קידור יותר גדול"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "קובץ גיבובי MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "שמור"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "העתק ללוח"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "אודות aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "אין שום דבר להעתיק נכון לעכשיו !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "לא הצליך לפתוח את "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "בבקשה תכניס שם קובץ שאינו ריק"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "שום דבר לשמור עכשיו !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8019,167 +7925,159 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "מגבב..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "בוטל !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "הסתיים ב %.2f שניות"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "כבר הוספת את כתובת URL הזאת !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "בבקשה תכניס כתובת URL שאינה ריקה"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "לא מצליח לפתוח את %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "ימים - %i, שעות -%i, דקות - %i, שניות - %i"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uימים %02uשעות %02uדקות %02uשניות"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uשעות %02uדקות %02uשניות"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02uדקות %02uשניות"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02uשניות"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f בתים"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f ק\"ב"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f מ\"ב"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f ג\"ב"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f ט\"ב"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "סטטיסטיקות מקוונות של אימיול - wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "קצב הורדה מקסימלי מאז ש wxCas החל לפעול"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "קצב הורדה מקסימלי אבסלוטי בעת הפעלות קודמות של wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "אתחל מחדש"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "מערכת"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "עצור רענון אוטומטי"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "שמור תמונה סטטיסטית מקוונת"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "הדפס תמונה סטטיסטית מקוונת"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "הגדרת העדפות"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "אודות wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "החל רענון אוטומטי"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "רענון אוטמטי נעצר"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "רענון אוטמטי התחיל"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "שמור תמונה סטטיסטית"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "סטטיסטיקות מקוונות של אימיול"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8187,11 +8085,11 @@ msgstr ""
 "ישנה בעייה בהדפסה.\n"
 "האם המדפסת הנוכחית שלך מוגדרת בצורה נכונה?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "מדפיס"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8208,403 +8106,392 @@ msgstr ""
 "\n"
 "מופץ תחת רשיון GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "או או.. אימיול לא פועל..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "אימיול פועל"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "אמיול פועל אך אינו מחובר"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "אימיול מתחבר..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "או או... המצב של אימיול אינו ידוע..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "אֵימיול "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " פועל במשך "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " הופסק !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " אינו מחובר !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " מתחבר..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " עושה משהו מוזר, תבדוק את זה!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " מחובר ל "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " קאד: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "מכובה"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " דלוק "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " עם "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "סכום כולל של הורדות: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", הועלה: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "הורד בהחתברות הנוכחית: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "מוריד: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " ק\"ב/ש, העלאה: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "משתף: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " קבצ(ים), לקוחות בתור: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "זמן: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " דלוק "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "עומס ממוצע של המערכת ( 1-5-15 דקות): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "משך הפעולה של המערכת:"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "תקיה המכילה את הקובץ amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "הכנס כאן את התקייה היכן שהקובץ amulesig.dat נמצא"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "קצב מרווח הרענון בשניות"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "צור תמונת סטאטוס בכל ארוע רענון"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "הכנס כאן את התקיה שבה אתה רוצה ליצור את תמונת הסטטוס"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "העלה בתקופתיות את תמונת הסטטוס לשרת FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "כתובת URL של FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "נתיב FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "הכנס כאן את כתובת ה URL של שרת ה FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "הכנס כאן את נתיב הספריה שבה אתה שם את תמונת הסטטוס על שרת ה FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "משתמש"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "הכנס כאן את שם המשתמש שאיתו תתחבר לשרת ה FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "הכנס את סיסמת הזיהוי להתחברות לשרת ה FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "קצב עדכון התקופתי של ה FTP בדקות"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "אַמת"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "תיקיה המכילה את קובץ החתימה שלך"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "תיקיה שבה יווצרו תמונות הסטאטוס"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "טוען תבנית<מחרוזת>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "מבואת UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "אפשר גישה לאורחים"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "מנע גישה מאורחים"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "נתיב קובץ ההגדרות של אימיול. לא לשימוש בצורה ישירה!!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "נטרל מפענח PHP (מיושן-מבוטל)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "הדר מחדש דפי PHP לאחר כל בקשה"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "שרת אימיול רשתי"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "הבקשה נכשלה עם השגיאות הבאות: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "קובץ האינדקס לא נמצא"
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "פג התוקף של החיבור - מבקש התחברות מחדש\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "התחברות הצליחה - מחובר\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "התחברות הצליחה, לא מזוהה\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "לא נפתחה התחברות - הולך לבקש להזדהות\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "נוצרה התחברות מבקש להזדהות\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "מעבד בקשה [מקורי]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "בודק סיסמא\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "גיבוב הסיסמא אינו תקף\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "הסיסמא בסדר\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "סיסמא שגויה\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "לא הזנת סיסמא. סיסמאות ריקות אינם קבילות.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "ב‏‎ֻקְשַה התנתקות\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "מעבד בקשה [הופנתה מחדש]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "התחברות נכשלה "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0beta1\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "O autoru:"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,76 +48,76 @@ msgstr ""
 "Autorsko pravo (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Autorsko pravo (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web stranica:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nije dostupno"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Dodaj prijatelja"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Ukucaj vazecu IP adresu i port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informacije"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -126,48 +126,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Neuspjelo povezivanje"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -176,176 +175,169 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Neuspjelo otvaranje %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Neuspjesno"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Potvrda izlaza"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "UPOZORENJE"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -355,271 +347,267 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo nikakvu garanciju da nece nista unistiti, tvoju kucu zapaliti, \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "POGREŠKA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Opcije"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -629,197 +617,190 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Fatalna greska: Neuspjesno stvaranje tajmera"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Izgubljena veza"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Pitanje pri napustanju"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -828,154 +809,144 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Fatalna greska: Neuspjesno stvaranje tajmera"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Spajanje"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Spreman"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Sve"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nije dostupno"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Datoteka nije pronađena."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nepoznat"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "ceka na spajanje..."
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Zahtijevan:"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -983,7 +954,7 @@ msgstr[0] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s prene
 msgstr[1] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s preneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -991,119 +962,119 @@ msgstr[0] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s prene
 msgstr[1] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s preneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Zatrazen nepoznat fajl"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Korisnik %s (%u) ja zahtio tvoju listu dijeljenih fajlova za direktorij %s -> %s"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Neocekivana fajl greska prilikom pisanja %s : %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Greska prilikom spajanja sa %s (%s:%i): %d"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Izaberi mapu (folder) za dolazece fajlove"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Brbljanje"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Zatvori oznaku"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Zatvori sve oznake"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Zatvori druge oznake"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Primi u prijatelje"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1111,7 +1082,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1119,173 +1090,170 @@ msgstr[0] "Krediti istekli!"
 msgstr[1] "Krediti istekli!"
 msgstr[2] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalji klienta"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Omogućeno"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Podržano"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nije podržano"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Onemogućeno"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Veza uspostavljena"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Prekinuta veza"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nedovrseno"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Los decko"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Priznat - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nije dostupno"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Korisnik %s (%u) ja zahtio tvoju listu dijeljenih fajlova za direktorij %s -> %s"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Korisnik %s (%u) ja zahtio tvoju listu dijeljenih fajlova za direktorij %s -> %s"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Korisnik %s (%u) dijeli direktorije %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Korisnik %s (%u) je poslao listu dijeljenih fajlova za direktorij %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Korisnik %s (%u) ja zavrsio slanje liste dijeljenih fajlova"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Korisnik %s (%u) ja zavrsio slanje nezeljene liste dijeljenih fajlova"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Komentari fajla"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Ime korisnika"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime fajla"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocjena"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentiraj"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "ceka na spajanje..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Bez komentara"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1293,425 +1261,412 @@ msgstr[0] "Bez komentara"
 msgstr[1] "Bez komentara"
 msgstr[2] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Neuspjesno citanje kreditnog fajla"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ni]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Vi]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoko"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Vrlo visok"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Pita"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Spaja preko servera"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Pun red cekanja"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "U redu cekanja"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloading"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Prima hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nepotrebni dijelovi"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Ne moze spojiti LowID sa LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Previse konekcija"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Zabranjen"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Star MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Novi MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Rezultati pretrage"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zavrseno"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferirano"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Brzina"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Napredak"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Izvori"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Preostalo vrijeme"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Posljednji put vidjen kompletno"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Posljedni prijem"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatski"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stop"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pauza"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Nastavak"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "O&dstrani zavrsene fajlove"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Primijeni sve A4AF ovom fajlu"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Primijeni sve A4AF ovom fajlu (Automatski)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Primijeni sve A4AF nekom drugom fajlu"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Prosirene opcije"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Preuvid"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Pokazi &detalje fajla"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Pokazi sve kommentare"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "neodredjeno"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Odredi u kategoriju"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otvori fajl"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Zahtjev dijeljenih fajlova od '%s'"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nisu nadjeni nikakvi poceti fajlovi"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1719,50 +1674,50 @@ msgstr[0] "Nadjeno %i pocetih fajlova"
 msgstr[1] "Nadjeno %i pocetih fajlova"
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Downloading %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1770,279 +1725,278 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Datoteka nije pronađena."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nepravilan naziv datoteke."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2050,23 +2004,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Izlaz iz aplikacije."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2074,59 +2028,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Sintaktička pogreška!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2135,525 +2089,519 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Spajanje"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Veza"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Privremene datoteke"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Pretrazi :"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Prijatelji"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Pokazi &Detalje"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Dodaj prijatelja"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Odstrani prijatelja"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Posalji &Poruku"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ugledaj fajlove"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Uspostavi slot zu prijatelja"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Pošalji poruku"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "U redu cekanja"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Upitao za drugi fajl"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Uploadovi na cekanju: %i"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "U redu cekanja"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Prijenos"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nijedno"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Downloading..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 #, fuzzy
 msgid "HTTP download cancelled"
 msgstr "Istinska sirina pojasa downloada"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Neuspjesno spasavanje part.met.seeds fajla za %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Downloaded:"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Istinska sirina pojasa downloada"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Neuspio download serverliste od %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Neuspio download serverliste od %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2661,7 +2609,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2669,71 +2617,67 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Poruka"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Nastaviti?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2741,12 +2685,11 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2754,7 +2697,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2762,2059 +2705,2028 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Naziv datoteke"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Veličina datoteke"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Nepoznat: %i"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Zavrsavanje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Zavrseno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausirano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Sa greskom"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Cekanje"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "POGREŠKA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Zatvori"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Staviti"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ocisti"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Izaberite sve"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Veza uspostavljena"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Veza uspostavljena"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Neuspjelo povezivanje"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nije povezano"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Izlaz"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Bezkrajno"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule izbor u koritu"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Brzina downloada"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Brzina uploada"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Nadimak: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "KlientID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Ime servera:"
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Veza nije uspostavljena"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online potpis: Omogucen"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online potpis: Onemogucen"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Vrijeme korisnika: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Primi u prijatelje"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Ucitava..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Broj korisnika na serveru sa kojim si spojen..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Korisnika: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ne povezan..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Pretraga"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Naziv:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Bilo koja"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arhiva"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD_Imidz"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Slike"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programi"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Tekstovi"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videa"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Ekstenzija"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Minimalna velicina"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maksimalna velicina"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Dostupnost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtar:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultati"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Nadjeni izvori :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Glavni"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Puno ime :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-fajl :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Velicina fajla :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Status pocetog fajla :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Posljednji put vidjen kompletno :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Nadjeni izvori :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Izvori koji transferuju :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Broj pocetog fajla :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Dostupnost :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Prenijeto :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Zavrsna velicina :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Rukovanje inteligentne korupcije (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Izgubljeno zbog korupcije :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paketi spaseni kroz I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Zahtjevi"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Prihvaceni zahtjevi"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Podatak transfera"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Bez ocjene"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Naziv :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Preuzimanje"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Ciscenje"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Primijeni"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Dobro!"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Kvalitet fajla"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Bez ocjene"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Neispravan / Koruptan / Falsifikat"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Los"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Vrlo dobar"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Dobar"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Odlican"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Izaberi ocjenu fajla ili savjet korisnika ako je fajl neispravan ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Obnovi"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Downoading, molim strpljenje ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Trazene informacije"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP adresa:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatne informacije"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Ime korisnika :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Prosjek misije"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Brzina uploada"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Drvo statistike"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Ime korisnika:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP adresa:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Rezultati"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Pun red cekanja"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nadimak"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Pocni minimiran"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Pitanje pri napustanju"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekundi"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video Plejer"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Alokacija slota"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Ponovni spoj kod gubitka veze"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Otstrani mrtve servere nakon"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "pokusaja"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Koristi sistem prioriteta"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Koristi pametnu LowID provjeru pri vezanju"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Sigurno povezivanje"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autopovezivanje samo sa serverima iz staticne liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Postavi rucno dodate servere na visoki prioritet"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Dodaj nove fajlove u stanju pauze"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Dodaj nove fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Pokusaj prvo downloadovati pocetni i zavrsni chunk "
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploadovi"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj nove dijeljene fajlove sa auto prioritetom"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Omogućiti"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafovi"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Obnovi kasnjenje : 5 sekundi"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Vrijeme za prosjecni graf: 100 minuta"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Boje: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Pozadina"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Mreza"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Trenutni download"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Prosjek tekuceg downloada"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Prosjek downloada misije"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Trenutni upload"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Prosjek tekuceg uploada"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktivne veze"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "poluga brzine prikazana u sistemskom koritu"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Izaberi"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! UPOZORENJE !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maksimalne veze u / 5 sekundi"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval obnavljanja veze servera %i minuta"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fajl Buffer velicina: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Duzina reda cekanja: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Pokazi transfer rate u naslovu"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Pljosnata"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4822,11 +4734,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4836,242 +4748,242 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Onemoguceno [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte"
 msgid_plural "bytes"
@@ -5079,31 +4991,31 @@ msgstr[0] "Bytes"
 msgstr[1] "Bytes"
 msgstr[2] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
@@ -5111,213 +5023,213 @@ msgstr[0] "kBytes/sec"
 msgstr[1] "kBytes/sec"
 msgstr[2] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sekundi"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minuta"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "sati"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dani"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "svi"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "svi drugi"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Nedovrseno"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Stopirano"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arhiva"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktivan"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "GRESKA: neuspjesno stvaranje zapocetog fajla)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Greska: fajl known.met je koruptan, nemoguce citati poznate fajlove"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Neuspjelo otvaranje %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "GRESKA kod spasavanja pocetog fajla: %s (%s => %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Neuspjesno spasavanje part.met.seeds fajla za %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5325,17 +5237,17 @@ msgstr[0] "Spaseni %i seeds izvora za poceti fajl: %s (%s)"
 msgstr[1] "Spaseni %i seeds izvora za poceti fajl: %s (%s)"
 msgstr[2] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Spaseni %i seeds izvora za poceti fajl: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5343,349 +5255,349 @@ msgstr[0] "Nadjen koruptan dio (%i) u %i pocetom fajlu %s - FileResultHash |%s| 
 msgstr[1] "Nadjen koruptan dio (%i) u %i pocetom fajlu %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Zavrseno rehashing %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Zavrseno rehashing %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Veza"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktoriji"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Sigurnost"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Sučelje"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Daljinsko upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Događaji"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debugiranje"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5701,220 +5613,220 @@ msgstr ""
 "aMule ce raditi dobro iako ne promijenis\n"
 "nista od ovih opcija."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Lozinka"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatski"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Vec pokusavate downloadovati fajl %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Nova vanjska veza prihvacena\n"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Privremene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5922,41 +5834,41 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Potrazi videoplejer"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standard sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5964,41 +5876,41 @@ msgstr ""
 "Dodaj ovdje URLs da dobijes server.met fajlove. \n"
 "Samo jedna URL po liniji."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6006,7 +5918,7 @@ msgstr[0] "Obnovi kasnjenje : 5 sekundi"
 msgstr[1] "Obnovi kasnjenje : 5 sekundi"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6014,12 +5926,12 @@ msgstr[0] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[1] "Vrijeme za prosjecni graf: 100 minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6027,7 +5939,7 @@ msgstr[0] "Velicina fajl buffera %i bytes"
 msgstr[1] "Velicina fajl buffera %i bytes"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6035,7 +5947,7 @@ msgstr[0] "Duzina liste cekanja %i klienata"
 msgstr[1] "Duzina liste cekanja %i klienata"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6043,234 +5955,234 @@ msgstr[0] "Interval obnavljanja veze servera %i minuta"
 msgstr[1] "Interval obnavljanja veze servera %i minuta"
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval obnavljanja veze servera: onemoguceno"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "onemoguci"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Pretrage"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Bez ocjene"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Upitao za drugi fajl"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Otkaz"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Novo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Spojen sa %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Uspostavljena veza sa: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Fatalna greska prilikom pokusaja spajanja. Veza interneta je moguce prekinuta"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Izgubljena veza sa %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) je mrtav"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6278,48 +6190,48 @@ msgstr[0] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
 msgstr[1] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
 msgstr[2] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6327,7 +6239,7 @@ msgstr[0] "%i servera pronadjeno u server.met"
 msgstr[1] "%i servera pronadjeno u server.met"
 msgstr[2] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6335,241 +6247,240 @@ msgstr[0] "%d servera dodato"
 msgstr[1] "%d servera dodato"
 msgstr[2] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 #, fuzzy
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Greska: fajl server.met je koruptan"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Neocekivana fajl greska prilikom pisanja %s : %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Neuspjelo spasavanje server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Neispravna URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Neuspio download serverliste od %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime servera"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresa"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Opis"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Korisnici"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Staticni"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzija"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serveri (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Odstrani servera"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
 msgstr "Odstrani servera"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstrani sve servere"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Novi klientID je %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6577,179 +6488,179 @@ msgstr[0] "Primljeno %d novih servera"
 msgstr[1] "Primljeno %d novih servera"
 msgstr[2] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server je odbio posljednju komandu"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule Log"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Veza"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Veza uspostavljena"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Radi"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Vrh broja veza (procjena)"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Spajanje"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Spojen sa %s (%s:%i)"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Nadjeni izvori :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Ne radi"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6757,7 +6668,7 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6765,7 +6676,7 @@ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6773,426 +6684,426 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Ime korisnika"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Brzina downloada"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Brzina uploada"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Dostupnost :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Uploadovi"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Download Status"
 msgstr "Downloads"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Ime fajla"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Dijeljeni fajlovi"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Dobiveni dijelovi"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Preimenovanje"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopiraj ed2k &linkove u klipbord (&Source)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Za ispravan izvorni link, potrebna je HIGH ID"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Ime fajla"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Prosjecno vrijeme uploada: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Ponovno vezan: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Vriejme od prvog transfera: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Spojen sa serverom vec: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienti"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Nepoznat: %i"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Filtrirani: %i"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Zabranjen"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zauzetost servera: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktivne veze (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nije dostupno"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nikad"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7200,7 +7111,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7208,156 +7119,154 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Downloads (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Iskljuceno"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Uključen"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "Dobro!"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "%s Nije dostupan"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7366,46 +7275,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7413,35 +7322,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7452,121 +7361,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7585,387 +7494,384 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Pokazi polugu napretka"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Pokazi polugu napretka"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Dijeljeni fajlovi"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Da li zaista zelite da ponistite i obrisete sve fajlove u ovoj kategoriji?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Potrebna potvrda"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Previse konekcija"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Izaberi filter za gledanje"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Dodaj kategoriju"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editiraj kategoriju"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Odstrani kategoriju"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Spremi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Otvori"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Spremi kao"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7977,178 +7883,170 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 #, fuzzy
 msgid "Cancelled !"
 msgstr "Otkaz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Ponistenje"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sustav"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8159,402 +8057,391 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Neuspjelo povezivanje"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -19,20 +19,20 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: .\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "aMule megjelenítése"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule távoli vezérlő "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Pillanatkép:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -40,7 +40,7 @@ msgstr ""
 "'Minden-platform' p2p ügyfél az eMule alapján \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -48,79 +48,79 @@ msgstr ""
 "Szerzői jog (c) 2003-2026 aMule csapat \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Az aMule részben a következőn alapul: \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Egyenrangú útvonal-megállapítás a XOR metrika alapján.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Honlap:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Dokumentáció:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Gondok:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Indításkor új verzió keresése"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kapcsolódás a Kad-hoz..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nem elérhető"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Barát hozzáadása"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Érvényes IP címet és portot kell megadnod!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Információ"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "A megadott felhasználói azonosító (userhash) érvénytelen!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
@@ -133,47 +133,46 @@ msgstr ""
 "\n"
 "Installálásra kerüljön az asztal integráció?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "aMule hozzáadása az alkalmazások menüjéhez?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Telepítés"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Most nem"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Ne kérdezze újra"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Asztal integráció nem telepíthető: az APPDIR környezeti változónak nincs értéke. Ez általában azt jelenti, hogy az AppImage egy szokatlan módon került indításra."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "aMule integráció sikertelen"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Az asztal integráció telepítése sikertelen: %s létrehozása nem sikerült. Elleőrizze hogy a home könyvtár írható."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Az asztal integráció telepítése sikertelen: %s írása nem sikerült. Elleőrizze hogy a home könyvtár írható."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, fuzzy, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage integráció: aMule hozzá lett adva az alkalmazások menüjéhez."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -187,103 +186,100 @@ msgstr ""
 "\n"
 "aMule újraindítása most?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule telepítve"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Újraindítás most"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Később"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "ED2KLinks fájl megnyitása sikertelen."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg alacsony azonosítód (lowid) van."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Kilépés a fő alkalmazásból..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Sikertelen"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - bezárása ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Az amuleweb instancia - melynek a pid-je '%d' - kivégzése ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Mag leállítása."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Az aMule leállítása befejeződött."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Memória debug eredmények az aMule bezárásáról:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Nyelvi beállításaid egy konfigurációs változás miatt az alapértelmezettre lettek átállítva. Bocs."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Infó"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -291,20 +287,19 @@ msgstr ""
 "\n"
 "EC beállítások"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "FIGYELEM"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -312,52 +307,49 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "HIBA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "web kiszolgáló fut, pid=%d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nem tudom a portokat a megadott címhez (%s) rendelni."
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "A %u port nem elérhető. Alacsony kliens azonosítót kapsz (LOWID)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +364,48 @@ msgstr ""
 "\n"
 "Ellenőrízd a hálózatodat, hogy megbizonyosodj, hogy a port nyitva van kifelé és befelé egyaránt."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Online-Aláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Az aMule OnlineAláírás fájl létrehozása sikertelen"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "A kiválasztott nyelvi beállítások úgy látszik nincsenek telepítve a gépeden. (Megjegyzés: Mindenesetre mepróbálom ezt beállítani)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ez az első alkalom, hogy az aMule %s-t futtatod"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ez egy teszt verzió, naponta frissítve, és\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nem vállalunk garanciát, hogy nem omlik össze, gyújtja fel a házad,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vagy öli meg a kutyád. *Elvileg* nyugodtan használható.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Még több információ, támogatás és új kiadások találhatóak honlapunkon,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "a https://amule-org.github.io, vagy az #aMule IRC csatornánkon az irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nyugodtan jelezz bármilyen hibát a https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,223 +413,219 @@ msgstr ""
 "Az Online aláírás fájl könyvtárának megadott hely ÉRVÉNYTELEN!\n"
 " Az OnlineAláírás letiltásra kerül, amíg ki nem javítod azt a beállítások menüpontban."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Lemezterület helyfoglalás a '%s' fájl számára sikertelen: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "HIBA: Nem tudom megnyitni a napló fájlt"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "FIGYELEM: a napló üres. Valami nem stimmel."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Napló törölve"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "KiszolgálóÜzenet: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "A %s letöltése kihagyva, mert a kívánt fájl nem újabb."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Csomópont-lista letöltése sikertelen."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Nem sikerült megnyitni a letöltött verzió-ellenőrző fájlt"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Sérült verzió-ellenőrző fájl"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Az aMule egy elavult verzióját használod!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A te aMule verziód %i.%i.%i, a legújabb verzió pedig %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "FIGYELEM: A te aMule verziód elavult: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Az aMule verziód naprakész."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Verzió-ellenőrzés fájl letöltése sikertelen."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Felhasználók: %s | Fájlok: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Felhasználók: E: %s K: %s | Fájlok: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nincs hálózat kiválasztva"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "LowID-val"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "HighID-val"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Kapcsolódva ehhez %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Kapcsolódás %s-hez"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Leválasztva az eD2k-ról"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad elindítva."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad leállítva."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kapcsolódva a Kad-hoz (rendben)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kapcsolódva a Kad-hoz (tűzfal mögül)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A Kad hálózat nem használható, ha az UDP port le van tiltva a beállításokban, nem indítom."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A Kad hálózat le van tiltva  a beállításokban, nem kapcsolódom."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "HIBA: az aMule démon nem használható, ha a külső kapcsolatok le vannak tiltva. A Külső Kapcsolatok engedélyezéséhez használd a normál aMule-t, vagy indítsd az amuled-t a --ec-config paraméterrel, vagy állítsd az \"AcceptExternalConnections\" kulcs értékét 1-re a ~/.aMule/amule.conf fájlban."
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "HIBA: Egy érvényes jelszó szükséges a külső kapcsolatok használatához, és az aMule démon nem használható külső kapcsolatok nélkül. Az aMule démon futtatásához az \"ECPassword\" nevű mezőt a ~/.aMule/amule.conf nevű fájlban egy megfelelő értékre kell állítani. Indítsa az amuled-t a --ec-config paraméterrel, a jelszó beállításához. További információk https://amule-org.github.io/docs alatt találhatóak."
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - időzítő indítása"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Pid fájl létrehozása nem lehetséges"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ez az aMule %s, az eMule alapján."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,192 +635,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Nincs hálózat"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule távoli vezérlő"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Végzetes hiba: a Mag Időzítőjének létrehozása sikertelen"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Kapcsolódás a távoli aMule-hez"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Kapcsolat megszakadt"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Figyelmeztetés kilépéskor"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -841,41 +822,41 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Végzetes hiba: a Lekérdezés Időzítőjének létrehozása sikertelen"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Esemény ciklus megkezdése..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Kapcsolódás..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Kapcsolat sikertelen. Kerém ellenőrizze a host, port és jelszó értékeket."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Távoli GUI EC esemény kezelő"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Kapcsolat sikertelen. Kapcsolat felvétel %s:%d-el nem lehetséges\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Kikapcsolás folyamatban"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Kapcsolódási kísérlet %s-hez (%s:%i): időtúllépés."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -884,680 +865,657 @@ msgstr ""
 "Kapcsolat időtúllépés. Képtelen a %s:%d elérése a megadott időn bellül.\n"
 "Kérem ellenőrízze a host, port értékeket, és hogy a külső kapcsolatok aktiválva vannak az aMule-ban."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Kapcsolódás a hálózathoz."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Kapcsolat sikertelen. Kapcsolat felvétel %s:%d-el nem lehetséges\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Készen"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Mind"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nem elérhető"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Fájl nem található."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a '%s' könyvtár megtartva."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Pajtás keresése lowid kapcsolatra"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Hamis eMule %#x verzió)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Hamis eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Hamis eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x  (az eMule v0.%u alapján)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Becenév: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Kért: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fájlstatisztika ehhez a folyamathoz: %d kérés elfogadva %d-ből, %s átmásolva\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fájlstatisztika az összes folyamathoz: %d kérés elfogadva %d-ből, %s átmásolva\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Ismeretlen lekérdezett fájl"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Üzenet kiszűrve '%s'-től (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Új üzenet '%s'-től (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a nem létező '%s' könyvtárban megosztott fájljaid listájá -> Mellőzve"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "FIGYELEM: %s nem nyitható meg."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "FIGYELEM: A megszakított fájlok listája sérült, érvénytelen fejlécet tartalmaz."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO hiba a %s fájl olvasása közben: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Hiba a %s fájl mentése közben: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategória"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Új kategória"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Könyvtár kiválasztása az érkező fájloknak"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Meg kell adnod a kategória nevét!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Meg kell adnod a kategória elérési útvonalát!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Bejövő könyvtár létrehozása sikertelen a kategóriához. Kérlek érvényes elérési utat adj meg!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Csevegési folyamat elindítva: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Connected to Client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Kapcsolódás a klienshez ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Kapcsolódás sikertelen / Kapcsolat elveszítve ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** A captcha vizsgálaton túlestél és a felhasználó megkapta az üzenetet. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** A megadott captcha hibás volt, így az üzenet nem lett tudomásul véve. Egy új üzenet küldésével újabb captcha-t kérhetsz. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Csevegés"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Fül bezárása"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Az összes fül bezárása"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "A többi fül bezárása"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Hozzáadás a barátokhoz"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Kredit fájl betöltve, %u kliens ismert"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u kliens kreditérvényessége lejárt!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "A 'cryptkey.dat' fájlt nem találom, létrehozok egyet."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Kliens részletei"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Támogatott"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nem támogatott"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Letiltva"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Csatlakozva"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Szétkapcsolva"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Befejezetlen"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Rossz fiú"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Hitelesítés - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nem elérhető"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a megosztott fájlok listáját -> Elfogadva"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a megosztott fájlok listáját -> Megtagadva"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "A(z) %s (%u) felhasználó lekérdezte megosztott könyvtáraid listáját -> Elfogadva"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "A(z) %s (%u) felhasználó lekérdezte megosztott könyvtáraid listáját -> Megtagadva"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a '%s' könyvtárban megosztott fájljaid listáját -> elfogadva"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a '%s' könyvtárban megosztott fájljaid listáját -> megtagadva"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "A(z) %s (%u) felhasználó megosztja a '%s' könyvtárat"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "A(z) %s (%u) felhasználó kéretlen megosztott könyvtárakat küldött."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "A(z) %s (%u) felhasználó elküldte megosztott fájljai listáját a '%s' könyvtárhoz"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "A(z) %s (%u) felhasználó befejezte megosztottfájl-listájának elküldését"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "A(z) %s (%u) felhasználó kéretlen megosztottfájl-listát küldött"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "A(z) %s (%u) felhasználó megtagadta a megosztott könytár/fájl listájához történő hozzáférést"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Fájl megjegyzés"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Felhasználói név"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fájlnév"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Értékelés"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Megjegyzés"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad keresést nem lehet végrehajtani ha a Kad nem fut"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Pajtás keresése lowid kapcsolatra"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Nincs megjegyzés"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u megjegyzés"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Kliens %s kitiltva az összesen %s adatból %s hibás adat küldése miatt a '%s' fájlt illetően."
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "'%s' ország adatainak betöltése sikertelen."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Al]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Ma]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Magas"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Nagyon magas"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Forgalomba helyez"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Engedély kérése"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Kapcsolódás a kiszolgálón keresztül"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Várólista betelt"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Várólistások"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Letöltés alatt"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "HashSet fogadása"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nincs hiányzó fájlrész"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nem lehet alacsony ID-vel alacsony ID-hez kapcsolódni"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Túl sok a kapcsolat"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Kapcsolódás a Kad-on keresztül"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Túl sok Kad kapcsolat"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Kitiltott"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Kapcsolódási hiba"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Távoli várólista betelt"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Régi MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Új MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule kompatibilis"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Helyi kiszolgáló"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Forrás-csere"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passzív"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Hivatkozás"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Mentett források"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Keresés eredménye"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Befejezett"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Folyamatban"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "HIBA: Elfogyott a szabad lemezterület"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "HIBA: Partmet nem található"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "HIBA: IO hiba!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "HIBA: Sikertelen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Várólistán"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Letöltés alatt"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Ismeretlen vagy rossz ideiglenes-fájl formátum."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Rész"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Átmásolva"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sebesség"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Folyamatjelző"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Források"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritás"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Állapot"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Hátralévő idő"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Utoljára teljesnek látott"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Utoljára fogadott"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Biztos, hogy törlöd a kiválasztott fájlt?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Biztos, hogy törlöd a kiválasztott fájlokat?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1566,109 +1524,106 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatikus"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Állj"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Szüneteltet"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Folytatás"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Befejezettek &eltávolítása"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Összes A4AF cseréje ehhez a fájhoz most"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Összes A4AF cseréje ehhez a fájhoz most (Automatikusan)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Összes A4AF cseréje a többi fájhoz most"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Kibővített beállítások"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Előnézet"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Fájl &részleteinek megjelenítése"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Összes megjegyzés megjelenítése"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Magnet URI másolása a vágólapra"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "eD2k hivatkozás másolása a vágólapra"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Visszajelzés másolása a vágólapra"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "hozzárendelés megszüntetése"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Hozzárendelés kategórához"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Fájl &megnyitása"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Írd be az új nevet ennek a fájlnak:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Fájl átnevezés"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Letöltések (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1677,344 +1632,343 @@ msgstr ""
 "Állítsd be a kedvenc videó-lejátszódat a beállításoknál,\n"
 " hogy ezt a figyemeztetést ne kapd minden előnézetnél (alapértelmezett az %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Fájl előnézet"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "HIBA: Külső média-lejátszó indítása sikertelen! Parancs: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "PartFile mentése %u a(z) %u-ból"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Az összes PartFile kimentve."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Temp fájlok betöltése %s-ról."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "PartFile betöltése %u a(z) %u-ből"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "HIBA: A biztonsági mentés betöltése sikertelen. Keressen a https://github.com/amule-org/amule/discussions oldalon .part.met visszaállítási lehetőségeket."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Az összes PartFile betöltve."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nem található .part fájl"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u .part fájlt találtam"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Az ideiglenes fájlok könyvtárának fájlrendszere nem tudja kezelni a nagy fájlokat."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "A bejövő fájlok könyvtárának fájlrendszere nem tudja kezelni a nagy fájlokat."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Letöltés %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Már megkísérelted a(z) '%s' fájlt letölteni"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Már megvan ez a fájl: '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Már megvan ez a fájl: '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Már próbálod letölteni a(z) '%s' fájlt."
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "A magnet hivatkozás nem konvertálható eD2k-ra: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "A következő hivatkozás protokollja ismeretlen: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Érvénytelen eD2k hivatkozás! HIBA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Kliens csomagot küldött sikertelen hitelesítést követően."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Külső kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "A külső kapcsolatok letiltásra kerültek üres jelszó miatt!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "A külső kapcsolatok le vannak tiltva konfig fájlban"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Új külső kapcsolat elfogadva"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HIBA: nem tudtam fogadni egy új külső kapcsolatot"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Külső kapcsolat elutasítva, üres jelszó a beállításokban!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kapcsolódó kliens: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Ismeretlen verzió"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Helytelen EC verzió azonosító, összeférhetetlenség lehetséges. A fő- és a távoli programot ugyanabból a pillanatképből használd."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nem kapcsolódhatsz egy kiadott verzióhoz egy tetszőleges fejlesztés alatti verzióval! *sóhaj* lehetséges összeomlás megelőzve"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Hiányzó protokoll verzió azonosító."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Hitelesítés sikertelen: az EC jelszóként megadott hash érvénytelen."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Hitelesítés sikertelen: rossz jelszó."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Hitelesítés sikertelen: hiányzó jelszó."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Érvénytelen kérés, először hitelesíteni kell."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Hozzáférés elfogadva."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Hibaüzenet elküldve a \"%s\" klienshez."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Jogosulatlan hozzáférési kísérlet %s részéről. Kapcsolat lezárva."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Távoli PartFile parancs sikertelen: nem található FileHash: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash nem található: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Hoppá! Opkód feldolgozási hiba!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Kiszolgáló nem lett hozzáadva"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "kiszolgáló nem található: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "ki kell jelölnöd a kiszolgálót az eltávolításhoz"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "Az eD2k le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Barát nem található."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Kliens nem található."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED igényel EC_TAG_FRIEND vagy EC_TAG_CLIENT értéket."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Webes keresésnek a távoli felületről nincs értelme."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Keresés folyamatban. Kérdezze le az eredményeket egy rövid idő múlva!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Nincsenek pontok a grafikonhoz."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "A kliensed nincs beállítva ehhez a részletességi szinthez."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Külső kapcsolat: leállítás kérve"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Kikapcsolás folyamatban."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: hivatkozás hozzáadása: '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d link %d linkből sikertelen (érvénytelen vagy már a listán van)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Fájl nem található."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Érvénytelen fájl név."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nem tudom átnevezni a fájlt."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "A Kad le van tiltva a beállításokban."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Már csatlakozva az eD2k-hoz."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Kapcsolódás az eD2k-hoz..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Már kapcsolódva a Kad-hoz."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kapcsolódás a Kad-hoz..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Minden hálózat le van tiltva."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Leválasztva az eD2k-ról."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Leválasztva a Kad-ról."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Külső kapcsolat: érvénytelen opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Érvénytelen opcode (rossz protokoll verzió?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Ismeretlen bővítmény '%s' a '%s' parancshoz.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Ismeretlen parancs: '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2022,7 +1976,7 @@ msgstr ""
 "\n"
 "Ennek a parancsnak nem lehet argumentuma.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2030,7 +1984,7 @@ msgstr ""
 "\n"
 "Ennek a parancsnak kötelező az argumentum.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2038,7 +1992,7 @@ msgstr ""
 "\n"
 "Ez a parancs nem teljes, az alábbi bővítmények valamelyikét kell használnod.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2046,11 +2000,11 @@ msgstr ""
 "\n"
 "Elérhető bővítések:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Elérhető parancsok:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2061,17 +2015,17 @@ msgstr ""
 "Minden parancs érzéketlen a kis-/nagybetűkre.\n"
 "Ha részletes infót akarsz egy <parancs>-ról, add ki a '%s <parancs>' parancsot.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Kilép az alkalmazásból."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Súgó megjelenítése."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2079,7 +2033,7 @@ msgstr ""
 "Ha egy parancsról kérsz súgót, használd a 'help <parancs>'-ot.\n"
 "A teljes parancslistához használd a 'help'-et.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2090,46 +2044,46 @@ msgstr ""
 "A parancslistához használd a '%s'-et\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Szintaktikai hiba!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Hiba a parancs feldolgozásában - soha sem kellene előfordulnia! Kérlek, küldd el a hibajelentést\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Ennek a parancsnak kötelező paramétert adni."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Érvénytelen paraméter."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Ez a parancs így nem teljes."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "A '%s' paranccsal kaphatsz bővebb segítséget.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Ez a(z) %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Ez a(z) %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2137,7 +2091,7 @@ msgstr ""
 "\n"
 "Kliens létrehozása...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2146,7 +2100,7 @@ msgstr ""
 "\n"
 "Ok, kilépés a %s-ből...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2160,331 +2114,326 @@ msgstr ""
 "\n"
 "Kilépés...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "E súgó megjelenítése."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host, ahol az aMule fut (alap: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Az aMule Távoli Elérés portja (alap: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Külső kapcsolat jelszava."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Konfiguráció betöltése fájlból."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nem ír ki semmit a szabvány kimenetre."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Legyen bőbeszédű - mutassa a hibakeresési üzeneteket is."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Beállítja a program nyelvét."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "A parancssori opciók konfig fájlba írása."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Konfig fájl létrehozása az aMule konfig fájlja alapján."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "A program verziójának kiírása."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "ZLIB tömörítés kikényszerítése a tárcsázott IP-cím helyétől függetlenül (hasznos, ha a szerver egy VPN-alagúton keresztül érhető el, amely LAN IP-címre kerül feloldásra)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Fájl részletei"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% kész"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Üdvözöljük!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Kapcsolódás a pajtáshoz"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Kapcsolat állapota:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Hálózatok"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Szabvány TCP port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Bővített UDP port (Kad / globális keresés) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "UPnP engedélyezése a router port továbbításhoz"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Rendszerbetöltés"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Már próbálod letölteni a(z) '%s' fájlt."
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Kiszolgáló lista automatikus frissítése indításkor"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatikus indítása bejelentkezéskor"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Tallóz"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "A barátokat tartalmazó emfriends.dat fájl olvasásra megnyitása sikertelen!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikertelen!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Barátok"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "&Részletek megjelenítése"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Barát hozzáadása"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Barát törlése"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "&Üzenet küldése"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Fájlok megtekintése"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Társ Slot létesítése"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Tényleg törölni szeretnéd a kiválasztott barátot?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Tényleg törölni szeretnéd a kiválasztott barátokat?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2492,11 +2441,11 @@ msgstr ""
 "Nem lehet egynél több barát slot-ot létrehozni.\n"
 "Csak egy slot lett hozzárendelve."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Többszörös kiválasztás"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2504,204 +2453,203 @@ msgstr ""
 "Nem szabad egynél több baráti csatlakozást létesíteni.\n"
 " Csak egy csatlakozás lett hozzárendelve."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Üzenet küldése ennek a személynek"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Küldendő üzenet:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Eltávolítás a barátok közül"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Üzenet küldése"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Csere ehhez a fájlhoz"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Várólistán: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Másik fájl kérve"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Várakozás feltöltési slot-ra"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Várólistán: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Feltöltés alatt"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Egyik sem"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nem"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Igen"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Letöltés..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP letöltés megszakítva"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "A letöltendő URL nem lehet üres"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "A %s iránti HTTP kérés létrehozása sikertelen"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP letöltés: a %s válasz tartalma üres"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Letöltve %s (%llu bájt)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "Válasz a %s URL-tól: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP letöltés megszakítva"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Létező GeoLite2-Country.mmdb migrálva %s helyre"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country: MaxMind van kiválasztva GeoIP forrásként, de nincs megadva licenckulcs. Nyissa meg a Beállítások -> IP2Country pontot, illessze be az ingyenes MaxMind licenckulcsát, és kattintson a „Frissítés most” gombra."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country: Egyéni URL van kiválasztva GeoIP forrásnak, de nincs URL konfigurálva. Nyissa meg a Beállítások -> IP2Country pontot, és adjon meg egy URL-t, amely egy .mmdb (vagy egy olyat tartalmazó .gz / .tar.gz) fájlra mutat."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country: nem sikerült a GeoIP letöltési URL-t feoldani."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Új %s letöltése %s cím alól"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "%s letöltése sikertelen, frissítés megszakítása."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "%s fájl törlése sikertelen, frissítés megszakítása."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "%s fájl átnevezése sikertelen, frissítés megszakítása."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s frissítése sikerrel járt."
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Hiba %s frissítésekor"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "DB-IP letöltése a jelen hónapnak sikertelen - újrapróbálkozás az elmúlt hónap URL-jával."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "%s letöltése %s-től sikertelen"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "IP-szűrők 'ipfilter.dat' és 'ipfilter_static.dat' betöltése."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "ipfilter.dat fájl '%s' betöltése sikertelen, ismeretlen formátum."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "ipfilter.dat fájl '%s' betöltése sikertelen, nem nyitható meg a fájl."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u IP-tartomány '%s'-ból betöltve."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u hibás sor lett eldobva."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Új %s fájl átnevezése sikertelen, frissítés megszakítása."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP szűrő készen áll"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2709,866 +2657,834 @@ msgstr ""
 "Indítás ismert \n"
 "kliensektől"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Csomópontok (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Érvénytelen IP a rendszerindításhoz"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Érvénytelen port a rendszerindításhoz"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Kérlek töltsd ki az összes kötelező mezőt"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Üzenet"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Biztos, hogy le akarsz tölteni egy új nodes.dat fájlt?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Ezzel eltávolítod az aktuális csomópontokat és újraindul a Kademlia kapcsolat."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Folytassuk?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: a keresési kulcsszó túl rövid"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: A keresési kulcsszó már a keresési listán: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "A nodes.dat fájl olvasása sikertelen volt - túl régi. Ez a verzió (0) már nincs támogatva."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u Kad kapcsolat beolvasva"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Nincsenek kontaktusok, indítsd el a betöltési folyamatot, vagy tölts le magad egy nodes.dat fájlt."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Csak %d Kad kapcsolat elérhető, a nodes.dat fájl nem lett felülírva"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d Kad kapcsolat kiírva"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad hálózat"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Fájl név"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Fájl méret"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Megosztási arány"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Kért"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Elfogadott"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Teljes források"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "FIGYELEM: Az ismert fájlok listája sérült, érvénytelen fejlécet tartalmaz."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Bejegyzés betöltése az ismert fájlok listájából sikertelen, hiba lehet a fájlban"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Érvénytelen bejegyzés az ismert fájlok listájában, hiba lehet a fájlban: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Ismeretlen hiba %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "A %d hiba leírásának lekérése sikertelen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Tördelőalgoritmizálás"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Befejezés"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Kész"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hibás"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Várakozik"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Egy nem üres jelszót kell megadni."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Érvénytelen jelszó, nem egy MD5 hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Kapcsolódási hiba"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Külső kapcsolat elveszítve - kilépés."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC kapcsolat sikertelen. Üres válasz."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Külső kapcsolat: Rossz válasz, kézfogás sikertelen. Kapcsolat megszüntetve."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Sikerült! Kapcsolat létrejött ezzel: aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Sikerült! Kapcsolat létrejött."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Külső kapcsolat: Hozzáférés megtagadva, mert: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: rendben."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "HIBA: A TCP porton nem lehet hallgatni."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "HIBA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "FIGYELEM: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Bezár"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Kivágás"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Másolás"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Törlés"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Mindent kijelöl"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Csatlakozva (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Csatlakozva (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Kapcsolódva (tűzfal mögül)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Szerver: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "Szerver IP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nincs kapcsolódva"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP port: Nem áll készen"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP port: Nem áll készen"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Kliens információk"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Feltöltési korlát"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Letöltési korlát"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "aMule megjelenítése"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "aMule elrejtése"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Kilépés"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Korlátlan"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule Tálca menü"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Sebesség korlátok:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Fel: nincs"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Fel: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Le: nincs"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Le: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Letöltési sebesség: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Feltöltési sebesség: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Becenév: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nem lett Becenév kiválasztva!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "KliensID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Kiszolgáló Név: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Kiszolgáló IP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Nincs kapcsolódva"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Aláírás: Engedélyezve"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Aláírás: Letiltva"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Aktivitási idő: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Megosztott fájlok: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Várólistás ügyfelek: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Összes letöltés: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Összes feltöltés: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Egy eD2k vagy magnet hivatkozás hozzáadása a maghoz."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Hozzáadás a barátokhoz"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Kattints ide, hogy a szövegbeviteli mezőben található eD2k hivatkozást hozzáadd a letöltési sorhoz."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Itt kerülnek megjelenítésre az események. A teljes eseménylistáért nézd meg a naplót a kiszolgáló-fülön."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Betöltés..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Felhasználók száma azon a kiszolgálón, amelyre kapcsolódott ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Felhasználók: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Felhasználó van kapcsolódva az aktuális kiszolgálóhoz és egy becslés az összes felhasználó számát illetően."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Fel: 0.0 | Le: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Aktuális feltöltési és letöltési arány átlaga. Ha engedélyezed, kapcsos zárójelben jeleníti meg a kliens-kommunikáció többletterhelését."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "A kapcsolat állapotát és az aktív adatátviteleket jelzi ki. A piros nyilak azt jelentik, hogy jelenleg nem vagy kapcsolatban, a sárga nyilak, hogy alacsony ID-d van (tűzfali) és a zöld nyilak pedig, hogy magas ID-d van (optimális kapcsolódási típus)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Nincs csatlakozva ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Jelenleg csatlakozott kiszolgáló."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Keresés"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Név:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Típus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Helyi"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globális"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Kibővített paraméterek"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Szűrés"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Fájltípus"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Akármelyik"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archívált fájlok"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Zene"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Image"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Képek"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programok"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Dokumentumok"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Filmek"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Kiterjesztés"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min. méret"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "bájt"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Max. méret"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Elérhetőség"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Szűrő:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Eredmények szűrése"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Eredmény megfordítása"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Ismert fájlok elrejtése"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Indít"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Több"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Kérje meg a már válaszolt Kad partnereket, hogy szélesítsék a keresést. Minden kattintás a legközelebbi partnertől kérdez le kapcsolatokat (KADEMLIA_FIND_VALUE_MORE), további fájltalálatokat hozva, amelyeket a keresés kezdeti alfa határa kihagyott."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Leállít"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Letöltés"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Mezők törlése"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Eredmények"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Befejeződött letöltések törlése"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fájl források:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Általános"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Teljes név :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-fájl :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Tördelőalgoritmus (hash) :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Fájlméret :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Átvitel"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Fájlrész állapot :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Utoljára teljesnek látott :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Forrás találatok :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Átviteli források :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Fájlrész-számláló :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Elérhető :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Adatráta :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Aktív letöltési idő: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Átmásolva :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Teljes méret :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligens Sérülés Kezelés"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Sérülés miatt elveszett :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Tömörítéssel nyert :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.S.K.-val megmentett csomagok :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Megosztva: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Kérések"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Elfogadott kérések"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Átmásolt adat"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Megosztási arány"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Teljes források"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Megosztott fájlok"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Feltöltés: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nincs értékelve"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Cím :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Fájl nevek"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Átvétel"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Kitisztítás"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Alkalmaz"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Megjegyzés/Értékelés ehhez a fájlhoz (ezt az összes felhasználó látni fogja)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3576,574 +3492,572 @@ msgstr ""
 "Megadhatod egy film hosszát, történetét, nyelvét...\n"
 "és ha a fájl hamis, elmondhatod ezt a többi aMule felhasználónak."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Fájl minősítése"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nincs értékelve"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Érvénytelen / Sérült / Hamis"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Gyenge"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Korrekt"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Jó"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Kitűnő"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Értékeld a fájlt minőségét vagy adj tanácsot a többi felhasználónak, ha a fájl érvénytelen ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Leválasztva a Kad-ról"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Frissít"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Letöltés folyamatban, kis türelmet ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Ismeretlen méret"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Kötelező adatok"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-cím :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Kiegészítő adatok"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "User név :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Hozzáad"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Feltöltési sebesség"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statisztika fa"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Felhasználó neve:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Felhasználói hash:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Kliensszoftver:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Kliensverzió:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-cím:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Felhasználó ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Kiszolgáló IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Kiszolgáló neve:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Zavarás:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Átvitel a kliensnek"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Aktuális kérés:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Átlagos feltöltési arány:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Átlagos letöltési arány:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Feltöltve (ebben a szakaszban):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Letöltve (ebben a szakaszban):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Feltöltve (összesen):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Letöltve (összesen):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Eredmények"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Le/Fel módosító:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Biztonsági azonosító:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Várólista helyezés:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Feltöltési várólista pontszám:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Becenév"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - a multi-platform Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Ezt a nevet fogja a többi felhasználó látni, amikor kapcsolódnak hozzád."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Nyelv: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Késleltetés a tool-tippek előtt."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Ez határozza meg a nyelvet, amelyet az irányításhoz használ."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Indításkor új verzió keresése"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Engedélyezve indításnál az aMule új verziót fog keresni."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Felhasználónkénti automatikus indítási bejegyzést regisztrál, hogy az aMule bejelentkezéskor elinduljon. Ha áthelyezi az aMule bináris fájlt, indítsa el az aMule-t manuálisan a bejegyzés frissítéséhez."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Indítás minimalizálva"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Engedélyezve indításnál minimalizálni fogja magát az aMule."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Figyelmeztetés kilépéskor"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Figyelmeztessen az aMule bezárása előtt."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Tálca ikon engedélyezése"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Ez engedélyezi/tiltja a tálca ikont."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Az alkalmazás ablakának elrejtése a bezárás gomb megnyomásakor"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimalizálás a rendszer tálcára"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Engedélyezve az aMule a rendszer tálcára fogja magát minimalizálni a tálca helyett."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Értesítések megjelenítése a letöltés befejezésekor"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Ezt engedélyezve az aMule értesítéseket fog megjeleníteni a befejezett letöltésekről."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Szóbuborék késési idő: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "másodperc"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Böngésző kiválasztása"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Megnyitás új fülön, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Weboldal megnyitása új fülön új ablak helyett, ha lehetséges"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videólejátszó"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Sávszélesség korlátok"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Slot kiosztás"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portok"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ez a szabvány eD2k port és nem lehet letiltani."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP port a kiszolgáló kérésekhez (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ezt az UDP portot a bővített eD2k kérések és a Kad hálózat használja"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP port (nem kötelező):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Max források letöltési fájlonként:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automatikus kapcsolódás induláskor"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Kapcsolódás megismétlése megszakadt kapcsolat esetén"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Halott kiszolgálók eltávolítása"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "próbálkozás után"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Kiszolgáló lista frissítése kiszolgálóhoz való kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Kiszolgáló lista frissítése amikor egy ügyfél kapcsolódik"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Prioritási rendszer használata"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Intelligens LowID ellenőrzés használata kapcsolódáskor"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Biztonságos kapcsolódás"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatikus kapcsolódás kizárólag az állandó kiszolgálókhoz"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "A kézileg hozzáadott kiszolgálók Magas Prioritással történő felvétele"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Fájlok felvétele szüneteltetett módban"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Új letöltések felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Előszőr az első és utolsó adatelemet próbálja meg letölteni"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Következő szüneteltetett fájl indítása amikor egy letöltés befejeződik"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Ugyanabból a kategóriából"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Betűrendi sorrendben"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Lemezterület helyfogalalás az új fájloknak"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Az új fájlok számára előre lefoglalja a lemezterületet, így csökkentve a töredezettséget"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Letöltések megállítása amikor a szabad hely kevesebb mint "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Jelöld be, ha azt szeretnéd, hogy az aMule ellenőrizze a szabad lemezterületet"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Add meg a kívánt min. szabad lemezterületet."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Mentsen el 10 forrást ritka fájloknál (< 20 forrás)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Feltöltések"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Új megosztott fájl felvétele automatikus prioritással"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligens Sérülés Kezelő (I.S.K.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Feljett I.S.K. megbízzon minden hash-ben (nem ajánlott)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4151,691 +4065,689 @@ msgstr ""
 "Elvégzett letöltések tárolási helye. Minden fájl ebben a könytárban automatikusan megosztásra kerül másokkal.\n"
 "Ha a könyvtár fájlokat tartalmaz, amelyek ne kerüljenek megosztásra, állítsa át egy megfelelő alkönyvtárra."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Megosztott mappák"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Eltávolít"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Jobb klikk az mappa ikonra az összes alatta levő mappát is megosztja)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Rejtett fájlok megosztása"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Megosztott könyvtárak automatikus újraszkennelése"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Szimbólikus hivatkozások követése megosztott könyvtárakban"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikonok"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Frissítés késleltetés: 5 mp"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Grafikon átlagos ideje: 100 perc"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Kapcsolatok grafikon skálája: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Letöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Feltöltési grafikon méretaránya:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Színek: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Háttér"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rács"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Aktuális letöltés"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Letöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Letöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Aktuális feltöltés"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Feltöltési futás átlaga"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Sebességmérő a rendszertálcán"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-csomópontok aktuális"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-csomópontok futó"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Kiválaszt"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Fa"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Megjelenített ügyfél verziók száma (0=mind)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! FIGYELEM !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Max új kapcsolat / 5 mp"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Fájl buffer méret: 240000 bájt"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Feltöltők várólistájának nagysága: 5000 kliens"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Számítógép időzített készenléti állapotának hatástalanítása"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Használt felület: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "A \"Gyors eD2k hivatkozás kezelő\" mutatása minden ablakban."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Kibővített infók megjelenítése a kategória füleken"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Az alkalmazás verziójának megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Átviteli ráták megjelenítése a címsorban"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Az alkalmazás neve előtt"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Az alkalmazás neve után"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Többletterhelés sávszélességének mutatása"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Függőleges eszköztár elrendezés"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Letöltendő fájlok várakozási sora"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Százalékos arány mutatása"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Folyamatjelző csík mutatása"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Lapos"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Vendég felhasználó tiltása"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Vendég jelszó a web kiszolgálóhoz"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4847,11 +4759,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4867,11 +4779,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4881,500 +4793,500 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Tiltva [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "bájt"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "bájt/mp"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "mp"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "perc"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "óra"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "nap"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "mind"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "összes egyéb"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Befejezetlen"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Megállítva"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Film"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archívált"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Szöveg"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktív"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Konfigurációk könyvtára: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Várakozás a partfile kovertáló thread befejeztére..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "%s importálása: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Ideiglenes mappa olvasása"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Alapvető információk megszerzése a letöltési infó fájlból"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Célfájl létrehozása"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Adat töltése a régi letöltési fájlból (%u a(z) %u-ből)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Adat blokk mentése az új letöltési fájlba (%u a(z) %u-ből)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Forrás letöltési fájl információ megszerzése"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Új letöltés hozzáadása és az új részfájl mentése"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Részfájlok importálása"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Állapot"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Fájl Hash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Lemezen: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Válassz egy mappát ahol ideiglenes letöltéseket fogok keresni! (az almappákban is)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Törölni akarja a sikeresen importált letöltések forrás fájljait?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Források eltávolítása?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "HIBA: Részfájl létrehozása sikertelen"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Megpróbálom betölteni a met-fájl biztonsági másolatát a %s-ből"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "HIBA: part.met fálj megnyitása sikertelen: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "HIBA: A part.met fájl 0 méretű: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "HIBA: Érvénytelen .part.met fájl változat: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Hiba: %s (%s) sérült (rossz tagek: %s), a fájl betöltése nem lehetséges."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "HIBA: %s (%s) sérült (hibás tag szám), nem lehet betölteni a fájlt."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Fájl infó helyreállításának megkísérlése..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Névtelen fájl helyreállítása - helyreállítás megkísérlése RecoveredFile.dat néven"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Összes elérhető fájl infó helyreállítva :D - használatának megkísérlése..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Fájl infó helyreállítása nem lehetséges :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "A(z) %s (%s) megnyitása sikertelen"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "FIGYELEM: %s lehet, hogy sérült (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "HIBA a fájlrész mentésénél: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Adatforgalmi hiba a partfile mentésekor: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "0/ismeretlen bájt lett írva a '%s' helyre -- megőrizve a létezö .part.met fájlt."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "A %s. part.met.seeds fájl mentése sikertelen"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i forrás elmentve a részfájlnak: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr " A %s (%s) részfájl forrás fájlja nem olvasható"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Hiba a részfájl forrás-fájljának olvasása közben (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Sérült részt (%d) találtam a %d részű %s fájlban - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "(%i) befejezett fájlrészt találtam a(z) %s fájlban"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s újra algoritmizálása befejeződött"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Váratlan hiba a %s fájl befejezése közben. A fájl szüneteltetve."
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Letöltés befejeződött: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5383,307 +5295,307 @@ msgstr ""
 "Letöltés befejeződött:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Fájl törlése: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "FIGYELEM: Nem tudom a letöltött részt hash-elni - hash-készlet a(z) '%s'-hez hiányos"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "HIBA: Nem tudom a letöltött részt hash-elni - hash-készlet hiányos (%s). Nem volna szabad előfordulnia"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF hiba tördelőalgoritmizáláskor a %u. letöltött résznél, amely %u (max %u) hosszú és a(z) '%s' részfájlhoz tartozik, amely %u hosszú: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "FIGYELEM: Nincs elég szabad hely a lemezen! Fájl szüneteltetése: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "A %i. letöltött fájlrész sérült a %s fájlban"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: %i. sérült rész helyreállítva a '%s'-hez -> megmentett bájtok: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Helyfoglalás"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Elégtelen lemezterület"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Letöltve"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Csatlakozás"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mappák"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Kiszolgálók"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Biztonság"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Felület"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Szűrők"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Távoli elérés"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online aláírás"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Haladó"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Események"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Hibakeresés"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5693,15 +5605,15 @@ msgstr ""
 "    %PARTFILE - teljes út a fájlhoz\n"
 "    %PARTNAME - csak a fájl neve"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5717,35 +5629,35 @@ msgstr ""
 "Ezen beállítások módosítása nélkül is remekül fog\n"
 "működni az aMule."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg csatolása a widget-hez (ID-je: %d, kulcsa: %s) sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Adatátvitel a Cfg-ből a Widget-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "A proxy típusa amihez kapcsolódsz"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Adatátvitel a Widget-ből a Cfg-be (ID-je: %d, kulcsa: %s) sikertelen."
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5753,41 +5665,41 @@ msgstr ""
 "Újra kell indítani az aMule-t, hogy az alábbi változás(ok) érvénybe lépjen(ek):\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP port megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Külső kapcsolat port megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Külső kapcsolat elfogadása megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Külső kapcsolat interfész megváltoztatva.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokoll zavarás támogatása megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5795,7 +5707,7 @@ msgstr ""
 "Az automatikusan frissített kiszolgálóü lista üres.\n"
 "A 'kiszolgáló lista automatikus frissítése induláskor' letiltva."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5803,33 +5715,33 @@ msgstr ""
 "Engedélyezted a távoli elérést, de nem adtál meg jelszót.\n"
 "A távoli elérés nem használható érvényes jelszó nélkül."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Nyelv megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Ideiglenes mappa megváltozott.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K hálózat engedélyezve.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Érvénytelen protokoll verzió."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5837,7 +5749,7 @@ msgstr ""
 "Az eD2k és a Kad hálózat is le van tiltva.\n"
 "Nem fogsz tudni kapcsolódni, amíg legalább az egyiket nem engedélyezed."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5845,7 +5757,7 @@ msgstr ""
 "A Kad nem fog elindulni, ha az UDP portod le van tiltva.\n"
 "Engedélyezd az UDP portot vagy tiltsd le a Kad-ot."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5855,69 +5767,69 @@ msgstr ""
 "Most újra KELL indítanod az aMule-t.\n"
 "Ha nem indítod újra most, ne panaszkodj, ha bármi rossz történik.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Jelszó beállítva, külső kapcsolatok engedélyezve."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5927,65 +5839,65 @@ msgstr ""
 "Kérlek adj meg legalább egy URL-t, ami érvényes server.met fájlra mutat .\n"
 "Az URL megadásához klikkelj a \"Lista\" gombra ezen checkbox mellett."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "az Ideiglenes fájloknak"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Bejövő fájlok"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "az Online aláírásnak"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Válassz egy mappát a %s-nek"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Böngészés a videolejátszóhoz"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Válaszd ki a böngésződet"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Futtatható%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Alapértelmezett"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Kiszolgáló lista szerkesztése"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5993,1194 +5905,1193 @@ msgstr ""
 "URL-ek felvétele a server.met fájl letöltéséhez.\n"
 "Egy sorba csak egy URL."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Teljes források"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Állapot:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Frissítés késleltetése: %d másodperc"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Grafikon átlagos ideje: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Kapcsolatok grafikon-skálája: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Fájl buffer méret: %d bájt"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Feltöltési várólista nagysága: %d kliens"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Kiszolgáló kapcsolat frissítési gyakorisága: %d perc"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Kiszolgáló kapcsolat frissítési gyakorisága: Tiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "letiltva"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Parancs végrehajtása a(z) '%s' eseménynél"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Parancs futtatása a magon"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Mag parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Parancs futtatása a grafikus felületen"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI parancs:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "A következő változók lesznek behelyettesítve:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Megosztott mappák"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Keresési hiba"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum méret figyelmen kívül hagyva."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Keresési figyelmeztetés"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Alap"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k keresést nem lehet végrehajtani, ha nincs kapcsolódva az eD2k-hoz"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "A Kad kereséshez nincs kulcsszó - megszakítva"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nem várt hiba amíg a Kad kereséssel próbálkoztam: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fájl ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nincs értékelve"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Letöltés kategóriába"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s lekérése ehez a fájlhoz"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Kapcsolódó fájlok keresése (eD2k, helyi kiszolgáló)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Ismertként megjelölés"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k hivatkozás másolása a vágólapra"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olyan kiszolgálót próbál törölni, amelyikhez csatlakozva van. Kérém először válassza le."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Megszakítva"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Új"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Az összes felsorolt zavart kiszolgálóval sikertelen a kapcsolatfelvétel. Újra próbálkozom zavarás nélkül."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Az összes felsorolt zavart kiszolgálóval sikertelen a kapcsolatfelvétel. Újra próbálkozom zavarás nélkül."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Az összes felsorolt kiszolgálóval történő kapcsolatfelvétel sikertelen. Újra próbálkozom."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Az összes felsorolt kiszolgálóval történő kapcsolatfelvétel sikertelen. Újra próbálkozom."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Az eD2k hálózat le van tiltva a beállításokban, nem kapcsolódom."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "A kiszolgáló listában nem található érvényes kiszolgáló, amelyhez csatlakozni lehetne."
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Kapcsolódva %s-hez (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Kapcsolat létrejött a %s-vel"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Végzetes hiba kapcsolatfelvétel közben. Lehet, hogy megszakadt az Internet kapcsolat"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Megszakadt a kapcsolat %s-vel (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "A %s (%s:%i) halottnak tűnik."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "A %s (%s:%i) úgy látszik megtelt."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatikus kapcsolódás a kiszolgálóhoz %d másodperc múlva"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Kapcsolódás %s-hez (%s:%i) sikertelen."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "HIBA: A socket érvénytelen az időtúllépés-ellenőrzés során"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Kapcsolódási kísérlet %s-hez (%s:%i): időtúllépés."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Elkésett válasz érkezett egy DNS tudakozáshoz, figyelmen kívül hagyva."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "server.met fájl betöltése: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met fájl nem található!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "server.met fájl '%s' betöltése sikertelen: ismeretlen formátum."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "A server.met megnyitása sikertelen!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "A server.met fájl sérült, érvénytelen verzió-tag: 0x%x, mérete %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i kiszolgálót találtam a server.met fájlban"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d kiszolgáló hozzáadva"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Hiba: a 'server.met' fájl sérült: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "IO hiba a 'server.met' fájl olvasása közben: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Kiszolgáló nem lett hozzádva: [%s:%d] nem egy érvényes port."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Kiszolgáló nem lett hozzáadva: Az IP címe [%s:%d]-nek ki van szűrve vagy érvénytelen."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Kiszolgáló nem lett hozzáadva: Ezzel az IP:Port-tal [%s:%d] már van kiszolgáló a listában."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Kiszolgáló hozzáadva: Kiszolgáló [%s:%d] '%s' néven."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Olyan kiszolgálót próbál törölni, amelyikhez csatlakozva van. Kérém először válassza le."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Nem sikerült megnyitni a '%s'-t"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "A server.met mentése sikertelen!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Érvénytelen URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Kiszolgáló lista letöltése %s-ről befejeződött"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Az addresses.dat fájlban nem található kiszolgáló-lista cím bejegyzés. Kérlek írj be egy érvényes kiszolgáló-lista címet ebbe a fájlba, hogy automatikusan tudjam frissíteni a kiszolgáló listát."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Kiszolgáló lista letöltése %s-ről megkezdve."
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "FIGYELEM: érvénytelen URL megadva a kiszolgálók automatikus frissítéséhez: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Nincs érvényes url a server.met fájl automatikus letöltéséhez az addresses.dat fájlban"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Kiszolgáló lista letöltése sikertelen %s-ről"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "A helyi kiszolgálót kiszűrte az IP-szűrő, újracsatlakozom egy másik kiszolgálóhoz!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Kiszolgáló neve"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "IP-cím"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Leírás"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Felhasználók"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Állandó"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzió"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Olyan kiszolgálót próbál törölni, amelyikhez csatlakozva van. Kérém először válassza le. A kiszolgáló NEM került törlésre."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Ismeretlen név)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Biztos, hogy törlöd az állandó %s kiszolgálót"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Kiszolgálók száma (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Kiszolgáló"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Kapcsolódás a kiszolgálóhoz"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Kiszolgáló megjelölése állandóként"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Kiszolgáló megjelölése nem állandóként"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Kiszolgálók megjelölése állandóként"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Kiszolgálók megjelölése nem állandóként"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Kiszolgáló eltávolítása"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Kiszolgálók eltávolítása"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Összes kiszolgáló eltávolítása"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "eD2k hivatkozások másolása a vágólapra"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Újracsatlakozás a kiszolgálóhoz"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Biztos, hogy törlöd az összes kiszolgálót?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Biztos, hogy törlöd a kiválasztott kiszolgálót?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Biztos, hogy törlöd a kiválasztott kiszolgálókat?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "HIBA: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "FIGYELEM: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Az új ügyfélazonosító %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "FIGYELEM: Alacsony azonosítót (LowID) kaptál!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tLegvalószínűbb oka az lehet, hogy tűzfal vagy router mögött vagy."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tTovábbi információért, kérlek látogasd meg a https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Ismeretlen kiszolgáló infó fogadva! - túl rövid"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d új kiszolgáló fogadva"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Kiszolgáló-lista mentése kész."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "A kiszolgáló visszautasította az utolsó parancsot"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Hibás csomag érkezett a kiszolgálótól: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Kezeletlen hiba a kiszolgálóról történő adatok feldolgozásánál: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "A DNS feloldó szálat nem lehet létrehozni a %s-hez való kapcsolódáshoz"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "A %s IP-jű kiszolgáló (%s) ki van szűrve. Nem kapcsolódom."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "protokoll zavarással."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Kapcsolódás %s-hez (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Nem tudom a DNS-t feloldani a %s kiszolgálóhoz: Nem tudok kapcsolódni!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule Napló"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Kiszolgáló nem lett hozzáadva: IP vagy host név nincs megadva."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Kiszolgáló nem lett hozzáadva: Érvénytelen kiszolgáló-port."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k állapot:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Kapcsolat állapota:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Csatlakozva"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia állapot:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "LAN módban működik"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Fut"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia kliens ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Állapot:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Kapcsolat állapota:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tűzfal által levédve - nyisd meg a %d. TCP port-ot a routereden vagy a tűzfaladon"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP Kapcsolat Állapota:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tűzfal által levédve - nyisd meg a %d. UDP port-ot a routereden vagy a tűzfaladon"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Tűzfal állapot: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nincs szükség pajtásra - TCP port nyitva"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nincs szükség pajtásra - UDP port nyitva"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nincs pajtás"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Kapcsolódás a pajtáshoz"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Pajtáshoz kapcsolódva %s-on"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indexelt források:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indexelt kulcsszavak:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indexelt jegyzetek:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indexelt terhelés:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Átlagos felhasználószám:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Átlagos fájlszám:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "nem fut"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Fájl %s hozzáadása a megosztásokhoz"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i ismert és %i ismeretlen megosztott fájlt találtam"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "HIBA: Megpróbáltuk megosztani a(z) %s-t"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Megosztott könyvtár nem található, mellőzve: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Felhasználói név"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Letöltési sebesség"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Feltöltési sebesség"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Elérhető részek"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Feltöltési állapot"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Letöltési állapot"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Eredet"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Helyi fájlnév"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Fájl lista megosztása"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Megszerzett részek"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Könyvtár útvonal"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Megjegyzés/Értékelés hozzáadása"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Megjegyzés/Értékelés szerkesztése"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Átnevezés"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Add a gyűjteményben szereplő fájlokat az átviteli listához"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Magnet &URI másolása a vágólapra"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "eD2k hivatkozás másolása a vágólapra (Forrás)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "eD2k hivatkozás másolása a vágólapra (Forrás) (Titkosítási opciókkal)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "eD2k hivatkozás másolása a vágólapra (Gazda név)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "eD2k hivatkozás másolása a vágólapra (Gazda név) (Titkosítási opciókkal)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "eD2k hivatkozás másolása a vágólapra (AICH infó)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "eD2k hivatkozás másolása a vágólapra (&AICH infó + forrás)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Érvényes forráshivatkozáshoz magas azonosító (HighID) szükséges"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Távoli fájlnév"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Feltöltött adatok (folyamat (összesen)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Összes többletterhelés (csomagok): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Fájlkérés többletterhelése (csomagok): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Forrásváltás többletterhelése (csomagok): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Kiszolgáló többletterhelése (csomagok): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad többletterhelés (csomagok): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Titkosítás többletterhelés (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktív feltöltések: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Várakozó feltöltések: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Összes sikeres feltöltési folyamat: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Összes sikertelen feltöltési folyamat: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Átlagos feltöltési idő: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Letöltött adatok (folyamat (összesen)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Forrás találatok: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktív letöltések száma (adatelemek): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Fel:Le töltési folyamat aránya (összesen): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Átlagos letöltési arány (folyamat): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Átlagos feltöltési arány (folyamat): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Maximum letöltési arány (folyamat): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Maximum feltöltési arány (folyamat): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Újrakapcsolódások: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Első átvitel óta eltelt idő: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Kiszolgálóhoz kapcsolódva: %s óta"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktív kapcsolatok száma (becsült): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Max kapcsolódási korlát elérve: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Kapcsolatok átlagos száma (becsült): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Legtöbb kapcsolat (becsült): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Kliensek"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Ismeretlen: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Kiszűrve: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Kitiltott: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Összesen: %i Ismert: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Működő kiszolgálók: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Sikertelen kiszolgálók: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Összes: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Törölt kiszolgálók: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Kiszűrt kiszolgálók: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Felhasználók száma a működő kiszolgálókon: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Fájlok a működő kiszolgálókon: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Összes felhasználó: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Összes fájl: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Kiszolgáló leterheltség: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Megosztott fájlok száma: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Megosztott fájlok teljes mérete: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Átlagos fájlméret: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operációs rendszer"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Nem fogadott"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktív kapcsolatok (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nem elérhető"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Soha"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "A '%s' parancs - melynek pid-je '%d' - befejeződési állapotkódja '%d' volt."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Végrehajtja az <str>-t és kilép."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Érvénytelen IP cím formátum. Így használd: xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Ez a parancs argumentumot igényel. Érvényes argumentumok: 'all', fájlnév vagy egy szám.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Feldolgozás hash alapján: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Feldolgozás fájlnév alapján: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Ennek a parancsnak szüksége van egy argumentumra. Érvényes argumentumok: egy fájl hash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Érvénytelen szám\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Nem érvényes hash (a hossza pontosan 32 karakter kell legyen)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7191,7 +7102,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7202,7 +7113,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7210,82 +7121,80 @@ msgstr ""
 "Nem lett megadva keresési típus.\n"
 "A 'help search' paranccsal kaphatsz bővebb segítséget.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Letöltöndő fájl: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Kérés ismeretlen hibával sikertelen."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "A művelet sikeres volt."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "A kérés sikertelen volt a következő hibával: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Kliens IP szűrés %s van kapcsolva.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "KI"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "BE"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Kiszolgáló IP szűrés %s van kapcsolva.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "IP szűrő szintje jelenleg %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Sávszélesség korlátok: Fel: %u kB/s, Le: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Kapcsolódva %s-hez %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Kapcsolódás folyamatban"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "tűzfal mögül"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "rendben"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7294,7 +7203,7 @@ msgstr ""
 "\n"
 "Letöltés:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7303,7 +7212,7 @@ msgstr ""
 "\n"
 "Feltöltés:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7312,7 +7221,7 @@ msgstr ""
 "\n"
 "Várólistás kliensek száma:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7321,46 +7230,46 @@ msgstr ""
 "\n"
 "Összes forrás:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Részfájl]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Keresés eredményeinek száma: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Keresés haladása: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Keresés haladása nem elérhető"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Ismeretlen válasz érkezett a kiszolgálótól, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Rövid állapot információ megjelenítése."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Megjeleníti a kapcsolat állapotát, aktuális fel/letöltési sebességet, stb.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Megjeleníti a teljes statisztika fát."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7375,11 +7284,11 @@ msgstr ""
 "Példa: 'statistics 5' csak a leggyakoribb 5 verziót mutatja minden ügyfél\n"
 "típusból.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Az aMule leállítása."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7389,35 +7298,35 @@ msgstr ""
 "Ez a szöveges klienst is le fogja állítani,\n"
 "hiszen az használhatatlan futó mag nélkül.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "A megadott objektum újratöltése."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "A megosztott fájlok listájának újratöltése."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Az IP szűrő tábla újratöltése."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Az aktuális IP szűrő tábla újratöltése."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "IP szűrő tábla frissítése URL-ról."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Ha nincs megadva URL, a beállításokban megadott URL lesz használva."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Kapcsolódás a hálózathoz."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7429,35 +7338,35 @@ msgstr ""
 "kiszolgálóhoz kapcsolódik. Az IP-nek egy egy hagyományos IPv4 címnek, vagy egy\n"
 "érvényes DNS névnek kell lennie."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Kacsolódás csak az eD2k-hoz."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Kapcsolódás csak a Kad-hoz."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Leválaszt a hálózatról."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Ez leválaszt minden jelenleg kapcsolódott hálózatról.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Leválasztás csak az eD2k-ról."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Csak a Kad-ról választ le."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Egy eD2k vagy magnet hivatkozás hozzáadása a maghoz."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7476,51 +7385,51 @@ msgstr ""
 "\n"
 "A magnet hivatkozásnak tartalmaznia kell az eD2k hash-t és a fájl hosszát.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Egy beállítási érték megadása."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "IP szűrő beállítások megadása."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "IP szűrés bekapcsolása mind a kliensek, mind a kiszolgálók részére."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "IP szűrés kikapcsolása mind a kliensek, mind a kiszolgálók részére."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Engedélyezi/Letiltja a kliensek IP szűrését."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Kliens IP szűrés bekapcsolása."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Kliens IP szűrés kikapcsolása."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Engedélyezi/Letiltja a kiszolgálók IP szűrését."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Kiszolgáló IP szűrés bekapcsolása."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Kiszolgáló IP szűrés kikapcsolása."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "IP szűrési szint kiválasztása."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7528,73 +7437,73 @@ msgstr ""
 "Az érvényes szűrési szintek a 0-255 tartományban vannak, és az alapértelmezett\n"
 "értéke 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Sávszélességi korlátok beállítása."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Az ezeknek a parancsoknak adott érték kilobájt/mp-ben kell legyen.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Feltöltési sávszélesség beállítása."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "A megadott érték kilobájt/mp-ben kell legyen.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Letöltési sávszélesség beállítása."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "A megadott érték kilobájt/mp-ben kell legyen.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Beállítási értékek megjelenítése."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "IP szűrő beállítások lekérdezése."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Az IP szűrő állapotának lekérdezése ügyfelek és kiszolgálók számára."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "IP szűrő állapotának lekérdezése csak ügyfeleknek."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "IP szűrő állapotának lekérdezése csak kiszolgálóknak."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "IP szűrési szint lekérdezése."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Sávszélességi korlátok megtekintése."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Keresés végrehajtása."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7613,44 +7522,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Globális keresés végrehajtása."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Helyi keresés végrehajtása."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Kad hálózaton való keresés végrehajtása."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Az utolsó keresés eredményeinek megjelenítése."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Egy keresés állapotának megjelenítése."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Fájl letöltése."
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7658,80 +7567,80 @@ msgstr ""
 "Az utolsó keresésből a fájl sorszámát kell megadni.\n"
 "Pl: 'download 12' az előző keresésből a 12-es sorszámú fájlt fogja letölteni.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Letöltés szüneteltetése."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Letöltés folytatása."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Letöltés megszakítása."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Letöltési prioritás beállítása."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Alacsony, normál, magas vagy automatikus prioritást állít be.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Alacsony prioritás beállítása."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Normál prioritás beállítása."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Magas prioritás beállítása."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Automatikus prioritás beállítása."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Várósorok/listák megmutatása."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Feltöltési/letöltési várósor, kiszolgáló lista vagy a megosztott fájlok listájának megjelenítése.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Feltöltési várósor megmutatása."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Letöltési várósor megmutatása."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Napló megjelenítése."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Kiszolgáló-lista megmutatása."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "A megosztott fájlok listájának megjelenítése."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Napló törlése."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Elavult parancs, használd a(z) '%s'-t helyette."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7740,261 +7649,258 @@ msgstr ""
 "Ez egy elavult parancs és a jövőben eltávolításra kerülhet.\n"
 "Használd a '%s'-t helyette.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule szöveges kliens"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "A régi AICH hashkészlet konvertálása 64b-re '%s'-ből '%s'-be."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "FIGYELEM: A fájlnév '%s' érvénytelen és '%s'-re lett átnevezve."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "FIGYELEM: A fájl '%s' már létezik, az új fájl '%s'-re lett nevezve."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Biztos benne, hogy megszakítja a letöltéseket és töröl minden fájlt ebből a kategóriából?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Megerősítés szükséges"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Csak 99 kategória támogatott."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Túl sok kategória!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Összes egyéb"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Válassz nézetet"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Új kategória"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Kategória szerkesztése"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Kategória törlése"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hash-készlet kérés az ismeretlen %s fájlhoz"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Fájl feltöltés folytatása: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Fájl feltöltés felfüggesztése: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "A(z) '%s' parancsot a(z) '%s' esemény kapcsán nem sikerült végrehajtani."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Letöltés befejezve"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "A fájl teljes elérési útja."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "A fájlnév könyvtár komponens nélkül."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "A fájl eD2k hash-e."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Fájlméret bájtokban."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Összegzett letöltési aktivitás idő."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Új beszélgetés kezdődött"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Üzenetküldő."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Helyhiány"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Lemez partíció."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Hiba a befejezésnél"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "%u fájl számának feldolgozása: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Rész-hash-eket kért (Csak 9.5 MB fájlméret fölött lehet használni)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Nem létező fájl !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, az aMule eD2k hivatkozás készítője"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Üdvözöljük!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Bemeneti paraméterek"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fájl tördelőalgoritmizálása"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "URL(ek) hozzáadása ehhez a fájlhoz (nem kötelező)"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Itt azt a fájlt add meg, amelyhez eD2k hivatkozást akarsz generálni"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Itt add meg az URL-t amit az eD2k hivatkozáshoz szeretnél adni; ha a végére / jelet teszel, az aLinkCreator automatikusan hozzáfűzi az aktuális fájlnevet."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Hivatkozás készítése rész-hash-ekkel"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Új és ritka fájlokat segít gyorsabban elterjeszteni megnövelt hivatkozásméret segítségével"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 fájl hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k fájl hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k hivatkozás"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Ment"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Másolás a vágólapra"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Megnyitás"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Fájl megnyitása, amire eD2k hivatkozást kell készíteni"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "A számított eD2k hivatkozás másolása a vágólapra"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Mentés másként"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "A számított eD2k hivatkozás mentése fájlba"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "aLinkCreator Névjegy"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Válaszd ki a fájlt, hogy kiszámíttasd az eD2k hivatkozását"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Nem tudom megnyitni a vágólapot"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Nem került másolásra semmi !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Válaszd ki a fájlt a számított eD2k hivatkozásodnak"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Nem lehet megnyitni: "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Kérlek, ne üres fájlnevet adj meg"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Nem került mentésre semmi !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8014,167 +7920,159 @@ msgstr ""
 "\n"
 "GPL alatt terjesztve"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Tördelőalgoritmizálás..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "Az aLinkCreator dolgozik"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "MD4 hash számítása..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "eD2k hash-ek számítása..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Megszakítva !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Elkészült  %.2f mp alatt"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ezt az URL-t már felvette a letöltési listába !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Kérlek, ne üres URL-t adj meg"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "%s-t nem lehet megnyitni"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Elfogyott a memória az ed2k hash kiszámítása közben!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i nap %i óra %i perc %i mp"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02un %02uó %02uperc %02ump"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uó %02uperc %02ump"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02uperc %02ump"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02ump"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule Online Statisztikák"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Legmagasabb letöltési arány a wxCas futása óta"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Abszolút legmagasabb letöltési arány a wxCas előző futása alatt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Töröl"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Rendszer"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Automatikus frissítés leállítása"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Online statisztikák mentése"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Online statisztikák nyomtatása"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Tulajdonságok beállítása"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "wxCas Névjegy"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Automatikus frissítés elindítása"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatikus frissítés leállítva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automatikus frissítés elindítva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Statisztikák mentése"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule online statisztikák"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8182,11 +8080,11 @@ msgstr ""
 "Nyomtatási probléma történt.\n"
 "Lehet, hogy a nyomtatód nincs helyesen beállítva?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Nyomtatás"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8204,403 +8102,392 @@ msgstr ""
 "\n"
 "Distributed under GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Ó ó, az aMule nem fut..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule fut"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "Az aMule fut, de nincs kapcsolódva"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule kapcsolódása folyamatban..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Ó-Ó, az aMule állapota ismeretlen..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " fut "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " megállt !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " nincs kapcsolódva !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " kapcsolódás folyamatban ..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " valami különös történik, ellenőrízd !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " kapcsolódva ehhez: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "nincs"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " csatlakozva ehhez "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " ezzel "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Összes letöltés: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Feltöltés: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Szakasz letöltés: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Letöltés: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Feltöltés: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Megosztva: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fájl(ok), Várólistás kliensek száma: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Idő: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " IP címen "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Rendszer betöltési átlag (1-5-15 perc): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "A rendszer aktivitási ideje (uptime): "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat fájlt tartalmazó könyvtár"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Itt azt a könyvtárat add meg, ahol az amulesig.dat fájl található"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Frissítés gyakorisága mp-ben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Statisztikai kép készítése minden frissítés alkalmával"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Itt azt a könyvtárat add meg, ahová a statisztikát akarod elkészíteni"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Statisztikai kép periódikus feltöltése FTP kiszolgálóra"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP útvonal"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Itt az FTP kiszolgálójának az URL-jét add meg"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Könyvtár megadása"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Felhasználó"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Itt a felhasználói nevet add meg az FTP kiszolgálóra törénő bejelentkezéshez"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Itt a jelszavad add meg az FTP kiszolgálóra törénő bejelentkezéshez"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP frissítési gyakorisága percekben"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Mentés"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Aláírás fájlt tartalmazó könyvtár"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "A statisztika készítésének könyvtára"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Betölti a(z) <str> sablont"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web kiszolgáló HTTP port"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "UPnP port továbbítás használata a web kiszolgáló porton"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Gzip tömörítés használata"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Teljes jogú jelszó a web kiszolgálóhoz"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Vendég jelszó a web kiszolgálóhoz"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Vendég felhasználó tiltása"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "A web kiszolgáló beállításait a távoli aMule-től kéri, illetve oda menti"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule konfig fájl útvonala. NE HASZNÁLD!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP feldolgozó letiltása (nem ajánlott)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "PHP oldalak újrafordítása minden kérésnél"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Web kiszolgáló"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "web ügyfél kapcsolat elfogadva\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "HIBA: nem tudom fogadni a web ügyfél kapcsolatot\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "A kérés sikertelen volt a következő hibával: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Index fájl nem található: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Munkafolyamat időtúllépés - bejelentkezés kérése\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Munkamenet rendben, bejelentkezve\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Munkamenet rendben, nincs bejelentkezve\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nincs munkafolyamat megnyitva - bejelentkezés kérése\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Munkafolyamat létrehozva - bejelentkezés kérése\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Kérés feldolgozása [eredeti]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nincsen megadva jelszó, bejelentkezés nem lesz engedélyezve."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Jelszó hash érvénytelen\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Jelszó rendben\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Hibás jelszó\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Nem adtál meg jelszót. Üres jelszó nem megengedett.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Kijelentkezés\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Kérés feldolgozása [átirányított]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Kapcsolódás sikertelen "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -30,19 +30,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "Informazioni su aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Controllo remoto di aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -50,7 +50,7 @@ msgstr ""
 "Client p2p multipiattaforma basato su eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -58,76 +58,76 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte di aMule è basata su \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer basato su metrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Sito:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Documentazione:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Segnalazioni:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Fai clic per verificare la disponibilità di una versione più recente."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Controlla la presenza di aggiornamenti"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "Controllo aggiornamenti in corso..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "Stai utilizzando la versione più recente."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Una nuova versione (%s) è disponibile:"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "Impossibile verificare la disponibilità di aggiornamenti. Riprova più tardi."
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Aggiungi amico"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Inserire un indirizzo IP e una porta validi!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informazione"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "L'hash utente specificato non è valido!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -139,47 +139,46 @@ msgstr ""
 "\n"
 "Installare ora l'integrazione con il desktop?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "Aggiungere aMule al menu delle applicazioni?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Installa"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Impossibile installare l'integrazione con il desktop: la variabile di ambiente APPDIR non è impostata. Di solito significa che l'AppImage è stata avviata in modo non standard."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "Integrazione di aMule non riuscita"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione con il desktop: errore nella creazione di %s. Verificare che la home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Impossibile installare l'integrazione con il desktop: errore nella scrittura di %s. Verificare che la home directory sia scrivibile."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integrazione AppImage: aMule aggiunto al menu delle applicazioni (%d collegamenti shell in ~/.local/bin)."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -193,103 +192,100 @@ msgstr ""
 "\n"
 "Riavviare aMule ora?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule installato"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Riavvia ora"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Più tardi"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Impossibile aprire il link ed2k."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Chiusura dell'applicazione..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleweb con pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Sto terminando forzatamente l'istanza di amuleapi con pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule in fase di chiusura: Terminazione del core."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule, arresto completato."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Risultati del debug della memoria per la chiusura di aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Associazione del traffico peer-to-peer di aMule all'interfaccia: %s (gli aggiornamenti HTTP usano la route predefinita)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Associazione di tutto il traffico di rete all'interfaccia: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "ATTENZIONE: l'interfaccia di rete configurata '%s' non è stata trovata - il traffico NON è associato ad essa e potrebbe uscire tramite la route predefinita. Controlla il nome dell'interfaccia nelle Preferenze."
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "ATTENZIONE: l'associazione all'interfaccia di rete '%s' richiede privilegi elevati e NON è stata applicata - il traffico potrebbe uscire tramite la route predefinita. Concedi la capability (ad es. 'sudo setcap cap_net_raw+ep' sul binario di aMule) oppure esegui con privilegi sufficienti."
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "ATTENZIONE: impossibile associare all'interfaccia di rete '%s' - il traffico potrebbe uscire tramite la route predefinita."
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Le tue impostazioni di localizzazione sono state impostate a quelle predefinite dal sistema in conseguenza del cambio di configurazione. Spiacente."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -297,22 +293,21 @@ msgstr ""
 "\n"
 "Configurazione EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Password impostata, connessioni esterne abilitate."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Bootstrap di rete"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -321,52 +316,49 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server in esecuzione su pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi in esecuzione su pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Hai scelto di lanciare amuleapi all'avvio, ma il programma amuleapi non può essere eseguito. Installa il pacchetto contenente amuleapi, oppure compila aMule dai sorgenti con -DBUILD_AMULEAPI=YES e installalo."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Impossibile aprire le porte sull'indirizzo specificato: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "La porta %u non è disponibile. Otterrai un ID basso\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -381,48 +373,48 @@ msgstr ""
 "\n"
 "Controlla le impostazioni di rete e verifica che la porta sia aperta in ingresso e in uscita."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Impossibile creare il file per l'online signature di aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "L'impostazione locale selezionata non sembra essere installata sul tuo computer (si tenterà di impostarla in ogni caso)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "È la prima che volta che avvii aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Questa è una versione di prova, aggiornata quotidianamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "non garantiamo che essa non distrugga qualcosa, bruci la tua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "o uccida il tuo cane. Ma *dovrebbe* essere comunque sicura.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Altre informazioni, supporto e nuove versioni possono essere trovate nella nostra homepage,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, o nel nostro canale IRC #aMule su irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Puoi segnalare qualsiasi bug su https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -430,222 +422,218 @@ msgstr ""
 "La directory scelta per contenere il file dell'online signature non è valida!\n"
 "La firma verrà pertanto disabilitata fino a quando il problema non sarà stato risolto attraverso il pannello delle preferenze."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Preallocazione dello spazio su disco per il file '%s' fallita: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERRORE: impossibile aprire il file di log"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ERRORE: il file di log è vuoto. Qualcosa non va."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Il file di log è stato reimpostato"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Messaggio del server: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download di %s saltato, perché il file richiesto non è il più recente."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Impossibile scaricare la lista dei nodi."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Impossibile aprire il file scaricato per il controllo della versione"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Il file per il controllo della versione è corrotto"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Stai usando una versione non aggiornata di aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "La tua versione di aMule è la %i.%i.%i e l'ultima è la %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "L'ultima versione è sempre disponibile su https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATTENZIONE: La tua versione di aMuled è obsoleta: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "La tua copia di aMule è aggiornata."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Impossibile scaricare il file per il controllo della versione"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utenti: %s | File: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utenti: E: %s K: %s | File: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nessuna rete selezionata"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "con ID basso"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "con ID alto"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Connesso a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Connessione in corso a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Disconnesso dalla rete eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad avviato."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad arrestato."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Connesso alla rete Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Connesso alla rete Kad (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Disconnesso dalla rete Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "La rete Kad non può essere utilizzata se la porta UDP è disattivata dalle opzioni. Connessione non avviata."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rete Kad disattivata dalle opzioni. Connessione interrotta."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERRORE: il demone di aMule non può essere usato se le connessioni esterne sono disattivate. Per abilitare le connessioni esterne, puoi usare un aMule normale, far partire amuled con l'opzione --ec-config o impostare la voce \"AcceptExternalConnections\" a 1 nel file ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERRORE: Una password valida è richiesta per utilizzare connessioni esterne, ed il demone aMule non può essere usato senza connessioni esterne. Per lanciare il demone di aMule devi impostare il campo \"ECPassword\" nel file ~/.aMule/amule.conf con un valore appropriato. Esegui amuled con il flag --ec-config per impostare la password. Per maggiori informazioni https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - avvio del timer"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Impossibile creare il file Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -660,191 +648,184 @@ msgstr ""
 "\n"
 "Vuoi aprire la pagina di download?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Nessuna rete"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Controllo remoto di aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "ERRORE FATALE: Creazione del timer principale fallita"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Connessione ad aMule remoto"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Connessione persa"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "Interrompi ed esci"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "Riconnessione... (tentativo %d)"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "Prossimo tentativo tra %d s..."
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -857,40 +838,40 @@ msgstr ""
 "\n"
 "L'interfaccia è in pausa fino al ripristino della connessione."
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "ERRORE FATALE: Creazione del timer di interrogazione fallita"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Ciclo evento..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Connessione in corso..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Connessione non riuscita. Controlla host, porta e password."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Gestore eventi GUI EC remota"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Connessione fallita. Impossibile connettersi a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Qualcosa è andato storto"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Tentativo di riconnessione scaduto; nuovo tentativo in corso."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -899,681 +880,658 @@ msgstr ""
 "Connessione scaduta. Impossibile raggiungere %s:%d entro il tempo previsto.\n"
 "Verificare l'host, la porta e che aMule sia in esecuzione con le connessioni esterne abilitate."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Connessione al core remoto persa. Tentativo di riconnessione..."
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "Riconnesso al core remoto."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentativo di riconnessione %d: connessione a %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "Impossibile avviare la riconnessione; nuovo tentativo a breve."
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Pronto"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Tutto"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "non leggibile"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "non trovato"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "Il core ha rifiutato queste cartelle condivise:%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Collegamento non valido o già nella lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mantenuta la directory '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Ricerca amico per connessione con ID basso"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (falso eMule versione %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (falso eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falso eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basato su eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Richiesto: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiche file per questa sessione: accettata %d di %d richiesta, %s trasferita\n"
 msgstr[1] "Statistiche file per questa sessione: accettate %d di %d richieste, %s trasferite\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiche file per tutte le sessioni: accettata %d di %d richiesta, %s trasferita\n"
 msgstr[1] "Statistiche file per tutte le sessioni: accettate %d di %d richieste, %s trasferite\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Richiesto file sconosciuto"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Messaggio filtrato da '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuovo messaggio da '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi in una cartella inesistente '%s' -> richiesta ignorata"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ATTENZIONE: %s non può essere aperto."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ATTENZIONE: la lista dei file conosciuti è danneggiata, contiene un'intestazione non valida."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Errore I/O durante la lettura del file %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Errore durante il salvataggio del file %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nuova categoria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Scegli una directory per i file scaricati"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Devi specificare un nome per la categoria!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Devi specificare un percorso per la categoria!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Impossibile creare una directory per i file in ingresso per questa categoria. Specificare un percorso valido!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sessione di chat iniziata: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Connesso al client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Connessione al client in corso ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Impossibile connettersi al client / Connessione persa ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Hai superato il controllo captcha e l'utente ha ricevuto il tuo messaggio. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** La tua risposta al captcha era errata ed il tuo messaggio è stato ignorato. Puoi richiedere un nuovo captcha inviando un nuovo messaggio. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Chiudi scheda"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Chiudi tutte le schede"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Chiudi le altre schede"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Inserisci tra gli amici"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Il file dei crediti è stato caricato, %u client conosciuto"
 msgstr[1] "Il file dei crediti è stato caricato, %u client conosciuti"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Crediti scaduti per %u client!"
 msgstr[1] " - Crediti scaduti per %u client!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Non è stato trovato il file 'cryptkey.dat', creazione del file in corso."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Dettagli client"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID basso"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID alto"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Supportato"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Non supportato"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connesso"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Disconnesso"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Non completo"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Cattivo"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificata - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Non disponibile"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi -> richiesta accettata"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi -> richiesta negata"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "L'utente %s (%u) ha richiesto la lista delle directory condivise -> richiesta accettata"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "L'utente %s (%u) ha richiesto la lista delle directory condivise -> richiesta negata"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi nella cartella '%s' -> richiesta accettata"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi nella cartella '%s' -> richiesta negata"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "L'utente %s (%u) condivide la cartella '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "L'utente %s (%u) ha inviato una lista delle directory condivise non richiesta."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "L'utente %s (%u) ha inviato la lista dei file condivisi nella cartella '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "L'utente %s (%u) ha finito di inviare la lista dei file condivisi"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "L'utente %s (%u) ha inviato una lista di file condivisi non richiesta"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "L'utente %s (%u) ha negato l'accesso alla lista dei file e directory condivisi"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Commenti file"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nome utente"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome file"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Giudizio"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Commento"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "Impossibile avviare una ricerca Kad"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Impossibile effettuare una ricerca sulla rete Kad senza esserci connessi"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "Ricerca di commenti su Kad in corso..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Nessun commento"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u commento"
 msgstr[1] "%u commenti"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Client %s bannato per aver spedito %s dati corrotti di %s totali, per il file '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Impossibile caricare i dati delle nazioni da '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Bassa]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Alta]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Molto alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Release"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Richiesta in corso"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Connessione in corso attraverso il server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Coda piena"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In coda"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Download in corso"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Ricezione hashset in corso"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nessuna parte utile"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Impossibile connettere un ID basso a un altro ID basso"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Troppe connessioni"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Connessione via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Troppe connessioni Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Bannati"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Errore di connessione"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Coda remota piena"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Vecchio MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nuovo MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "compatibile con eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Server locale"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Scambio fonti"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiva"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Collegamento"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Fonti salvate"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Risultato della ricerca"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completati"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "In corso"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "ERRORE: Spazio su disco esaurito"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERRORE: Partmet non trovato"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERRORE: Errore di input/output!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERRORE: Fallito!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "In coda"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Download già in corso"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formato del file temp sconosciuto o errato."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Trasferiti"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocità"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonti"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Stato"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tempo rimanente"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Ultima fonte completa vista"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Ultima ricezione"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Sei certo di voler eliminare il file selezionato?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Sei certo di volere eliminare i file selezionati?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1582,109 +1540,106 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "Fer&ma"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Continua"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Rimuovi file completati"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Sposta ogni A4AF su questo file"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Sposta ogni A4AF su questo file (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Sposta ogni A4AF sugli altri file"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opzioni avanzate"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Anteprima"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Mostra &dettagli file"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Mostra tutti i commenti"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copia URI magnet negli appunti"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copia il &link eD2k negli appunti"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copia feedback negli appunti"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "rimuovi"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Assegna a categoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Apri file"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Inserisci un nuovo nome per questo file:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Rinomina file"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Download (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "il gestore di shell predefinito di Windows"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1693,346 +1648,345 @@ msgstr ""
 "Per prevenire questo avviso ad ogni anteprima, \n"
 "seleziona nelle preferenze il tuo lettore video preferito (di default è %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Anteprima"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRORE: Impossibile eseguire il lettore multimediale esterno! Comando: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Salvataggio file parziale %u di %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Tutti i file parziali sono stati salvati."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Caricamento dei file parziali da: %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Caricamento del file parziale %u su %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERRORE: Impossibile caricare il file di backup. Cerca su https://github.com/amule-org/amule/discussions come recuperare i file .part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Tutti i file parziali sono stati caricati."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Non è stato trovato alcun file parziale"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Trovato %u file parziale"
 msgstr[1] "Trovati %u file parziali"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Il filesystem della cartella Temp non supporta file di grandi dimensioni."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Il filesytem della cartella Incoming non supporta file di grandi dimensioni."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Download di %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Stai già cercando di scaricare il file '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Hai già il file '%s' (richiesto come '%s')"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Hai già il file '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Stai già cercando di scaricare il file %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Non posso convertire il magnet link in eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocollo del link %s sconosciuto"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "Impossibile aggiungere %u collegamento (vedere il log per i dettagli)."
 msgstr[1] "Impossibile aggiungere %u collegamenti (vedere il log per i dettagli)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Collegamento eD2k non valido! ERRORE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Il client ha inviato un pacchetto dopo che l'autenticazione era fallita."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Connessione esterna chiusa."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Connessioni esterne disabilitate perché la password è vuota!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Connessioni esterne disabilitate nel file di configurazione"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Accettata nuova connessione esterna"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRORE: impossibile accettare una nuova connessione esterna"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Connessione esterna rifiutata perché la password nelle preferenze è vuota!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Connessione al client: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versione sconosciuta"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID della versione EC non corretto, potrebbe esserci un'incompatibilità binaria. Usare core e client remoto dello stesso snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Non puoi connetterti a una versione stabile da una versione CVS qualsiasi! *fiuu!* possibile crash evitato"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versione protocollo non valida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Tag versione protocollo mancante."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticazione fallita: l'hash specificato come password EC non è valido."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Autenticazione fallita: password errata."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Autenticazione fallita: devi inserire la password."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Richiesta non valida, prima devi autenticarti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Accesso consentito."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Invia il messaggio di errore \"%s\" al client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativo di accesso non autorizzato da %s. Connessione terminata."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando Partfile remoto fallito: hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash del file non trovato: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! errore nel processare l'opcode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Server non aggiunto"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "server non trovato: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "è necessario definire il server da rimuovere"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k è disabilitato nelle preferenze."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Amico non trovato."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Client non trovato."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED richiede EC_TAG_FRIEND o EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ha senso usare la ricerca Web da interfaccia remota."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ricerca in corso. Risultati in arrivo!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Niente punti per il grafico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Il tuo client non è configurato per questo livello di dettaglio."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Connessione esterna: arresto richiesto"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Sto già uscendo."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: aggiungo il collegamento '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d di %d collegamenti non riusciti (non validi o già in elenco)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "Controllo versione soggetto a limite di frequenza; riprova a breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "Il controllo versione non è disponibile su questo demone."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "File non trovato."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nome file non valido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Impossibile rinominare il file."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "La rete Kad è disabilitata nelle Preferenze."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Già connesso ad eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Connessione alla rete eD2k in corso..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Già connesso alla rete Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Connessione alla rete Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Tutte le reti sono disabilitate."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Disconnesso dalla rete eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Disconnesso dalla rete Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Connessione esterna: ricevuto un opcode invalido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode non valido (versione errata del protocollo?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Estensione '%s' sconosciuta per il comando '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comando sconosciuto '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2040,7 +1994,7 @@ msgstr ""
 "\n"
 "Questo comando non può avere un argomento.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2048,7 +2002,7 @@ msgstr ""
 "\n"
 "Questo comando richiede un argomento.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2056,7 +2010,7 @@ msgstr ""
 "\n"
 "Questo comando è incompleto, devi usare una delle estensioni qui riportate.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2064,11 +2018,11 @@ msgstr ""
 "\n"
 "Estensioni disponibili:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comandi disponibili:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2079,17 +2033,17 @@ msgstr ""
 "Tutti i comandi possono essere digitati in maiuscolo o minuscolo.\n"
 "Digitare '%s <comando>' per avere informazioni dettagliate su <comando>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Esce dall'applicazione."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Mostra aiuto."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2097,7 +2051,7 @@ msgstr ""
 "Per avere aiuto su un comando, digitare 'help <comando>'.\n"
 "Per avere la lista completa dei comandi, digitare 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2108,46 +2062,46 @@ msgstr ""
 "Usa '%s' per la lista dei comandi\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Errore di sintassi!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Errore nell'eseguire il comando - ciò non dovrebbe mai accadere! Segnala il bug\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Questo comando non deve avere parametri."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Questo comando richiede un parametro."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argomento non valido."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Questo comando è incompleto."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Digita '%s' per avere altro aiuto.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Questo è %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Questo è %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2155,7 +2109,7 @@ msgstr ""
 "\n"
 "Creazione del client in corso...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2164,7 +2118,7 @@ msgstr ""
 "\n"
 "Ok, uscita in corso da %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2178,331 +2132,326 @@ msgstr ""
 "\n"
 "Sto uscendo...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Mostra questo suggerimento."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host su cui aMule è in esecuzione (default: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta di aMule per connessioni esterne (default: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Password connessioni esterne."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Leggi la configurazione da file."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Non stampare output sullo stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Verboso - mostra anche i messaggi di debug."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Impostazioni locali (lingua) del programma."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Salva le opzioni linea di comando nel file di configurazione."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Crea un file di configurazione basato su quello di aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Mostra la versione del programma."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Forza la compressione ZLIB indipendentemente dalla località dell'IP contattato (utile quando il server è raggiungibile tramite un tunnel VPN che risolve a un IP locale)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "Accoda una copia di tutto l'output della console a questo file di log (default: <config-dir>/amuleapi.log)."
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "Non scrivere alcun file di log; stampa solo sulla console."
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Dettagli file"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% completato"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Benvenuto!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Connessione in corso all'amico"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Tipo di connessione:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Reti"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Porta TCP standard "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estesa (Kad / ricerca globale) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Abilita UPnP per il port forwarding del router"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Stai già cercando di scaricare il file %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Aggiorna lista server all'avvio"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "Avvia aMule automaticamente all'accesso"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registra aMule per i link ed2k://"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra aMule per i link magnet:"
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Cartella per i file temporanei"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Impossibile aprire in lettura il file della lista degli amici 'emfriend.met'!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfriend.met'!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amici"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Mostra &dettagli"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Aggiungi amico"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Rimuovi amico"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Invia &messaggio"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Visualizza file"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Crea slot amico"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Sei sicuro di voler cancellare l'amico selezionato?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Sei sicuro di voler cancellare gli amici selezionati?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2510,11 +2459,11 @@ msgstr ""
 "Non puoi assegnare più di uno slot amico.\n"
 "Assegnato un solo slot."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selezione multipla"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2522,206 +2471,205 @@ msgstr ""
 "Non puoi assegnare più di uno slot amico.\n"
 "Assegnato un solo slot."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Invia messaggio all'utente"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Messaggio da inviare:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Elimina dagli amici"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Invia messaggio"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposta su questo file"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In coda: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Altro file richiesto"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "In attesa di slot d'invio"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "In coda: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Caricamento"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nessuno"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sì"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Scaricamento in corso..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancellato"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "L'URL per scaricare non può essere vuoto"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Impossibile creare la richiesta HTTP per %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "Download HTTP: corpo della risposta vuoto per %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Impossibile spostare il file scaricato in %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Scaricato %s (%llu byte)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "L'URL %s ha restituito: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Download HTTP fallito per %s: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Non autorizzato per %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Migrato il file GeoLite2-Country.mmdb esistente in %s"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country: MaxMind selezionato come sorgente GeoIP ma nessuna License Key configurata. Apri Preferenze -> IP2Country, incolla la tua License Key MaxMind gratuita e clicca su 'Aggiorna ora'."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country: URL personalizzato selezionato come sorgente GeoIP ma nessun URL configurato. Apri Preferenze -> IP2Country e fornisci un URL che punti a un .mmdb (o un .gz / .tar.gz che ne contenga uno)."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country: impossibile risolvere un URL di scaricamento GeoIP."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Scaricamento in corso di nuovo %s da %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Scaricamento del file %s fallito, interruzione aggiornamento."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Impossibile rimuovere %s file, interruzione aggiornamento."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Impossibile rinominare %s file, interruzione aggiornamento."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s aggiornato con successo"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Errore durante l'aggiornamento di %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "Scaricamento DB-IP fallito per il mese corrente - nuovo tentativo con l'URL del mese precedente."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Impossibile scaricare %s da %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Caricamento filtri IP da 'ipfilter.dat' e 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Impossibile caricare il file ipfilter.dat '%s', trovato formato sconosciuto."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Impossibile caricare il file ipfilter.dat '%s', impossibile aprire il file."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Caricato %u intervallo di IP da '%s'."
 msgstr[1] "Caricati %u intervalli di IP da '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u riga non valida è stata scartata."
 msgstr[1] "%u righe non valide sono state scartate."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Impossibile rinominare il nuovo file %s, interruzione aggiornamento."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "Filtro IP pronto"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2729,860 +2677,828 @@ msgstr ""
 "Bootstrap dai\n"
 "client noti"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodi (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP non valido per il bootstrap"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Porta non valida per il bootstrap"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Completa tutti i campi obbligatori"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Messaggio"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Sei sicuro di voler scaricare un nuovo file nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Così facendo, rimuoverai i nodi attuali e riavvierai la connessione Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Continuare?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: chiave di ricerca troppo corta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: la chiave di ricerca è già nella lista: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Impossibile leggere il file nodes.dat - versione troppo vecchia. Questa versione (0) non è più supportata."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Letto %u contatto Kad"
 msgstr[1] "Letti %u contatti Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Nessun contatto trovato: fai un bootstrap oppure scarica un file nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Solo %d contatto Kad disponibile, file nodes.dat non scritto"
 msgstr[1] "Ci sono solo %d contatti Kad disponibili, file nodes.dat non scritto"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Scritto %d contatto Kad"
 msgstr[1] "Scritti %d contatti Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Utente Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "Ricerca note Kad per '%s' non avviata: Kad non è connesso"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "Ricerca note Kad per '%s' non avviata: una ricerca note è già in corso per questo file"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "Ricerca note Kad per '%s' non avviata: il file non è nella lista dei condivisi, nella coda di download né nei risultati di ricerca"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "Ricerca note Kad per '%s' non avviata: un'altra ricerca Kad (es. una ricerca di fonti) sta già usando l'hash di questo file - riprovare tra poco"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "Ricerca note Kad per '%s' non avviata: PrepareLookup non riuscito"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nome file"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Dimensione file"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Rapporto di condivisione"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Richiesto"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Accettato"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fonti complete"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ATTENZIONE: la lista dei file conosciuti potrebbe essere danneggiata, contiene un'intestazione non valida."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Impossibile caricare la voce nella lista dei file conosciuti, il file potrebbe essere corrotto"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Voce non valida nella lista dei file conosciuti, il file potrebbe essere corrotto: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Errore sconosciuto %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Impossibile avere una descrizione dell'errore %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashing in corso"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "In completamento"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Errato"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "In attesa"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Devi specificare una password non vuota."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Password non valida, non è un hash MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Connessione fallita"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "Connessione esterna persa - uscita in corso."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Connessione EC fallita. Risposta vuota."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Connessione esterna: risposta errata dal server. Connessione terminata."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Fatto! Connessione stabilita con aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Fatto! Connessione stabilita."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Connessione esterna: accesso negato a causa di: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Connessione esterna: errore di negoziazione."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERRORE: Impossibile mettersi in ascolto sulla porta TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERRORE: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Taglia"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Incolla"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pulisci"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Connesso (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Connesso (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Connesso (firewalled)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Server: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "IP server: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Non connesso"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Porta TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Porta TCP: Non disponibile"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Porta UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Porta UDP: Non disponibile"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informazioni client"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limite di invio"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limite di scaricamento"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostra aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Nascondi aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Esci"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Illimitato"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menu di aMule nella barra di sistema"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limiti velocità:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: nessuno"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: nessuno"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocità di scaricamento: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocità d'invio: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Nickname: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nessun nickname selezionato!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID client: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nome server: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP server: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Non connesso"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Signature: abilitata"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Signature: disabilitata"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Uptime: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "File condivisi: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Client in attesa: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "DL totale: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "UL totale: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "Incolla qui un link eD2k o un magnet link."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "Aggiungi collegamenti"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Clicca qui per aggiungere il link eD2k dalla casella di testo ai download."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Gli eventi sono visualizzati qui. Per la lista completa, controllare il log nella scheda dei Server."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Caricamento in corso..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Numero di utenti presenti sul server al quale sei connesso..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Utenti: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Utenti connessi al server attuale e stima del numero totale di utenti."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Medie attuali di upload e download. Se l'opzione è stata abilitata i numeri tra parentesi indicano l'overhead dovuto alla comunicazione tra client."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Mostra lo stato attuale di connessione e i trasferimenti attivi. Le frecce rosse indicano che attualmente non sei connesso, le frecce gialle indicano che hai un ID basso (probabilmente il tuo pc è dietro un firewall) e le frecce verdi indicano che hai un ID alto (la miglior connessione possibile)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Non connesso..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Server attualmente connesso."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Cerca"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Locale"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globale"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parametri avanzati"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtraggio"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipo file"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Qualsiasi"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archivi"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Immagini CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Immagini"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programmi"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Testi"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Video"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Estensione"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Dimensione minima"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Byte"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Dimensione massima"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilità"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtra risultati"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverti risultati"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Nascondi file conosciuti"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Cerca"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Ancora"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni clic interroga il peer più vicino successivo per ottenere altri contatti (KADEMLIA_FIND_VALUE_MORE), facendo emergere ulteriori corrispondenze di file che la frontiera alfa iniziale della ricerca non ha rilevato."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Azzera campi"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Risultati"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Rimuovi download completati"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonti del file:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Generale"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nome completo:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "file met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Dimensione file:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Trasferimento"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Stato file part:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Ultima volta visto completo:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fonti trovate:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Fonti in trasferimento:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Numero parti:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibili:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Velocità:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Download Active Time: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Trasferiti:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Completati:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Corruption Handling"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdita per corruzione:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Guadagno per compressione:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pacchetti recuperati da ICH:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "Condivisione"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Richieste"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Richieste accettate"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Dati trasferiti"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Rapporto condivisione"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fonti complete"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "Condiviso dal"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "Ultimo upload"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "Media Info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Durata :"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Bitrate :"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Codec :"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Artista :"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titolo:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nomi file"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Sovrascrivi"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Pulisci"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Applica"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Commenta/giudica il file (il testo sarà visibile a tutti gli utenti)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3590,570 +3506,568 @@ msgstr ""
 "In un film puoi specificare ad esempio durata, trama, lingua... \n"
 "e se è fake, puoi avvisare gli altri utenti di aMule, in modo che NON LO SCARICHINO."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Qualità file"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Senza voto"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Non valido / Corrotto / Falso"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Mediocre"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Discreto"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Buono"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Eccellente"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Giudica il file o avvisa gli altri utenti se il file non è quello corretto..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "Ottieni da Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Download in corso, attendere prego..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Dimensione sconosciuta"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informazioni richieste"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Indirizzo IP:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informazioni aggiuntive"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nome utente:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Aggiungi"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Media sessione"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocità upload"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Download attivi"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Albero statistiche"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nome utente:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software client:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versione client:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Indirizzo IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID utente:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP server:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nome server:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Offuscamento:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Trasferimenti al client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Richiesta attuale:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Velocità media upload:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Velocità media download:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Inviati nella sessione:"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Scaricati nella sessione:"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Inviati in totale:"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Scaricati in totale:"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punteggi"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificatore DL/UL:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificazione sicura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Punteggio in coda:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Punteggio in coda:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nick"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - il Mulo multipiattaforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Questo è il nome che gli altri utenti visualizzeranno quando saranno connessi a te."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Lingua: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Intervallo prima che vengano mostrati i suggerimenti."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Scelta della lingua utilizzata."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Controlla periodicamente la disponibilità di una nuova versione"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Abilitare questa opzione farà sì che aMule verifichi la disponibilità di nuove versioni all'avvio e una volta al giorno durante l'esecuzione"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra una voce di avvio automatico per l'utente nel sistema operativo affinché aMule venga avviato all'accesso. Se sposti l'eseguibile di aMule, avvialo manualmente una volta per aggiornare la voce."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Imposta aMule come gestore predefinito per i link ed2k://, cliccandone uno nel browser o nel file manager verrà aperto qui."
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "aMule gestisce solo i magnet compatibili con eD2k (che contengono xt=urn:ed2k:). I magnet BitTorrent NON sono supportati e cliccandoli non succederà nulla. Se usi un client BitTorrent (Transmission, qBittorrent, ecc.), lascia questa opzione disattivata."
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Avvia ridotto ad icona"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Abilitando questa opzione, aMule si minimizzerà automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Fa in modo che aMule chieda conferma prima di uscire."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Abilita icona nella barra"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Abilita o disabilita l'icona nella barra di sistema o nella barra delle applicazioni."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Nascondi la finestra quando viene premuto il pulsante di chiusura"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Icona nella barra di sistema"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Abilitando questa opzione aMule verrà minimizzato nella barra di sistema invece che nella barra delle applicazioni."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Mostra notifica al termine dello scaricamento"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Con questa funzione abilitata aMule mostrerà una notifica al termine di ogni download."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Ritardo dei suggerimenti: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "secondi"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selezione browser"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Apri in una nuova scheda se possibile"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Se possibile, apri la pagina web in una nuova scheda invece che in una nuova finestra"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Riproduttore video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limiti di banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Allocazione slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Porte"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Questa è la porta standard di eD2k e non può essere disabilitata."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP per le richieste al server (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Questa porta UDP è utilizzata per le richieste estese eD2k e per la rete Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP per UPnP (Facoltativa):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Solo per utenti esperti: forza tutto il traffico di aMule su un'unica interfaccia di rete, scelta dall'elenco oppure digitata per nome (ad es. tun0, eth0, en0) o indice. A differenza dell'associazione a un IP, questo impedisce al traffico di fuoriuscire tramite la route predefinita - utile con una VPN. Non richiede privilegi elevati."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Fonti massime per file in scaricamento:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Connetti automaticamente all'avvio"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Riconnetti dopo perdita connessione"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Rimuovi server inattivi dopo"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr "I server statici non vengono mai rimossi, nemmeno quando risultano irraggiungibili."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "tentativi"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Aggiorna la lista server quando ti connetti ad un server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Aggiorna la lista server quando ti connetti ad un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usa sistema di priorità"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Usa controllo intelligente ID basso in fase di connessione"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Connessione sicura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Connetti automaticamente solo ai server statici"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Assegna priorità alta ai server aggiunti manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Aggiungi i nuovi file da scaricare mettendoli in pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Aggiungi i nuovi file da scaricare con priorità automatica"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Cerca di scaricare prima la parte iniziale e finale del file"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modalità endgame: passa a fonti più veloci per gli ultimi blocchi"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Quando un file viene completato inizia a scaricare il primo file in pausa"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Della stessa categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "In ordine alfabetico"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Prealloca lo spazio su disco per i nuovi file"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Per i nuovi file prealloca lo spazio su disco per l'intero file, in questo modo ridurrai la frammentazione"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Interrompi i download quando termina lo spazio su disco "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleziona se vuoi che aMule controlli il tuo spazio su disco"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Inserire lo spazio disco minimo desiderato."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salva 10 fonti per i file rari ( con < 20 fonti)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Assegna priorità automatica ai nuovi file condivisi"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Trattamento intelligente delle corruzioni (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "L'I.C.H. avanzato si fida di ogni hash (sconsigliato)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "Estrazione dei metadati multimediali"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Estrai durata / bitrate / codec dai file audio e video condivisi"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando abilitato, aMule esegue ffprobe su ogni file multimediale condiviso per compilare le colonne Durata / Bitrate / Codec che gli altri client vedono quando trovano il file in una ricerca. Richiede l'installazione di ffmpeg (il binario ffprobe)."
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "Percorso di ffprobe:"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Percorso completo del binario ffprobe. Lascia vuoto per far sì che aMule lo rilevi automaticamente all'avvio."
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "Rileva"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4161,684 +4075,682 @@ msgstr ""
 "Qui vengono salvati i download completati. Tutti i file in questa cartella sono condivisi automaticamente con gli altri peer.\n"
 "Se questa cartella contiene anche file che non vuoi condividere, impostala su una sottocartella riservata ad aMule."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Cartelle condivise"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Cartelle condivise dal core. Inserisci un percorso per aggiungerne una.)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Percorso assoluto di una cartella sulla macchina del core, ad es. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "Ricorsivo"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Condividi tutte le sottocartelle contenute in questa, comprese quelle create in seguito."
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(fai click con il tasto destro sulle icone per condividere ricorsivamente le sottodirectory)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Condividi file nascosti"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Ricontrolla automaticamente le modifiche nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Segui i collegamenti simbolici nelle cartelle condivise"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "Escludi i file corrispondenti a:"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Modelli con caratteri jolly separati da '|', ad es. .DS_Store|Thumbs.db|*.tmp. I file il cui nome corrisponde non vengono condivisi. La corrispondenza non distingue tra maiuscole e minuscole."
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "I pattern sono espressioni regolari"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Se attivato, l'intero campo è un'unica espressione regolare ('|' indica l'alternanza). Se disattivato, è un elenco di caratteri jolly separati da '|'."
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafici"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Intervallo di aggiornamento: 5 secondi"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Intervallo grafico valori medi: 100 minuti"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Scala grafico connessioni: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Scala grafico di scaricamento:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Colori: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Griglia"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Download attuale"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Media download in corso"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Media sessione di download"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Upload attuale"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Media upload in corso"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Connessioni attive"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nodi Kad attuali"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nodi Kad attivi"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seleziona"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Albero"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numero di versioni di client visualizzate (0=illimitate)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ATTENZIONE !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Numero massimo nuove connessioni / 5 secondi"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "Ricerche di fonti Kad simultanee"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervallo tra le ricerche di fonti Kad (minuti)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervallo tra le richieste alle fonti (minuti)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensione buffer file: 240000 byte"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usa MMAP: accesso ai file mappato in memoria (minor uso di memoria)"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mappa i file parziali in memoria invece di bufferizzarli nell'heap, riducendo l'occupazione di memoria del processo. Potrebbe ridurre la velocità di download su alcuni dischi; ideale per sistemi con memoria limitata o con molto traffico in upload."
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensione coda upload: 5000 client"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervallo aggiornamento connessione al server: disabilitato"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Disabilita la modalità standby a tempo"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Skin da usare: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostra il \"Gestore rapido dei collegamenti eD2k\" in ogni finestra."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostra informazioni estese sulle schede delle categorie"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Mostra versione dell'applicazione nella barra del titolo"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Mostra velocità di trasferimento nella barra del titolo"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Prima del nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Dopo il nome dell'applicazione"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Mostra l'overhead di banda"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientamento verticale della barra degli strumenti"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordinamento colonne in tempo reale (riordina le righe automaticamente al variare dei loro valori)"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Scaricamento dei file in coda"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Mostra la percentuale di avanzamento"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Mostra la barra di avanzamento"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Piatta"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Vieta l'accesso guest"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Password per l'accesso Guest al web server"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "Lancia il webserver all'avvio (deprecato)"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4850,11 +4762,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4870,11 +4782,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4884,504 +4796,504 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "File condivisi"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Disabilitato [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "byte"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/s"
 msgstr[1] "byte/sec"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sec"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ore"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "giorni"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "tutti"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "tutti gli altri"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleti"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Fermo"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archivio"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Testo"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Attivo"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Directory di configurazione in uso: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "In attesa della fine del processo di conversione del file incompleto..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importazione %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lettura directory file temporanei"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Recupero informazioni di base dal file info del download"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Creazione file di destinazione"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Caricamento dati da vecchio file in download (%u su %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Salvataggio blocchi di dati in un singolo file (%u su %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Recupero informazioni fonti e file in download in corso"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Aggiunta download e salvataggio nuovo file parziale in corso"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importazione file parziale"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Stato"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disco: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Scegli una directory in cui cercare download temporanei! (le sottodirectory saranno incluse)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Vuoi che le fonti dei download importati con successo siano cancellate?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Rimuovi fonti?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERRORE: Impossibile creare il file Part"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Caricamento del backup del file met da %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERRORE: Apertura del file part.met fallita: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERRORE: La dimensione del file part.met è 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERRORE: Versione del file part.met invalida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "ERRORE: %s (%s) è corrotto (etichette errate: %s), impossibile caricare il file."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERRORE: %s (%s) è corrotto (computo dell'etichetta errato), impossibile caricare il file."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Tentativo di recupero informazioni sul file..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Recupero file senza nome - tentativo di recupero come RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperate tutte le informazioni disponibili :D - Tentativo di utilizzo in corso..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Impossibile recuperare le informazioni sul file :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Impossibile aprire %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ATTENZIONE: %s potrebbe essere corrotto (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "Errore durante il salvataggio del file incompleto: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Errore di I/O durante il salvataggio dei file Part: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "Scritti 0/sconosciuti byte in '%s' -- viene conservato il .part.met esistente."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Impossibile salvare il file part.met.seeds per %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Salvata %i fonte per il file incompleto: %s (%s)"
 msgstr[1] "Salvate %i fonti per il file incompleto: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Impossibile accedere alle fonti del file Part %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Errore nella lettura del file delle fonti del partfile (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Trovata parte danneggiata (%d) in %d parte %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Trovata parte danneggiata (%d) in %d parti %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Trovata parte completata (%i) in %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Nuovo hashing completato %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Errore imprevisto durante il completamento di %s. File messo in pausa"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Download completato: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5390,306 +5302,306 @@ msgstr ""
 "Download completato: \n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Cancellazione file in corso: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ATTENZIONE: Impossibile calcolare l'hash del file parziale - hashset incompleto per '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRORE: Impossibile calcolare l'hash delle parti scaricate - hashset incompleto (%s). Ciò non dovrebbe mai accadere"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u di '%s' segnata come completata ma il file parziale è più corto del previsto (presenti %llu byte, richiesti %llu); il gap viene riaperto per riscaricare."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF durante l'hashing della parte %u scaricata con lunghezza %u (max %u) del file Part '%s' con lunghezza %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ATTENZIONE: non c'è abbastanza spazio libero su disco! Metto in pausa il file: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "La parte di file scaricata %i è danneggiata in: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: recuperata parte danneggiata %i in %s -> risparmiati byte: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Allocazione in corso"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Scaricato"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "Lettone"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Connessione"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Server"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "File"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Sicurezza"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfaccia"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controlli remoti"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventi"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5699,15 +5611,15 @@ msgstr ""
 "    %PARTFILE - percorso completo del file\n"
 "    %PARTNAME - solamente il nome del file"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Il supporto per l'icona nella tray richiede libayatana-appindicator3 in fase di compilazione."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Non disponibile su Wayland: il protocollo non segnala quando una finestra viene ridotta a icona, quindi questa opzione non può intercettare il pulsante di riduzione del sistema. Soluzione alternativa: avvia aMule con `GDK_BACKEND=x11` per usare XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5722,35 +5634,35 @@ msgstr ""
 "\n"
 "aMule funzionerà anche senza modificare questi parametri."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Insuccesso nel collegare Cfg al widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati da Cfg al Widget con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Il tipo di proxy a cui ti stai connettendo"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Insuccesso nel trasferire dati dal widget al Cfg con ID %d e chiave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Password amministrazione"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5758,39 +5670,39 @@ msgstr ""
 "aMule deve essere riavviato per rendere effettive queste modifiche:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Modifica della porta TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Modifica della porta UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- Associazione all'interfaccia di rete modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Porta della connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Accetta connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Interfaccia connessione esterna modificata. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Modificato il supporto all'offuscamento del protocollo.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- configurazione di amuleapi modificata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5798,7 +5710,7 @@ msgstr ""
 "La tua lista dei server per l'aggiornamento automatico è vuota.\n"
 "L'aggiornamento automatico all'avvio sarà disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5806,32 +5718,32 @@ msgstr ""
 "Hai abilitato le connessioni esterne senza però specificare una password.\n"
 "Le connessioni esterne non possono essere abilitate a meno che tu non scelga una password valida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Modifica della lingua.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Modifica della cartella Temp.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rete ed2k abilitata.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Il pattern di esclusione dei file condivisi non è un'espressione regolare valida. Il filtro è stato lasciato disattivato."
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5839,7 +5751,7 @@ msgstr ""
 "Le reti eD2k e Kad sono entrambe disabilitate.\n"
 "Non potrai connetterti finché non ne abiliterai almeno una."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5847,7 +5759,7 @@ msgstr ""
 "Kad non può partire se la porta UDP è disabilitata.\n"
 "Abilitala o disabilita Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5857,68 +5769,68 @@ msgstr ""
 "DEVI riavviare aMule ADESSO.\n"
 "Se non lo fai, non lamentarti se succede qualcosa di strano.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Impossibile registrare aMule per l'avvio automatico all'accesso. L'archivio di avvio automatico potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Impossibile rimuovere la voce di avvio automatico all'accesso."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Avvio automatico"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "Registra gestore URL"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule gestisce solo i magnet compatibili con eD2k. Se sostituisci il gestore magnet attuale (%s), i link magnet BitTorrent smetteranno di funzionare: aMule non può scaricare contenuti BitTorrent. Continuare?"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Attualmente un'altra applicazione è il gestore predefinito per questi link (%s). Sostituirla con aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Impossibile registrare aMule come gestore URL. Il registro delle associazioni potrebbe essere in sola lettura."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "Impossibile rimuovere la registrazione del gestore URL."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Il server web e aMule API richiedono che le connessioni esterne siano abilitate."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "Il server web di aMule è deprecato. Valuta in alternativa l'uso di aMule API."
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5928,64 +5840,64 @@ msgstr ""
 "Inserisci l'URL di almeno un server valido nel file server.met.\n"
 "Clicca sul pulsante \"Lista\" per inserire l'URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "File temporanei"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "File completi"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online Signature"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Scegli una directory per i %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Escluderebbe %u di %u file condiviso"
 msgstr[1] "Escluderebbe %u di %u file condivisi"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Sfoglia per trovare un riproduttore video"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Scegli browser"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "Seleziona il binario ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Eseguibile%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe non trovato nel PATH né nei percorsi di installazione standard. Installa ffmpeg (che include ffprobe) oppure usa Sfoglia per selezionare manualmente un binario."
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "Ripristinare le impostazioni di questa pagina ai loro valori predefiniti?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "Ripristina i valori predefiniti"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Modifica la lista dei server"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5993,114 +5905,114 @@ msgstr ""
 "Inserisci l'URL da cui scaricare il file server.met.\n"
 "Solo un URL per riga."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "Aggiornamento IP2Country fallito"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dati di MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "Sorgente personalizzata"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "Dati di DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Stato: Caricato%s"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stato: Caricato%s - %s"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Stato: Caricamento fallito - clicca su 'Aggiorna ora' per ricaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Stato: Non trovato - clicca su 'Aggiorna ora' per scaricare."
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervallo aggiornamento: %d secondo"
 msgstr[1] "Intervallo aggiornamento: %d secondi"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Intervallo grafico della media: %d minuto"
 msgstr[1] "Intervallo grafico della media: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scala grafico delle connessioni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dimensione buffer file: %d byte"
 msgstr[1] "Dimensione buffer file: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Dimensione coda upload: %d client"
 msgstr[1] "Dimensione coda upload: %d client"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervallo aggiornamento connessione ai server: %d minuto"
 msgstr[1] "Intervallo aggiornamento connessione ai server: %d minuti"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervallo aggiornamento connessione ai server: disabilitato"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "disattivato"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Esegui comando se si verifica l'evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Abilita l'esecuzione del comando sul core"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comando Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Abilita l'esecuzione del comando sulla GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comando GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Le seguenti variabili saranno sostituite:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6108,1082 +6020,1081 @@ msgstr ""
 "Le seguenti cartelle sembrano posizioni di sistema o sensibili:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle reti eD2k/Kad. Vuoi davvero procedere?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Analisi delle sottocartelle in corso..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Aggiornamento cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u cartelle analizzate..."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Cartella condivisa"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Errore di ricerca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principale"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "La ricerca eD2k non può essere effettuata se la rete eD2k non è connessa"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Nessuna chiave di ricerca per Kad - interruzione in corso"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Errore imprevisto durante la ricerca su Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Ricerca Kad: richiesti risultati più ampi a un altro peer."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Ricerca Kad: nessun peer rimasto a cui richiedere altri risultati (limite raggiunto o nessuna risposta ancora ricevuta)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID File"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Durata"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Download nella categoria"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Ottieni %s per questo file"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca file correlati (eD2k, server locale)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Segna come file conosciuto"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Al momento non sei connesso ad un server che supporta la Ricerca di File Correlati"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Annullata"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nuovo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Impossibile collegarsi ai server statici in lista con offuscamento di protocollo. Ci riprovo senza offuscamento."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Impossibile collegarsi ai server con offuscamento di protocollo. Ci riprovo senza offuscamento."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Impossibile connettersi a tutti i server statici in lista. Procedo con un altro tentativo."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Impossibile connettersi a tutti i server in lista. Procedo con un altro tentativo."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rete eD2k disabilitata nelle preferenze, connessione impossibile."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Nella lista dei server non è stato trovato un server valido a cui connettersi"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Connesso a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Connessione stabilita con: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Errore grave durante il tentativo di connessione. La connessione a Internet potrebbe non essere attiva"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Persa connessione a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) sembra non essere attivo."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) sembra essere pieno."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Riconnessione automatica al server tra %d secondo"
 msgstr[1] "Riconnessione automatica al server tra %d secondi"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Connessione a %s (%s:%i) non riuscita."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERRORE: Nessun socket valido trovato entro il tempo massimo"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Connessione a %s (%s:%i) non riuscita per timeout."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Risultato richiesta DNS ricevuto in ritardo, ignoro."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Caricamento file server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "File server.met non trovato!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Impossibile caricare il file server.met '%s', formato sconosciuto."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Impossibile aprire il file server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met corrotto, trovato tag di versione non valido: 0x%x, dimensione %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "Trovato %i server nel file server.met"
 msgstr[1] "Trovati %i server nel file server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d server aggiunto"
 msgstr[1] "%d server aggiunti"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Errore: il file 'server.met' è corrotto: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Errore I/O durante la lettura del file 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Server non aggiunto: [%s:%d] non specifica una porta valida."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Server non aggiunto: l'IP di [%s:%d] è filtrato o non valido."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Server non aggiunto: server con corrispondente IP:Porta [%s:%d] trovato nella lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Server aggiunto: server [%s:%d] con il nome '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Sei connesso al server che vuoi eliminare. Disconnettiti prima."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Impossibile aprire '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Impossibile salvare il file server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL non valido"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "È terminato il download della lista dei server da %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Non è stato trovato nessun indirizzo nel file 'addresses.dat'. Scrivi un indirizzo che contenga una lista di server in questo file in modo da poter aggiornare automaticamente la lista"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Inizia il download della lista dei server da %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ATTENZIONE: hai specificato un URL non valido per l'aggiornamento automatico dei server: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Nessun URL di file server.met valido in addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Impossibile scaricare la lista dei server da %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Il server locale è filtrato dal filtro IP, mi connetto a un altro server!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome server"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Indirizzo"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Porta"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descrizione"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Utenti"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statico"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versione"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "TCP Flags"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "UDP Flags"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Sei connesso al server che stai cercando di eliminare. Disconnettiti prima. Il server NON è stato eliminato."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(nome sconosciuto)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Sei sicuro di voler eliminare il server statico %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Server (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connetti al server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Segna il server come statico"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Segna il server come non statico"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Segna i server come statici"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Segna i server come non statici"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Rimuovi il server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Rimuovi i server"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Rimuovi tutti i server"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Riconnetti al server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Sei sicuro di voler eliminare tutti i server?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Sei sicuro di voler eliminare il server selezionato?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Sei sicuro di voler eliminare i server selezionati?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERRORE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ATTENZIONE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "Il server %s (%s) ha rifiutato il login (nessun ID client assegnato). Disconnessione in corso."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Il nuovo clientID è %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ATTENZIONE: hai ricevuto un ID basso!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tProbabilmente perché il tuo pc è dietro un firewall od un router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPer altre informazioni visita https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Ricevute informazioni sconosciute dal server! - troppo corto"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Ricevuto %d nuovo server"
 msgstr[1] "Ricevuti %d nuovi server"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Salvataggio della lista dei server completato."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Il server ha rifiutato l'ultimo comando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Pacchetto bogus ricevuto dal server: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Errore non gestito durante l'elaborazione del pacchetto dal server: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Non è possibile creare un thread per risolvere il DNS per connettersi a %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "L'IP del server %s (%s) è filtrato. Connessione bloccata."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "utilizzo offuscamento del protocollo."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Connessione a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Non è possibile risolvere il DNS per il server %s: impossibile connettersi!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "log di aMuleGUI"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Server non aggiunto: non è stato specificato l'IP o il nome dell'host."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Server non aggiunto: porta del server specificata non valida."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Stato eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Tipo di connessione:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Connesso"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Stato Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Esecuzione in modalità LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Attivo"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID client Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Stato:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Stato connessione:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta TCP %d nel tuo router o firewall"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Stato connessione UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta UDP %d nel tuo router o firewall"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Stato del firewall: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nessun amico richiesto - porta TCP aperta"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nessun amico richiesto - porta UDP aperta"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nessun amico"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Connessione in corso all'amico"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connesso all'amico a %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fonti indicizzate:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Parole chiave indicizzate:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Note indicizzate:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Utilizzo indicizzato:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Numero medio utenti:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Numero medio file:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Non attivo"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Aggiungo il file %s alle condivisioni"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Trovati %i file condiviso conosciuto"
 msgstr[1] "Trovati %i file condivisi conosciuti"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Trovato %i file conosciuto, %i sconosciuto"
 msgstr[1] "Trovati %i file condivisi conosciuti, %i sconosciuti"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "Escluso %i file dalla condivisione tramite il filtro"
 msgstr[1] "Esclusi %i file dalla condivisione tramite il filtro"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERRORE: Tentativo di condividere %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Cartella condivisa non trovata, ignoro: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nessun file condivisibile trovato nella cartella: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nome utente"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocità download"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocità upload"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Parti disponibili"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Stato upload"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Stato download"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nome locale file"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Lista file condivisi"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Parti ricevute"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Percorso directory"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Aggiungi commento/giudizio"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Modifica commento/giudizio"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Rinomina"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "Verifica Dati Locali"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Aggiungi i file della collezione alla lista dei trasferimenti"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copia &URI magnet negli appunti"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copia eD2k &link negli appunti (&Fonte)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copia &link eD2k negli appunti (Fonte) (con &opzioni di offuscamento)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copia il collegamento eD2k negli appunti (&Hostname)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copia il collegamento eD2k negli appunti (Hostname) (con &opzioni di offuscamento)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copia il collegamento eD2k negli appunti (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copia il collegamento eD2k negli appunti (&AICH info + Fonte)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Verifica Dati Locali su PartFile non è supportato al momento: %s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Hai bisogno di un ID alto per creare un sourcelink valido"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome file remoto"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Dati inviati (sessione (totale)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Overhead totale (pacchetti): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Overhead richieste file (pacchetti): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Overhead scambio fonti (pacchetti): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Overhead server (pacchetti): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Overhead Kad (pacchetti): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Overhead da offuscamento (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Upload attivi: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Upload in attesa: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Totale sessioni di upload riuscite: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Totale sessioni di upload fallite: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tempo upload medio: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Dati scaricati (sessione (totale)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fonti trovate: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Download attivi (parti): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Rapporto UL:DL sessione (totale): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Velocità media di scaricamento (Sessione): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Velocità media d'invio (Sessione): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Velocità di scaricamento massima (Sessione): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Velocità massima d'invio (Sessione): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Riconnessioni: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tempo dal primo trasferimento: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Connesso al server da: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Connessioni attive (stima): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Limite massimo connessioni raggiunto: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Connessioni medie (stima): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Picco connessioni (stima): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Client"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Sconosciuti: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrati: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Bannati: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Totale: %i Conosciuti: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Server attivi: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Server falliti: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Totale: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Server rimossi: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Server filtrati: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Utenti su server attivi: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "File su server attivi: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Utenti totali: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "File totali: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Occupazione server: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numero di file condivisi: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Dimensione totale file condivisi: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Dimensione media dei file: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema operativo"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Non ricevuto"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Connessioni attive (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Non disponibile"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Mai"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Il comando `%s' con pid `%d' è terminato con il codice di stato `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Esegui <str> ed esci."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formato IP non valido. Usa xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Questo comando richiede un argomento. Argomenti validi sono: 'all', nome file, or un numero.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Elaborazione dell' hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Elaborazione del file: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Questo comando richiede un argomento. Argomenti validi: un file hash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Non è un numero valido\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Non è un hash valido (la lunghezza deve essere di 32 caratteri)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7193,7 +7104,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7203,7 +7114,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7211,82 +7122,80 @@ msgstr ""
 "Il tipo della ricerca non è definito.\n"
 "Digitare 'help search' per ottenere ulteriori informazioni.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Download del file: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Richiesta fallita con errore sconosciuto."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operazione conclusa con successo."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Richiesta fallita con il seguente errore: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Il filtraggio IP per i client è %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "OFF"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "ON"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Il filtraggio IP per i server è %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Il livello IPFilter attuale è %d\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limiti di banda: Up: %u kB/s, Down: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "La rotazione delle fonti in modalità endgame è %s.\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Ricerca iniziata (id %u).\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Connesso a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Connessione in corso"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "firewalled"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7295,7 +7204,7 @@ msgstr ""
 "\n"
 "Download:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7304,7 +7213,7 @@ msgstr ""
 "\n"
 "Upload:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7313,7 +7222,7 @@ msgstr ""
 "\n"
 "Client in coda:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7322,46 +7231,46 @@ msgstr ""
 "\n"
 "Fonti totali:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Partfile]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "Ricerca scaduta o ID sconosciuto. Avvia una nuova ricerca.\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Totale risultati della ricerca: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Avanzamento ricerca: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Avanzamento ricerca non disponibile"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Ricevuta risposta sconosciuta dal server, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Mostra informazione sullo stato."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Mostra stato connessione, velocità di upload e download attuali, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Mostra le statistiche complete."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7374,11 +7283,11 @@ msgstr ""
 "nessun numero significa 'infinito'.\n"
 "Esempio: 'statistics 5' mostrerà solo le cinque versioni più diffuse per ogni tipo di client.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Arresta aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7388,35 +7297,35 @@ msgstr ""
 "L'azione arresterà anche il client testuale, dal momento che diventerà inutilizzabile senza un\n"
 "core in esecuzione.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Ricarica l'oggetto."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Ricarica la lista dei file condivisi."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Ricarica il filtro IP da file."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Seleziona il livello del filtraggio degli IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Aggiorna il filtro IP da URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Se l'URL è omesso verrà utilizzato quello inserito nelle Preferenze."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Connettiti alla rete."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7428,35 +7337,35 @@ msgstr ""
 "connettersi solamente a quello. Si può utilizzare un indirizzo IPv4 oppure\n"
 "un nome risolvibile da un server DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Connettiti solo alla rete eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Connetti solo alla rete Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Disconnettiti dalla rete."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Questo disconnetterà aMule da tutte le reti attive.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Disconnettiti solo dalla rete eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Disconnetti solo dalla rete Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Aggiungi un link eD2k o un magnet link al core."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7474,51 +7383,51 @@ msgstr ""
 "\n"
 "Il magnet link deve contenere l'hash eD2k e la lunghezza del file.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Imposta un valore delle preferenze."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Imposta le preferenze del Filtro IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Attiva il filtro IP per client e server."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Disattiva il filtro IP per client e server."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Attiva/Disabilita il filtro IP per i client."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Attiva il filtro IP per i client."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Disattiva il filtro IP per i client."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Attiva/Disabilita il filtro IP per i server."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Attiva il filtro IP per i server."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Disabilita il filtro IP per i server."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Seleziona il livello del filtraggio degli IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7526,71 +7435,71 @@ msgstr ""
 "I livelli di filtraggio validi vanno da 0 a 255 e il default (iniziale)\n"
 "è 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Imposta limiti di banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Il valore fornito a questi comandi deve essere in kilobyte al secondo.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Imposta limiti di banda per l'upload."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Il valore inserito deve essere espresso in kilobyte al secondo.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Imposta limiti di banda per il download."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "Attiva o disattiva la rotazione delle fonti in modalità endgame."
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Il valore fornito deve essere 1/ON (attiva) o 0/OFF (disattiva).\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Visualizza un'impostazione delle preferenze."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Visualizza le impostazioni del Filtro IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Ottieni stato del filtro IP sia del client che del server."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Ottieni stato del filtro IP per i client."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Ottieni stato del filtro IP dei server."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Imposta il livello del filtraggio degli IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Visualizza limita di banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "Ottieni lo stato della rotazione delle fonti in modalità endgame."
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Effettua una ricerca."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7624,23 +7533,23 @@ msgstr ""
 "Esempio: 'search global linux iso --type Iso --min-size 100M' restituisce\n"
 "risultati per \"linux iso\" di tipo Iso di almeno 100 MiB.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Effettua una ricerca globale."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Effettua una ricerca locale"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Effettua una ricerca sulla rete Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "Mostra risultati di una ricerca."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7648,11 +7557,11 @@ msgstr ""
 "Restituisce i risultati di una ricerca.\n"
 "Accetta facoltativamente un id di ricerca (da 'search ...'); senza id, restituisce i risultati della ricerca avviata più di recente.\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Mostra lo stato d'avanzamento della ricerca."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7660,11 +7569,11 @@ msgstr ""
 "Mostra lo stato d'avanzamento di una ricerca.\n"
 "Accetta facoltativamente un id di ricerca; senza id, mostra lo stato d'avanzamento della ricerca avviata più di recente.\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Scarica un file"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7672,80 +7581,80 @@ msgstr ""
 "Bisogna fornire il numero del file relativo all'ultima ricerca.\n"
 "Esempio: 'download 12' aggiungerà alla coda dei download il file col numero 12 trovato dall'ultima ricerca.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Metti il download in pausa."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Riavvia download."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Annulla download."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Imposta priorità del download."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Imposta la priorità del download a Bassa, Normale, Alta o Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Imposta priorità a Bassa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Imposta priorità a Normale."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Imposta priorità a Alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Imposta priorità a Auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Mostra code/liste."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Mostra la coda di upload/download, la lista dei server o la lista dei file condivisi.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostra la coda di upload."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostra la coda di download."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostra log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostra la lista dei server."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Mostra la lista dei file condivisi."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Cancella log."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comando deprecato, al suo posto usa '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7754,261 +7663,258 @@ msgstr ""
 "Questo è un comando obsoleto, e in futuro potrebbe essere rimosso.\n"
 "Al suo posto usa '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Client testuale aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversione dei vecchi hashset AICH in '%s' a 64b: '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "Verifica Dati Locali (%s): Risultato OK per %s"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "Verifica Dati Locali (%s): ERRORI RILEVATI! %s Blocchi con errori: MD4: %s. %s %s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ATTENZIONE: '%s' non è un nome di file valido ed è stato rinominato in '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ATTENZIONE: il file '%s' esiste già, il nuovo file sarà rinominato in '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Sei sicuro di voler interrompere e rimuovere tutti i file contenuti in questa categoria?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Conferma richiesta"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Solo 99 categorie sono accettate."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Troppe categorie!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Tutto il resto"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Seleziona filtro di visualizzazione"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Aggiungi categoria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Modifica categoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Elimina categoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset richiesto per il file sconosciuto: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Ripristino invio del file: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Sospensione invio del file: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Impossibile eseguire il comando `%s' per l'evento `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Download completato"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Il percorso completo del file."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Il nome del file senza la parte del percorso."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "L'hash eD2k del file."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "La dimensione del file in bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tempo cumulativo di download."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nuova sessione chat iniziata"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Mittente del messaggio."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Spazio esaurito"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partizione disco."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Errore nel completamento"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Elaborazione del file numero %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Hai richiesto l'hash delle parti (solo per file > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> File inesistente!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, il creatore di link eD2k per aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Benvenuto!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parametri di ingresso"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "File da esaminare"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Aggiungi URL per questo file"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Inserisci qui il file di cui vuoi creare il collegamento eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Inserisci qui l'URL che vuoi aggiungere al collegamento eD2k: Aggiungi / alla fine per permettere a aLinkCreator di aggiungere l'attuale nome del file"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Crea collegamento con hash delle parti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Aiuta a diffondere più in fretta i file nuovi e rari, al costo di una connessione più dimensione maggiore dei link"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hash del File MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "hash file eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "link D2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Salva"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Apri"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Apri un file per generare il suo link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copia il link eD2k generato negli appunti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Salva come"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Salva su file il link eD2k generato"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Informazioni su aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Seleziona il file di cui vuoi creare il link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Non posso aprire gli appunti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Non c'è niente da copiare per ora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleziona il file di cui vuoi generare il link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Impossibile aprire "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Inserire un nome file non vuoto"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Non c'è niente da salvare per ora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8028,167 +7934,159 @@ msgstr ""
 "\n"
 "sono distribuiti sotto licenza GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hashing..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator sta lavorando per voi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Calcolo degli hash MD4 in corso..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Calcolo degli hash eD2k in corso..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Annullato !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Eseguito in %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Hai già aggiunto questo URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Inserire un URL non vuoto"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Impossibile aprire %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Si è verificato un errore \"out of memory\" durante il calcolo di un hash ed2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i giorno(i) %i ora(e) %i minuto(i) %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uG %02uore %02umin %02usec"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uore %02umin %02usec"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02usec"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, statistiche in linea di aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Velocità di DL massima da quando wxCas è attivo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Velocità di DL massima nelle precedenti sessioni di wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Pulisci"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Ferma aggiornamento automatico"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Salva immagine statistiche in linea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Stampa immagine statistiche in linea"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Preferenze"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Informazioni su wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Avvia aggiornamento automatico"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Aggiornamento automatico fermato"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Aggiornamento automatico avviato"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Salva immagine statistiche"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Statistiche online aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8196,11 +8094,11 @@ msgstr ""
 "C'è stato un problema durante la stampa.\n"
 "La stampante potrebbe non essere impostata correttamente?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Stampa in corso"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8218,375 +8116,364 @@ msgstr ""
 "\n"
 "Distribuito con licenza GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh oh, aMule non è in esecuzione..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule è in funzione"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule è in esecuzione, ma non connesso"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule si sta connettendo..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh oh, stato di aMule sconosciuto..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " è stato in funzione per "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " è fermo!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " non è connesso!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " si sta connettendo..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " sta facendo qualcosa di strano, controllare!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " è connesso a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "inattivo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " è attivo "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " con "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Download totale: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Download sessione: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Condivisione: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " file, client in coda: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tempo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " attivo "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Carico medio del sistema (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Uptime del sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Cartella contenente il file amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Inserire la cartella contenente il file amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervallo di aggiornamento in secondi"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Genera un'immagine delle statistiche ad ogni aggiornamento"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Inserire la cartella nella quale generare l'immagine delle statistiche"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Carica periodicamente l'immagine delle statistiche sul server FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Percorso FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Inserire URL del tuo server FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Inserire la directory del server FTP nella quale copiare l'immagine"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Utente"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Inserisci il nome utente per accedere al server FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Inserisci la password per accedere al server FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervallo di aggiornamento FTP in minuti"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Verifica"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Cartella contenente il file di firma"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Cartella nella quale generare l'immagine"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carica modello <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web server porta HTTP"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Usa l'UPnP port forwarding sulla porta del server web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Porta UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usa compressione gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Password per l'accesso completo al web server"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Password per l'accesso Guest al web server"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permetti l'accesso guest"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Vieta l'accesso guest"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Carica/salva le impostazioni del web server da/su l'aMule remoto"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Percorso file di configurazione aMule. NON MODIFICARE MANUALMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Disabilita interprete PHP (deprecato)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Ricompila pagine PHP ad ogni richiesta"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Server web di aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "connessione web client accettata\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERRORE: Impossibile accettare la connessione del client web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Richiesta non riuscita per l'errore: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "File indice non trovato: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sessione scaduta - accesso richiesto\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessione valida, utente registrato\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessione valida, utente registrato\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nessuna sessione aperta - richiesta di accesso\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessione creata - richiesta di accesso\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Elaborazione richiesta [originale]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "Rifiuto di leggere `pass` dalla query string dell'URL\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nessuna password specificata, login fallito."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Verifica password\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash della password non valido\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Password valida\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Password errata\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Non hai inserito alcuna password. Le password vuote non sono ammesse.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Disconnessone richiesta\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Elaborazione richiesta [rediretta]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (obbligatorio)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Collegamento sul desktop"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "Avvia aMule all'accesso"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Disinstalla"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Rimuovi dati utente (configurazione, server ED2K, nodi Kad, file parziali)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "File dell'applicazione aMule (obbligatori)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Crea un collegamento di aMule sul desktop."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Avvia automaticamente aMule all'accesso dell'utente corrente (impostazione per singolo utente)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Rimuove i file dell'applicazione aMule, i collegamenti del menu Start e del desktop, la voce di avvio automatico nel registro, le registrazioni degli schemi URL e la voce in Installazione applicazioni (obbligatorio)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Elimina definitivamente %APPDATA%\\aMule per l'utente corrente (aMule.conf, elenco server ED2K, nodi Kad, file parziali, filtri IP, elenco amici). Lascia deselezionato per mantenere le impostazioni."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8594,7 +8481,7 @@ msgstr ""
 "Sembra che aMule sia in esecuzione da $INSTDIR.\r\n"
 "Chiudi aMule (e aMuleD / aMuleGUI) e riprova."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8602,11 +8489,11 @@ msgstr ""
 "Sembra che il demone di aMule (amuled.exe) sia in esecuzione da $INSTDIR.\r\n"
 "Arrestalo e riprova."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Rimozione dell'installazione precedente di aMule in $0..."
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8614,11 +8501,11 @@ msgstr ""
 "Impossibile rimuovere l'installazione precedente di aMule in $0.\r\n"
 "Chiudi i processi aMule in esecuzione e riprova, oppure disinstalla manualmente la versione precedente."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di disinstallazione."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "aMuleを表示する"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMuleリモート制御"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "スナップショット："
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,79 +48,79 @@ msgstr ""
 "  著作権2003-2019、aMuleのチーム\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademliaに基づいています：XORトリックに基づいたP2Pルーティング。\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "起動時に新バージョンを確認する"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kadに接続中です..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "利用不可"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "仲間を追加する"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "正当なIPとポートを入力しなければなりません！"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "情報"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "指定されたユーザハッシュは不正です！"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -129,48 +129,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "接続に失敗しました "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,181 +178,174 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "%s（%s）を開くことはできませんでした"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "OK、%s を終了中です...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "失敗しました"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "ダウンロード完了"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "申し訳ありませんが、設定の変更を行ったため、あなたのロケールはシステム標準に変更されました。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "情報"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "終了の確認"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMuleは動作しています"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "指定したアドレスにポートをバインドできませんでした: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "ポート%uは利用できません。あなたにはLOWIDが与えられます\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +360,48 @@ msgstr ""
 "\n"
 "ネットワークを調べ、ポートが入出力に対して開いているか確認してください。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "オンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMuleのオンライン証明ファイルの生成に失敗しました"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "選択したロケールはあなたのシステムにインストールされていないようです。（注意：いずれにせよ設定を試みます）"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "初めてaMule %sを起動しています"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "このバージョンはテスト・バージョンで、毎日更新されているものです。\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "あなたに損害を与えないということは保証できません。家を焼いてしまうかも知れないし、\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "犬を殺してしまうかも知れません。しかし、安全に使用できる「はず」です。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "私たちのホームページamule-org.github.io、またはIRCチャネルirc.libera.chatの#aMuleには、\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "詳細な情報、サポートや新しいリリースがあります。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "バグはhttps://github.com/amule-org/amule/issuesに気楽に報告してください"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,225 +409,221 @@ msgstr ""
 "あなたが指定したオンライン証明ファイルのフォルダは不正です！\n"
 "設定で訂正するまでオンライン証明を無効にします。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "ファイル '%s' のディスク領域の事前確保が失敗しました: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "エラー：ログファイルを開くことはできません"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "注意：ログファイルは空です。何かがおかしいです。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "ログはリセットされました"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "サーバ・メッセージ：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "ノード・リストをダウンロードのに失敗しました。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "ダウンロードされたバージョン確認ファイルを開くのに失敗しました。"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "破損されたバージョン確認ファイル"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "あなたは古いバージョンのaMuleを使用しています！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "あなたのaMuleバージョンは%i.%i.%iで、最新バージョンは%li.%li.%liです"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：あなたのaMuledバージョンは古くなっています：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "あなたのaMuleは最新のバージョンです。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "バージョン確認ファイルのダウンロードに失敗しました"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "ユーザ: %s | ファイル: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "ユーザ: E: %s K: %s | ファイル: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "ネットワークが選択されていません"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "LowIDを持っています"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "HighIDを持っています"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "接続しています：%s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "%sに接続中です"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kadを開始しました。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kadを中止しました。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kadに接続しています（OK）"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Kadから切断しています"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDPポートが設定で無効にされていると、Kadネットワークを使用できないため、開始しません。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadネットワークは設定で無効にされているため、接続はしません。"
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "エラー：外部接続が無効にされている時にはaMuleのデーモンは使用できません。外部接続を有効にするには、普通のaMuleを使用するか、あるいはamuledをオプション--ec-configで起動させるか、あるいはファイル~/.aMule/amule.confの中でキー\"AcceptExternalConnections\"を１に設定してください。"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "エラー： %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "これはeMuleに基づいたaMule %s です。"
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "設定"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "利用不可"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,196 +633,189 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "ネットワークなし"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "致命的なエラー：タイマを生成できませんでした"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "リモートamuleへ接続する"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "接続を失いました"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "終了時に確認する"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -843,725 +824,702 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "致命的なエラー：タイマを生成できませんでした"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "ファイル情報を回復しようとしています..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "接続中"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "%s（%s：%i）の接続の試しがタイムアウトました。"
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "ネットワークへ接続します。"
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "全て"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "利用不可能です"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr "（偽のeMuleバージョン %#x）"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr "（偽のeMule）"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule（偽のeMule）"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x（eMule v0.%u に基づいています）"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "NickName: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "要求：%s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "当セッションのファイル統計： %d / %d の要求を受け入れ、%s 転送された\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "全セッションのファイル統計： %d / %d の要求を受け入れ、%s 転送された\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "不明なファイルが要求されました"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "%s（IP：%s）からのメッセージがフィルタされました"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "%s（IP：%s）から新しいメッセージが届きました"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "ユーザ %s（%u）はあなたのディレクトリ %s の共有ファイル・リストを要求しました -> 拒否しました"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "警告：known.metを開くことはできません。"
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "警告：Knownfileリストは破損され、不正なヘッダーが含まれています。"
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "known.metファイル%sを読む時にIOエラーが発生しました"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "known.metファイル%sを保存する時にIOエラーが発生しました"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "カテゴリ"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "新しいカテゴリ"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "受信ファイルのフォルダを選択する"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "カテゴリに名前を与えなければなりません！"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "カテゴリにパスを与えなければなりません！"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "カテゴリに受信ディレクトリを生成するのに失敗しました。正当なパスを指示してください！"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "チャット・セションを開始しました：%s（%s：%u）-%s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** クライアントに接続しています ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** クライアントに接続中です ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** クライアントに接続に失敗しました／接続を失いました ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "タブを閉める"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "全てのタブを閉める"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "他のタブを閉める"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "仲間リストに追加する"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "クレジット・ファイルをロードしました。%u個のクライアントが既知です"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u個のクライアントのクレジット期限が満了しました！"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "'cryptkey.dat'が見つかりませんでした。生成します。"
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "クライアントの詳細"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "有効"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "サポート"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "非サポート"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "無効"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "接続"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "切断"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "不完全です"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "悪意の相手"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "検証されています"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "利用不可能です"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "ユーザ %s（%u）はあなたの共有ファイル・リストを要求しました -> 許可しました"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "ユーザ %s（%u）はあなたの共有ファイル・リストを要求しました -> 拒否しました"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "ユーザ %s（%u）はあなたの共有ディレクトリ・リストを要求しました -> 許可しました"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "ユーザ %s（%u）はあなたの共有ディレクトリ・リストを要求しました -> 拒否しました"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "ユーザ %s（%u）はあなたのディレクトリ %s の共有ファイル・リストを要求しました -> 許可しました"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "ユーザ %s（%u）はあなたのディレクトリ %s の共有ファイル・リストを要求しました -> 拒否しました"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "ユーザ %s（%u）は %s のディレクトリを共有しています"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "ユーザ %s（%u）は要求されていない共有ディレクトリを送りました。"
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "ユーザ %s（%u）はディレクトリ %s の共有ファイル・リストを送りました。"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "ユーザ %s（%u）は共有ファイル・リストの送信を終了しました"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "ユーザ %s（%u）は無用の共有ファイル・リストを送りました。"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "ユーザ %s（%u）は共有ファイルまたはディレクトリ・リストへのアクセスを拒否しました。"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "ファイル・コメント"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "ユーザ名"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "ファイル名"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "評価"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "コメント"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kadが走っていない中にはKadの検索はできません"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "コメントがありません"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u個のコメントがあります"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "サーバリストを%sからダウンロードするのに失敗しました"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "オート [Lo]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "オート [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "オート [Hi]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高い"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "非常に高い"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "離す"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "要求中"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "サーバ経由に接続中"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "キューが一杯"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "キューに入っています"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "ダウンロード"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "ハッシュセットを取得中"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "必要な部分がありません"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "LowIDとLowIDの間の接続ができません"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "接続が多すぎます"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Kad経由に接続中"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Kad接続が多すぎます"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "接続禁止"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "接続エラー"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "リモートキューが一杯"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "古いMLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "新しいMLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule互換"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "ローカルサーバ"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "ソース交流"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "パッシブ"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "リンク"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "ソースシード"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "完成された数"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "途中です"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "空き容量不足"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "キューに追加しました"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "すでにダウンロード中です"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "不明な、または不利なtempfileフォーマット。"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "転送済み"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "スピード"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "進捗状況"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "ソース数"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先度"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "ステータス"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "残り時間"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "最後に全部分を確認した時刻"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "最後に受信した時刻"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "本当に選択されたファイルを削除しますか？"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "本当に選択されたファイルを削除しますか？"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1570,460 +1528,456 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "中止する(&S)"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "停止する(&P)"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "再開する(&R)"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "完了したものをクリアする(&L)"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "すぐにこのファイルの全てのA4AFを交換する"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "このファイルの全てのA4AFを交換する（オート）"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "このファイル以外の全てのA4AFを交換する"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "拡張オプション"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "プレビュー"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "ファイルの詳細(&D)"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "全てのコメントを表示"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "マグネットURIをクリップボードへコピーする"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "フィードバックをクリップボードにコピーする"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "割り当てない"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "カテゴリに割り当てる"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "ファイルを開く(&O)"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "このファイルの新しい名前を入力してください："
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "ファイルの改名"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "ダウンロード数（%i）"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "ファイル・プレビュー"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "エラー：外部メディア・プレイヤーを実行できませんでした！コマンド: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "server.metファイルをロード中です：%s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "古いダウンロード・ファイル（%uから%u）からデータをロード中です"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "部分ファイルは見つかりませんでした"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u個の部分ファイルが見つかりました"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "一時ディレクトリがあるファイルシステムは大きなファイルを扱うことができません。"
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "受信ディレクトリがあるファイルシステムは大きなファイルを扱うことができません。"
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "%sをダウンロード中です"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "あなたはすでにファイル'%s'をダウンロードしようとしています"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "あなたはすでにファイル'%s'を持っています"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "あなたはすでにファイル'%s'を持っています"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "リンクの不明なプロトコル：%s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "外部接続は終了しました。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "外部接続は空パスワードのため無効にしました！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "外部接続を設定ファイルに無効しました"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "新しい外部接続を認められました"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "個人設定に空欄のパスワードがあるため、外部接続を拒否しました！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "クライアントを接続中： %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "不明なバージョン"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "間違ったECバージョンID。バイナリ不互換性の可能性があります。同じスナップショットの コアとリモートを使用してください。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "任意CVSバージョンからリリースバージョンに接続はできません！ *ハァ...*起こり得るクラッシュを予防しました"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "無効なプロトコルバージョン。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "プロトコルバージョンタグがありません。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "認証に失敗しました。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "無効なリクエストです。先に認証をしてください。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "アクセスを認められました。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "不正アクセスの試みがなされました。接続は閉じました。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "リモート部分ファイルコマンドが失敗しました：ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "ファイルハッシュは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "あら！OpCode処理エラーが発生しました！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "サーバは追加しませんでした"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "サーバは見付かりませんでした： %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "削除したいサーバを定義しなければなりません"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "リモートインタフェイスからWebSearchする意味がありません。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "検索中です。あと少しで結果をもう一度取ってきます！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "グラフを表示するための点がありません。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "あなたのクライアントはこの詳細段階には設定されていません。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "既にシャットダウン中です。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn：次のリンクを追加中です： '%s'。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "ファイルは見付かりませんでした。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "不正なファイル名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "ファイルを改名できません。"
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kadは個人設定に無効されています。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "すでにKadに接続しています。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kadに接続中です…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kadから切断しています。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "不正なOpCode（プロトコルバージョンが違いますか？）"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "'%s'コマンドに不明な拡張子'%s'。\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "不明なコマンド'%s'。\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2031,7 +1985,7 @@ msgstr ""
 "\n"
 "このコマンドには引数は認められていません。\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2039,7 +1993,7 @@ msgstr ""
 "\n"
 "このコマンドには引数が必要です。\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2047,7 +2001,7 @@ msgstr ""
 "\n"
 "このコマンドは不完全です。下記から拡張をひとつ選択してください。\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2055,11 +2009,11 @@ msgstr ""
 "\n"
 "利用可能な拡張：\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "利用可能なコマンド：\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2070,17 +2024,17 @@ msgstr ""
 "すべてのコマンドは大文字と小文字を区別しません。\n"
 "'%s <コマンド>'を入力すると<コマンド>の詳細情報が表示されます。\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "アプリケーションが終了します。"
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "ヘルプを表示します。"
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2088,7 +2042,7 @@ msgstr ""
 "コマンドに対してヘルプを得るためには'help ＜コマンド＞'を入力してください。\n"
 "全てのコマンドのリストを得るためには'help'を入力してください。\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2099,46 +2053,46 @@ msgstr ""
 "コマンド・リストには'%s'を使用してください\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "シンタックス・エラー！"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "コマンドを処理する時にエラーが発生しました。これはありえない！バッグをリポートしてください\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "このコマンドには引数が認められていません。"
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "このコマンドには引数が不可欠です。"
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "引数が不正です。"
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "このコマンドは不完全です。"
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "'%s'を入力して、ヘルプを得てください。\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "これは %s %s %s　です\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "これは %s %s　です\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2146,7 +2100,7 @@ msgstr ""
 "\n"
 "クライアントを生成中です…\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2155,7 +2109,7 @@ msgstr ""
 "\n"
 "OK、%s を終了中です…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2169,549 +2123,543 @@ msgstr ""
 "\n"
 "終了中です…\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "このヘルプ・テキストを表示する。"
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMuleが起動しているホストです。（デフォルト：127.0.0.1）"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMuleの外接続用のポート。（デフォルト：4712）"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "外接続用のパスワード。"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "設定をファイルから読み込む。"
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "アウトプットをstdoutにプリンとしないように。"
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "冗長にして：デバッグ・メッセージも表示する。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "プログラム・ロカールを設定する（言語）。"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "コマンド・ライン・オプションを設定ファイルに書き込む。"
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "aMuleの設定ファイルを元に設定ファイルを生成する。"
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "プログラム・バージョンをプリンとする。"
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "ファイルの詳細"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%%終わりました"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "ようこそ！"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "仲間と接続しています"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "接続状況："
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "ネットワーク"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "ブートストラップ"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "友達"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "詳細を表示(&D)"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "友達を追加する"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "友達を削除する"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "送信 &Message"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "ファイルを見る"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "友達スロットを設立する"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "選択された友達を削除しますか？"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "選択された友達を削除しますか？"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr "スロットが一つのみ提供されました。"
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "複数選択"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr "スロットが一つのみ提供されました。"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "ユーザへメッセージを送る"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "メッセージ："
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "仲間リストから外す"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "メッセージを送る"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "このファイルへ交換する"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "他のファイルを頼みました"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "待機中のアップロード数： %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "キューに入っています"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "アップロード"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "誰も許可しない"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "いいえ"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "はい"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "ダウンロード中…"
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "ダウンロード済み"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "ダウンロード数（%i）"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "サーバリストを%sからダウンロードするのに失敗しました"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "サーバリストを%sからダウンロードするのに失敗しました"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "IPフィルタ'ipfilter.dat'と'ipfilterstatic.dat'をロード中です。"
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "'ipfilter.dat'ファイル'%s'のロードに失敗しました：不明なファイル・フォーマットに出会いました。"
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "'ipfilter.dat'ファイル'%s'のロードに失敗しました：不明なファイルを開くことはできませんでした。"
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u個のIPレンジを'%s'からロードしました。"
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "不正な形式の行を %u 個破棄しました。"
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2719,2145 +2667,2109 @@ msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "ノード数（%u）"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "ブートストラップするためには正しくないIPです"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "ブートストラップするためには正しくないポートです"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "必要なフィールドをすべて入力してください"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "メッセージ"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "本当に新しいnodes.datファイルをダウンロードしますか？\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "そうすると、現在のノードがなくなり、Kademliaへの接続も初期化されます。"
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "続けますか？"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: 検索キーワードが短すぎます"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u 個のKadコンタクトを読み込みました"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d個のKadコンタクトを書き込みました"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kadネットワーク"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "ファイル名"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "ファイルサイズ"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "共有比"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "要求済み"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "受付済み"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "ソース完了"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "不明なバージョン"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "注意： スキンファイル '%s' を読むために開けませんでした"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "ハッシュ中"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "完了中"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "完了"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "停止"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "エラーあり"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "待機"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "空のパスワードは無効です。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "不正なパスワード、 MD5ハッシュではありません！"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "接続に失敗しました"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "外部接続は終了しました。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "ExternalConn: サーバーからの応答が不正です。接続を閉じました。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "成功です！aMuleへの接続を確立しました "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "成功です！接続を確立しました。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "閉じる"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "カット"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "コピー"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "ペースト"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "クリア"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "全ての選択"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "接続"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "接続"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kas: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Kadに接続しています（ファイアウォール）"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "サーバIP："
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "サーバIP："
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "切断しています"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP：%s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "クライアント情報"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "接続する"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "aMuleを表示する"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "aMuleを隠す"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "終了"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "無制限"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMuleのトレイ・メニュー"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL：無制限"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL：%u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL：無制限"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL：%u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "ダウンロード速度："
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "アップロード速度"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "あだ名：%s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "あだ名が選択されていません！"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "クライアントID："
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "サーバ名："
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "サーバIP："
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "接続されていません"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "オンライン証明：有効です"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "オンライン証明：無効です"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "動作時間： %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "DLの合計：%s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "ULの合計：%s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "コアにED2K、またはマグネット・リンクを追加します。"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "仲間リストに追加する"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "イベントはここに表示されます。イベントの全てのリストにはサーバ・タブに存在するログを参考してください。"
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "ロード中…"
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "接続中のサーバのユーザ数…"
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "ユーザ：0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "現在接続中のサーバのユーザ数と合計ユーザ数の推測。"
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "アップ： 0.0 | ダウン： 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "現在の平均アップロード・ダウンロード速度。有効であれば、ブレースに囲まれている数字はクライアント・コミュニケーションのオーバヘッドを意味します。"
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "接続状態とアクティブ転送数を表示します。赤い矢印は現在接続していないことを意味します。黄色の矢印はlow ID（ファイアウォールされている）を意味します。緑色の矢印はhigh ID（最善の接続）を意味します。"
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "切断しています…"
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "現在接続しているサーバ。"
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "検索"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "名前："
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "タイプ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "ローカル"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "グローバル"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "拡張パラメタ"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "フィルタリング"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "フィルタの種類"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "すべて"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "アーカイブ"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "オーディオ"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CDイメージ"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "画像"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "プログラム"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "テキスト"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "ビデオ"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "拡張子"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "最小サイズ"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "B"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "最大サイズ"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "入手可能範囲"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "フィルタ："
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "フィルタの結果"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "結果を反転する"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "既知のファイルを隠す"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "開始"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "もっと"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "中止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "ダウンロード"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "フィールドをリセット"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "結果"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "完成したダウンロードをクリアします"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "ソース完了"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "非適用"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "一般"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "完全名："
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "metファイル："
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "ハッシュ："
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "ファイル・サイズ："
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "転送"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "部分ファイルの状態："
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "最後に完全として見た時間："
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "見つかったソース："
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "転送中のソース："
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "ファイル部分の数："
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "入手可能数："
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "ダウンロードのアクティブ時間："
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "転送済み："
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "完全サイズ："
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "I.C.H.（知的破損処理）"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "破損による損失："
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "圧縮による獲得："
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.C.H.に救済されたパケット："
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "共有： "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "要求"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "認められた要求"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "転送されたデータ"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "共有比"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "完成したソース"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "共有ファイル"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr "、 アップロード： "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "評価されていません"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "タイトル："
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "ファイル名"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "引き継ぐ"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "クリーンアップ"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "適用"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "ファイルへのコメントまたは評価を書き込んでください（テキストは全ユーザが見ることができます）"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "ファイルの質"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "評価されていません"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "不正／損被／偽造"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "悪い"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "悪くない"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "良い"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "優秀"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "ファイルの評価を選択するか、または偽造の注意を他のユーザに伝えてください…"
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Kadから切断しています"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "リフレッシュする"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "ダウンロード中です。しばらくお待ちください…"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "サイズが不明です"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "不可欠な情報"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IPアドレス："
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "追加情報"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "ユーザ名："
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "追加"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "セッション平均"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "アップロード速度"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "統計木"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "ユーザ名："
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "クライアント・ソフトウェア："
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "クライアント・バージョン："
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IPアドレス："
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ユーザID："
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "サーバIP："
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "サーバ名："
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "難読化:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "クライアントへの転送数"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "現在の要求："
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "平均アップロード速度："
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "平均ダウンロード速度："
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "アップロード（セッション）："
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "ダウンロード（セッション）："
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "アップロード（合計）："
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "ダウンロード（合計）："
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "スコア"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DL/UP変更："
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "セキュア認証："
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "キューに追加しました"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "キュースコア："
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "ニックネーム"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "接続してくるユーザはこの名前を見ることになります。"
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "ツールチップを表示するまでの遅延時間。"
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "コントロールに使う言語をここで指定します。"
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "起動時に新バージョンを確認する"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "これを有効にするとaMuleはスタートアップの時に新バージョンをチェックする"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "起動時に最小化にする"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "これを有効にするとaMuleは起動時に最小化する。"
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "終了時に確認する"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "トレイ・アイコンを有効にする"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "システム・トレイ、またはタスク・バーのアイコンを有効／無効にします。"
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "最小化時にトレイ・アイコンに入れる"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "これを有効にするとaMuleはタスク・バーの代わりにシステム・トレイに最小化します。"
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "ブラウザ選択"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "可能ならば新しいタブで開く"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "可能なら、ウェブ・ページを新しいウインドウではなくて新しいタブで開きます"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "ビデオ・プレイヤー"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "アップロード"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "スロット割り当て"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "スタートアップに自動接続する"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "接続を失う時に再接続する"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "再試行後、応答のないサーバを削除する。再試行回数："
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "回"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "リスト"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "優先度システムを使用する"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "接続の時にLowIDチェックを使用する"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "安全接続"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "スタティック・リストに含まれているサーバのみに自動接続する"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "手動で追加したサーバを高い優先度に設定する"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "ダウンロードファイルを停止モードで追加する"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "ダウンロードファイルを優先度を自動にして追加する"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "最初と最後のチャンクを先にダウンロードしようとする"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "同じカテゴリから"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "新しいファイルのためのディスク領域を事前に確保する"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新しいファイルのためにファイル全体が格納できるディスク領域を事前に確保し、断片化を防ぎます。"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "望ましい最小のディスク領域をここに入力してください。"
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "珍しいファイルには10ソースを保存する（<20ソース）"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "アップロード数"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "新しい共有ファイルを自動優先度として追加する"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "削除"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "（再帰的に共有するにはフォルダ・アイコンを右クリックしてください）"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "隠れたファイルを共有する"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "グラフ"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "アップデート延期：５秒"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "平均グラフの時間：１００分"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "接続数のグラフスケール：１００"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "グリッド"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "ダウンロード現在"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "ダウンロード移動平均"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "ダウンロードセッション平均"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "アップロード現在"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "アップロード移動平均"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "アクティブ接続数"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "システム・トレイ・アイコン・スピードバー"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "現在のKadノード数"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "動作中のKadノード数"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "選択"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "表示されているクライアントのバージョン数（0＝無制限）"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "！！！注意！！！"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "最大の新しい接続数（5秒ごと）"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "ファイル・バファー・サイズ：240000バイト"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "アップロードキューサイズ：5000クライアント"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "サーバ接続のリフレッシュ空間：無効にする"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "延長情報をカテゴリ・タブで表示する"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "タイトルに転送速度を表示する"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "垂直ツールバー"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "フラット"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "ゲストアクセスを拒否する"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4865,11 +4777,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4879,850 +4791,850 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "共有ファイル"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "使用不可能 [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "バイト"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "B/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "秒"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "分"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "時間"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "日"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "全て"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "他の全て"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "未完成"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "中断しています"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "ビデオ"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "アーカイブ"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "テキスト"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "アクティブ"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "%s：%sをインポートします"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "一時フォルダを読み中です"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "基本情報をダウンロード情報ファイルから取ってきます"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "当てファイルを作成中です"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "古いダウンロード・ファイル（%uから%u）からデータをロード中です"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "データ・ブロックを一つの新しいダウンロード・ファイル（%uから%u）に纏め中です"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "ソース・ダウンロードファイル情報を取ってきます"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "ダウンロードを追加して、新しい部分ファイルを保存中です"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "部分ファイルをインポートをします"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "状況"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "ファイル・ハッシュ"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s（ディスク：%s）"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "一時ダウンロードを検索するフォルダを選択してください（サブフォルダは含まれます）"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "成功にインポートしたダウンロードのソース・ファイルを削除しますか？"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "ソースを削除しますか？"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "エラー：部分ファイルを作成できませんでした！"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "metファイルのバックアップを%sからロードしようとしています"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "エラー： %s（%s）は破損されて（tagcountが間違っています）、ファイルはロード出来ません。"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "ファイル情報を回復しようとしています…"
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "無名なファイルを回復中です：RecoveredFile.datとして回復しようとします"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "得られる全てのファイル情報を回復しました：使用しようとしています…"
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "残念ながら、ファイル情報を回復できませんでした。"
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "%s（%s）を開くことはできませんでした"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "部分ファイル%s（%s ==> %s）の保存中にエラーが発生しました"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "部分ファイル%s（%s ==> %s）の保存中にエラーが発生しました"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "%sのためのpart.met.seedsファイルは保存できませんでした"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i個のソース・シードを次の部分ファイルに保存しました：%s（%s）"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "%i個のソース・シードを次の部分ファイルに保存しました：%s（%s）"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "部分ファイルのシード・ファイルを読む時にエラーが発生しました：（%s - %s）%s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "破損されている部分（%d）が%d部分、ファイル%sに見つかりました：FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "完成した部分（%i）が%sに見つかりました"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%sの再ハッシュを終了しました"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "ダウンロードが終了しました：%s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "ダウンロードが終了しました：%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "ファイルを削除します：%s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "注意：ディスク容量が足りません！ファイルを停止します：%s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "ダウンロードした部分%i（ファイル：%s）は破損されています"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：破損された部分%i（%sのため）を回復しました→：%s バイトを保存しました"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "領域確保中"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "ダウンロード済み"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "接続"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "ディレクトリ"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "サーバ数"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "セキュリティ"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "プロクシ"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "リモート制御"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "イベント"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5738,85 +5650,85 @@ msgstr ""
 "この設定を変更しなくてもaMuleはうまく動いて\n"
 "います。"
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "接続するプロクシーの種類"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "パスワードをチェック中です\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr "この変更点を有効するにはaMuleを再起動しなければなりません：\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDPポートを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "外部接続は終了しました。"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "プロトコルを難読化する"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5824,40 +5736,40 @@ msgstr ""
 "外部接続を有効にしましたがパスワードを設定していません。\n"
 "有効なパスワードを設定しないと外部接続を可能できません。"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- 言語を変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- 一時フォルダを変更しました。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "全てのネットワークが無効になっています。"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "無効なプロトコルバージョン。"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5865,7 +5777,7 @@ msgstr ""
 "UDPポートが無効になっているとKadは開始できません。\n"
 "UDPポートを有効にするか、またはKadを無効にしてください。"
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5875,69 +5787,69 @@ msgstr ""
 "必ず早急にaMuleを再起動してください。\n"
 "今すぐに再起動しなければ、挙動がおかしくなる可能性があります。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "新しい外部接続を認められました"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5947,65 +5859,65 @@ msgstr ""
 "せめて一つのURLを入力して、有効なserver.metファイルを指定してください。\n"
 "このチェックボクスの近くの\"表\"ボタンをクリックして、URLを入力してください。"
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "一時ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "受信ファイル"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "オンライン署名"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr " %s のためのフォルダを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "ビデオプレイヤーを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "ブラウザを選択する"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "実行ファイル%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "システムの標準設定"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6013,1213 +5925,1212 @@ msgstr ""
 "server.metファイルをダウンロードするURLをここに追加してください。\n"
 "一行にひとつのURLのみです。"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "ソース完了"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "ステータス："
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "アップデート遅延時間： %d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均グラフの時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "接続グラフスケール： %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "ファイルバッファサイズ： %d バイト"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "アップロードキューサイズ： %d クライアント"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "サーバ接続リフレッシュ遅延時間： %d 分"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "サーバ接続リフレッシュ遅延時間： 無効"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "無効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr " `%s' イベントにコマンドを実行する"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "コアにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "コアコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "GUIにコマンドを実行することを有効にする"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUIコマンド："
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "次の変数は置換されます："
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "一時フォルダを読み中です"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "共有ファイル"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小サイズは最大サイズより小さくなければなりません。最大サイズを無視します。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "検索の注意"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "メイン"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kadを検索する間に不明なエラーが発生しました： "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ファイルID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "評価されていません"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "カテゴリにダウンロードする"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "このファイルにオプショナルURLを追加する"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "既知ファイルとしてマークする"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "削除しようとするサーバには現在接続しています。先に切断を行ってください。"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "キャンセル"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "難読化されたすべてのサーバへの接続に失敗しました。難読化せずにもう一度試みます。"
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "難読化されたすべてのサーバへの接続に失敗しました。難読化せずにもう一度試みます。"
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "リストされたすべてのサーバへの接続に失敗しました。もう一度試行します。"
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "リストされたすべてのサーバへの接続に失敗しました。もう一度試行します。"
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "%s（%s：%i）に接続しています"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr " %s に接続を確立しました"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "接続中に致命的なエラーが発生しました。インターネット接続がダウンしている恐れがあります。"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "%s（%s：%i）の接続を失いました"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s（%s：%i）は応答しないようです。"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s（%s：%i）は一杯のようです。"
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "自動的なサーバへの接続は、あと%d秒で再試行します"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "%s（%s：%i）の接続に失敗しました。"
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "%s（%s：%i）の接続の試しがタイムアウトました。"
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "server.metファイルをロード中です：%s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.metファイルは見つかりませんでした！"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "server.metファイル'%s'をロードに失敗しました。不明なフォーマットが原因です。"
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "server.metを開くのに失敗しました！"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "server.metファイルは破損しています。不正なバージョン・タグが見つかりました：0x%x、サイズ %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "server.metに%i個のサーバが見つかりました"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d個のサーバが追加されました"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "known.metファイル%sを読む時にIOエラーが発生しました"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "サーバは追加されていません：[%s:%d]は正当なポートを指示していません。"
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "サーバは追加されていません：[%s:%d]はフィルタされているか、または不正です。"
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "サーバは追加されていません：同じ[%s:%d]のIP:ポートはリストに見つかりました。"
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "サーバは追加されました：[%s:%d]は'%s'という名前を使用しています。"
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "削除しようとするサーバには現在接続しています。先に切断を行ってください。"
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "'%s'を開くことができませんでした"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "server.metを保存するのに失敗しました！"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "不正なURL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "サーバリストを%sからダウンロードするのを完了しました"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "サーバリストを%sからダウンロードするのを開始する"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "addresses.datに、正しいserver.metの自動ダウンロードURLがありません。"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "サーバリストを%sからダウンロードするのに失敗しました"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "ローカル・サーバはIPFiltersにフィルタされているため、違うサーバに接続します！"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "サーバ名"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "アドレス"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "ポート"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "説明"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "ユーザ"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "スタティック"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "バージョン"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "接続中のサーバを削除しようとしています。先に切断してください。 このサーバは削除されませんでした。"
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "（不明な名前）"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "スタティックサーバ %s を本当に削除しますか？"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "サーバ （%i）"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "サーバ"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "サーバへ接続する"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "サーバをスタティックとしてマークする"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "サーバを非スタティックとしてマークする"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "サーバをスタティックとしてマークする"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "サーバを非スタティックとしてマークする"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "サーバを削除する"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "サーバを削除する"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "全てのサーバを削除する"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "サーバへ再接続する"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "全てのサーバを本当に削除しますか？"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "全ての選択されたサーバを本当に削除しますか？"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "全ての選択されたサーバを本当に削除しますか？"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "新しいclientidは%uです"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "注意：あなたはLow-IDを得られました！"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t恐らくパソコンがファイラウォールやルータの裏にあるのが原因です。"
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "不明なサーバ情報を受信しました！理由：短しぎます"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d個の新しいサーバを受信しました"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "サーバ・リストの保存を終了しました。"
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "サーバは最後のコマンドを断りました"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "サーバ%sから偽造のパケットが届きました"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "サーバ%sのパケットを処理する時に未処理例外エラーが発生しました"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "%sに接続するためのDNS解決スレッドを作成せきません。"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IPアドレス%sのサーバ%sはフィルタリングされています。接続はしません。"
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "難読化プロトコルを使用しています。"
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "%s（%s - %s：%i）%sへ接続中です。"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "%sに接続するためのDNSは解決できませんでした：接続はできません！"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMuleのログ"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "サーバは追加しませんでした：IPまたはホスト名は指示されていませんでした。"
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "サーバは追加しませんでした：不正なサーバ・ポートが指示されました。"
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "接続状況："
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "接続"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademliaのステータス："
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "%s に起動しています"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "走っています"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademliaのステータス："
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "ステータス："
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "接続状況："
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "接続状況："
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "ファイアワォールされた状況："
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "仲間がありません"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "仲間と接続しています"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "仲間と接続しています"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "見つかったソース："
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "インデックスファイルが見付かりませんでした： "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "平均のユーザ数："
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "平均のファイル数："
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "動作していません"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i個の既知、%i個の未知の共有ファイルが見つかりました"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "サーバは見付かりませんでした： %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "ユーザ名"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "ダウンロード速度："
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "アップロード速度"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "入手可能数："
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "アップロードの状態"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "ダウンロードの状態"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "ファイル名"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "共有ファイル"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "得られた部分"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "ディレクトリパス"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "コメントおよび評価を追加する"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "コメントおよび評価を編集する"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "改名する"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "コレクションに存在するファイルを転送リストに追加する"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "マグネット &URI をクリップボードにコピーする"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "ED2kリンクをクリップボードにコピーする（&AICH インフォ）"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "有効なソースリンクを作るにはHighIDが必要です"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "ファイル名"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "アップロードされたデータ（セッション合計）： %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "合計オーバヘッド（パケット数）： %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "ファイル要求のオーバヘッド（パケット数）： %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "ソース交換のオーバヘッド（パケット数）： %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "サーバのオーバヘッド（パケット数）： %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kadのオーバヘッド（パケット数）： %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "暗号化オーバーヘッド (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "アクティブなアップロード数： %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "待機中のアップロード数： %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "成功したアップロードセッションの合計： %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "失敗したアップロードセッションの合計： %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "平均アップロード時間： %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "ダウンロードされたデータ（セッション合計）： %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "見付かったソース： %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "アクティブなダウンロード数（塊数）： %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "セッションの合計UL/DL比： %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "再接続数： %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "最初の転送からの経過時間： %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "サーバへの接続時刻： %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "アクティブな接続数（推測）： %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "最大接続数への到達： %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "平均接続数（推測）： %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "ピーク接続数（推測）： %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "クライアント数"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "サイズが不明です"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "フィルタされた数"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "接続禁止"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "合計： %i 既知： %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "動作サーバ数： %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "失敗したサーバ数： %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "合計： %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "削除されたサーバ数： %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "フィルタされたサーバ数： %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "動作サーバのユーザ数： %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "動作サーバのファイル数： %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "ユーザ合計： %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "ファイル合計： %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "サーバ占有： %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共有ファイル数： %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "共有ファイルの合計サイズ： %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "オペレーティング・システム"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "受信していません"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "アクティブな接続（1:%u）"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "利用不可"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "記録なし"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "PID `%2$d' のコマンド  `%1$s' がステータスコード  `%3$d' で終了しました。"
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str>を実行してから終了する。"
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "不正なIPフォーマット。xx.xxx.xxx.xxx:xxxxを使用ください\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "このコマンドには引数が必要です。有効な引数：'all'、ファイル名、または数字。\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "ハッシュで処理しています: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "ファイル名で処理しています: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "このコマンドには引数が必要です。有効な引数：ファイルのハッシュ。\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "正当な数字ではありません\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "正当なハッシュではありません（長さは丁度32半角文字あるべきです）\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7228,7 +7139,7 @@ msgstr "'%s'を入力して、ヘルプを得てください。\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7237,89 +7148,87 @@ msgstr "'%s'を入力して、ヘルプを得てください。\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "'%s'を入力して、ヘルプを得てください。\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "ダウンロード数（%i）"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "不明なエラーによって要求が失敗しました。"
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "オペレーションは成功しました。"
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "リクエストは次のエラーで失敗しました：%s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "クライアントのIPフィルタリングは%sです。\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "オフ"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "オン"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "サーバのIPフィルタリングは%sです。\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "現在のIPフィルタ段階は%dです。\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "%s %s %sに接続されています"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "只今接続中です"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "ファイアウォールされています"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7328,7 +7237,7 @@ msgstr ""
 "\n"
 "ダウンロード数：\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7337,7 +7246,7 @@ msgstr ""
 "\n"
 "アップロード数：\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7346,7 +7255,7 @@ msgstr ""
 "\n"
 "キューに入っているクライアント数：\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7355,46 +7264,46 @@ msgstr ""
 "\n"
 "合計ソース数：\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[部分ファイル]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "検索結果数：%i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "サーバから不明な返事が届きまして、OpCodeは%#xです。"
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "短い状態情報を表示する"
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "コ接続状態、現在のアップロード／ダウンロード速度等を表示する。\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "詳細な統計ツリーを表示する。"
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7408,51 +7317,51 @@ msgstr ""
 "\n"
 "例： 'statistics 5'は各クライアントの一番上の５つのバージョンしか表示しません。\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "指示されたオブジェクトを再ロードします。"
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "指示されたIPフィルタ・テーブルをファイルから再ロードします。"
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "IPフィルタリング段階を選択してください。"
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "指示されたIPフィルタ・テーブルをファイルから再ロードします。"
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "ネットワークへ接続します。"
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7464,36 +7373,36 @@ msgstr ""
 "形で指示できます。IPアドレスはIPv4形のドット10進数字、或いは解決できる\n"
 "DNS名として指示しなければなりません。"
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Kadのみに接続します。"
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "ネットワークから切断します。"
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "これで現在に接続している全てのネットワークから切断します。\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Kadのみから切断します。"
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "コアにED2K、またはマグネット・リンクを追加します。"
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7504,52 +7413,52 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "個人設定の値を設定してください。"
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "IPFilterを設定してください。"
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "クライアントとサーバの両方のIPフィルタリングをオンします。"
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "クライアントとサーバの両方のIPフィルタリングをオフします。"
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "クライアントのフィルタリングを有効／無効します。"
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "クライアントのフィルタリングをオンします。"
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "クライアントのフィルタリングをオフします。"
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "サーバのフィルタリングを有効／無効します。"
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "サーバのフィルタリングをオンします。"
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "サーバのフィルタリングをオフします。"
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "IPフィルタリング段階を選択してください。"
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7557,80 +7466,80 @@ msgstr ""
 "有効なフィルタリング段階は0〜255の間で、\n"
 "デフォルト値は127です。\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "帯域制限を設定します。"
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "このコマンドの引数の値は毎秒のキロバイトです。\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "アップロード・帯域幅の制限を設定します。"
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "このコマンドの引数の値は毎秒のキロバイトです。\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "ダウンロード・帯域幅の制限を設定します。"
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "このコマンドの引数の値は毎秒のキロバイトです。\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "個人設定の値を取ってきて、表示します。"
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "IPFilterの個人設定の値を取ってきます。"
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "クライアントとサーバの両方のIPFilter状況を取ってきます。"
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "クライアントのみのIPFilter状況を取ってきます。"
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "サーバのみのIPFilter状況を取ってきます。"
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "IPフィルタリング段階を選択してください。"
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "帯域制限の値を取ってきます。"
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Kadを検索します"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7649,48 +7558,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "グローバル検索（GLOBAL）を実行します。"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "ローカル検索（LOCAL）を実行します"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Kadを検索します"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "最後の検索の結果を表示します。"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "検索の進捗を表示します。"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "ファイルのダウンロードを開始します"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7698,82 +7607,82 @@ msgstr ""
 "以前の検索からファイル番号を選んで指定しなければなりません。\n"
 "例： 'download 12'は以前の検索結果で12として指定されたファイルのダウンロードを開始します。\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "ダウンロードを停止します。"
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "ダウンロードを再開します。"
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "ダウンロードをキャンセルします。"
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "ダウンロードのプライオリティーを設定します。"
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "ダウンロードのプライオリティーを低い（Low）、普通（Normal）、高い（High）、またはオート（Auto）に設定します。\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "プライオリティーを低いに設定します。"
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "プライオリティーを普通に設定します。"
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "プライオリティーを高いに設定します。"
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "プライオリティーをオートに設定します。"
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "キュー／リストを表示します。"
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "アップロード／ダウンロードキュー、サーバ・リスト、または共有リストを表示します。\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "アップロードキューを表示します。"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "ダウンロードキューを表示します。"
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "ログを表示します。"
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "サーバ・リストを表示します。"
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "共有ファイル・リストを再ロードします。"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "ログを再初期化します。"
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7782,262 +7691,259 @@ msgstr ""
 "これは廃止予定のコマンドで、将来に存在がなくなる可能性が高いです。\n"
 "代わりに'%s'を使用してください。\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMuleテキストクライアント"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s' の古いAICHハッシュセットを '%s' の64bに変換中です。"
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "警告：ファイル名 '%s' は無効です。'%s' に改名されました。"
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "警告：ファイル '%s' は既に存在します。新しいファイルを '%s' に改名しました。"
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "本当にこのカテゴリの全てのファイルをキャンセルして削除しますか？"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "確認が必要です"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "接続が多すぎます"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "他の全て"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "カテゴリを追加します"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "カテゴリを編集します"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "カテゴリを削除します"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "不明なファイルのハッシュセットが要求されました： %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "ファイル %s のアップロードを再開します"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "ファイル %s のアップロードを一時停止します"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "イベント'%2$s'にコマンド'%1$s'を起動できませんでした。"
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "ダウンロード完了"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "ファイルのフルパス。"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "パス部分を除いたファイルの名前。"
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "ファイルのサイズ（バイト）。"
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "累計ダウンロード活動時間"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "新しいチャットセッションの開始"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "メッセージ送信者。"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "空き容量不足"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "ディスク・パーティション。"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "完了中にエラー"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "ファイル %u: %s 番を処理中です"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "パートハッシュを要求しました（9.5MB以上のファイルサイズのみに使用されます）"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> このファイルは存在していません！\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "ようこそ！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "入力パラメタ"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "ハッシュをするファイル"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "このファイルにオプショナルURLを追加する"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "パートハッシュでリンクを生成する"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "リンクサイズが大きくなるかわりに、新しくて珍しいファイルの配布を速くする"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4ファイルハッシュ"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "保存する"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "クリップボードへコピーする"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "aLinkCreatorについて"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "現在コピーできる物がありません！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "開くことができません： "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "空でないファイル名を入力してください"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "現在保存できるものがありません！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8049,167 +7955,159 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "ハッシュ中…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "キャンセルされました！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr " %.2f 秒で完了しました"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "このURLはもう追加しました！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "空でないURLを入力してください"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "%s を開くことができません"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i 日 %i 時間 %i 分 %i 秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas、aMuleのオンライン統計"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "wxCasの起動以来の最大DL速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "前のwxCas起動を含めて記憶した最大DL速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "リセット"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "システム"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "オートリフレッシュを中止する"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "オンライン統計イメージを保存する"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "オンライン統計イメージを印刷する"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "設定"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "wxCasについて"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "オートリフレッシュを開始する"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "オートリフレッシュを中止しました"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "オートリフレッシュを開始しました"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "統計イメージを保存する"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMuleのオンライン統計"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8217,11 +8115,11 @@ msgstr ""
 "印刷中に問題が発生しました。\n"
 "選択されたプリンタの設定に異常がありませんか？"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "印刷中です"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8239,403 +8137,392 @@ msgstr ""
 "\n"
 "GPLの元で配布されます"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMuleは動作していません…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMuleは動作しています"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMuleは動作していますが接続はしていません"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMuleは接続中です…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "aMuleのステータスは不明です…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " の動作時間は "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " は停止しています！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " は接続していません！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " は接続中です…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " の挙動が変です。チェックしてください！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " は次のものに接続しています： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kas: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "オフ"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " はオンです "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " とともに "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "合計ダウンロード： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr "、 アップロード： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "セッションダウンロード： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "ダウンロード： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s、アップロード： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "共有： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " ファイル、キュー中のクライアント： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "時間： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " オン "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "システムロード平均 （1-5-15分）： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "システム動作時間： "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.datファイルの入っているディレクトリ"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "amulesig.datファイルが入っているディレクトリをここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "リフレッシュレート間隔（秒）"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "各リフレッシュイベントで統計イメージを生成する"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "統計イメージを生成したいディレクトリをここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "統計イメージを定期的にFTPサーバへアップロードする"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTPのUrl"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTPのパース"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "FTPサーバのURLをここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "統計イメージを置きたいFTPサーバのディレクトリをここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "ユーザ"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "FTPサーバのログインに使うユーザ名をここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "FTPサーバのログインに使うパスワードをここに入力してください"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTPアップデートレート間隔（分）"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "実証"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "署名ファイルが入っているフォルダ"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "統計イメージを生成するフォルダ"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "テンプレート <str> をロードします"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnPポート"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "ゲストアクセスを許可する"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "ゲストアクセスを拒否する"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMuleの設定ファイルパス。注意：直接使用しないでください！"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHPインタープリタを無効にする（非推奨）"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "各要求ごとにPHPページを再コンパイルする"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMuleウェブサーバ"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "ウェブクライアント接続が受け入れられました\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "次のエラーによって要求が失敗しました： %s。"
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "インデックスファイルが見付かりませんでした： "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "セッション有効期限が切れました - ログインを要求しています\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "セッションOK、ログインしています\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "セッションOK、ログインしていません\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "セッションが開いていません - ログインを要求します\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "セッションを作成しました - ログインを要求しています\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "要求を処理中です [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "パスワードをチェック中です\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "パスワードのハッシュが無効です\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "パスワードOKです\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "パスワードが正しくありません\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "パスワードを入力しませんでした。空のパスワードは許可されていません。\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "ログアウトが要求されました\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "要求を処理中です [変更しました]： "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "接続に失敗しました "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -22,104 +22,104 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "어뮬 보이기"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "어뮬 원격제어"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "스냅삿"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "시작할때 새 버젼이 있는지 확인"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad에 연결중..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "유효하지 않음"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "친구 추가"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "정확한 IP와 포트를 입력하세요!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "정보"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "설정된 사용자 해시가 옳바르지 않습니다!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -128,48 +128,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "연결 실패"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -178,180 +177,173 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "%s(%s)을 열지 못했습니다."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "실패"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "지역정보(로케일)가 설정 변경으로 인해 시스템 기본값으로 변경되었습니다. 죄송합니다."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "정보"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "종료 확인"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "경고"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "어뮬은 실행중입니다."
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "포트 %u는 사용할 수 없습니다. 낮은아이디를 가질것입니다.\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -366,48 +358,48 @@ msgstr ""
 "\n"
 "나가고 들어오는것에 대해 포트가 열려있는지 통신망을 체크하세요. "
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "어뮬 온라인서명 파일을 생성하지 못함"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "컴퓨터에 선택한 지역정보(로케일)가 설치 않된것 같습니다. (주의: 어쨌든 설정하겠습니다)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "이번에 어뮬 %s를 처음 실행했습니다."
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "이 버전은 테스트 버젼으로, 매일 업데이트되며, \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "이 프로그램이 어느 것도 부수지 않는다고, 집을 태우지 않는다고, 혹은 \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "개를 죽이지 않는다고 보장하지 않습니다. 그렇지만 안전하게 사용할 수 있을 것입니다.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "더 많은 정보, 지원, 새 릴리즈는 홈페이지 amule-org.github.io, 또는 IRC 채널\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "(irc.libera.chat의 #aMule)에서 찾을 수 있습니다.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "버그는 https://github.com/amule-org/amule/issues로 보고해 주십시오."
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -415,225 +407,221 @@ msgstr ""
 "지정한 온라인 서명 파일을 위한 폴더가 유효하지 않습니다.\n"
 " 온라인 서명은 환경설정에서 수정될 때까지 비활성화 됩니다."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "오류: 로그파일을 열 수 없음"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "경고: 로그파일이 비어있습니다. 뭔가 잘못되어 있습니다."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "로그가 초기화되었습니다."
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "서버메시지: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "노드 목록을 내려받지 못했습니다."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "내려받은 버젼 검사 파일을 열지 못했습니다."
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "손상된 버젼 검사 파일"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "오래된 어뮬 버젼을 사용하고 있습니다!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "어뮬 버젼은 %i.%i.%i이며 최신 버젼은 %li.%li.%li입니다."
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "경고: 어뮬 버젼은 오래되었습니다: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "어뮬은 최신 버전입니다."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "버젼 검사 파일을 내려받지 못했습니다."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "낮은아이디로"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "높은아이디로"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "%s %s에 연결되었음"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "%s에 연결중"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad를 시작했습니다."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad를 멈췄습니다."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kad에 연결됨 (양호)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 네트워크는 UDP 포트가 비활성될 시 사용할 수 없으며, 따라서 시작하지 않습니다."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 네트워크가 환경설정에서 비활성되어, 연결하지 않습니다."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "오류: 외부연결이 비활성화일때 어뮬 데몬은 사용할 수 없습니다. 외부연결을 활성화하기 위해서는 --ec-config를 사용하여 시작하거나 ~/.aMule/amule.conf 파일내에 \"AcceptExternalConnections\" 키를 1로 설정하여야 합니다."
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "오류: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "환경설정"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -643,201 +631,194 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "어뮬"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "치명적 오류: 타이머 생성 실패"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "원격 어뮬에 연결함"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "연결 끊김"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "종료시 확인창"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -846,1193 +827,1166 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "치명적 오류: 타이머 생성 실패"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "파일 정보를 복구하려고 하고있습니다..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "연결중"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "%s(%s:%i)에 접속을 시도하는데 시간이 지났습니다."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "통신망에 연결합니다."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "전부"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "불가능"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "알수없는"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (가짜 이뮬 버젼 %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (가짜 이뮬)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "엑스뮬(가짜 이뮬)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (이뮬 v0.%u 기반)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "별명: %s 아이디: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "요청됨:"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "이 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 msgstr[1] "이 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "모든 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 msgstr[1] "모든 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "알 수 없는 파일이 요청되었습니다."
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s'로부터 차단된 메시지 (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s'로부터 새로운 메시지 (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "사용자 %s(%u)가 폴더 %s의 공유파일 목록을 요청합니다. -> 거부됨"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "경고: known.met을 열 수 없습니다."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "경고: 알려진파일 목록이 손상됨, 유효하지 않는 머리말을 포함하고 있습니다."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "known.met 파일을 읽는동안 입출력 오류: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "known.met 파일을 저장하는 동안 오류: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "분류"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "새로운 분류"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "저장할 폴더를 선택"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "분류 이름을 정하세요."
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "분류 경로를 정하세요"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "분류를 저장할 폴더를 생성하지 못했습니다. 유효한 경로를 지정하세요."
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "채팅세션이 시작됨: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "***클라이언트에 연결되었습니다***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "***클라이언트에 연결중입니다***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "***클라이언트에 연결하지 못했습니다 / 연결이 끊어졌습니다***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "탭 닫기"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "모든 탭 닫기"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "다른 탭 닫기"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "친구에 추가"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "신용 파일을 읽었습니다. %u 클라이언트가 인식되었습니다."
 msgstr[1] "신용 파일을 읽었습니다. %u 클라이언트가 인식되었습니다."
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, fuzzy, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] "%u 클라이언트에 대한 신용이 만료되었습니다."
 msgstr[1] "%u 클라이언트에 대한 신용이 만료되었습니다."
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "'cryptkey.dat' 파일을 찾을 수 없습니다. 생성합니다."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "클라이언트 세부내역"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "낮은아이디"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "높은아이디"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "연결이 끊김"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "완료되지 않음"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "나쁜 사람"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "인증됨"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "불가능"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "사용자 %s(%u)가 공유파일 목록을 요청합니다. -> 허락됨"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "사용자 %s(%u)가 공유파일 목록을 요청합니다. -> 거부됨"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "사용자 %s(%u)가 공유폴더 목록을 요청합니다. -> 허락함"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "사용자 %s(%u)가 공유폴더 목록을 요청합니다. -> 거부됨"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "사용자 %s(%u)가 폴더 %s의 공유파일 목록을 요청합니다. -> 허락됨"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "사용자 %s(%u)가 폴더 %s의 공유파일 목록을 요청합니다. -> 거부됨"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "사용자 %s (%u)는 %s 폴더를 공유하고있습니다."
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "사용자 %s (%u)는 공유폴더를 요청하지 않았습니다."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "사용자 %s (%u)는 %s 폴더의 공유파일 목록을 보냅니다."
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "사용자 %s (%u)는 공유파일 목록 전송을 마쳤습니다."
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "사용자 %s (%u)는 공유파일 목록을 원하지않습니다."
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "사용자 %s (%u)는 공유파일이나 공유폴더 목록에 접근하는것을 거부합니다."
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "파일 의견"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "사용자이름"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "파일 이름"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "등급"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "의견"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad를 실행 중이 아니면 Kad 검색을 할 수 없습니다."
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "의견이 없음"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, fuzzy, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%s 의견"
 msgstr[1] "%s 의견"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "%s로부터 서버 목록를 내려받지 못함"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "자동[낮음]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "자동[아님]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "자동[높음]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "높음"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "매우높음"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "개방"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "요청"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "서버를 경유하여 연결중"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "대기열이 가득참"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "대기열에"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "받는중"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "해시설정을 받는중입니다."
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "필요없는 부분"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "낮은아이디에서 낮은아이디로 연결할수 없습니다."
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "매우 많은연결"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Kad를 경유하여 연결중"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "매우 많은 Kad 연결"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "퇴장됨"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "연결 오류"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "원격 대기열이 가득참"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "오래된 MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "새로운 MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "이뮬에 호환"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "지역 서버"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "자료 교환"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "수동적인"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "링크"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "자료 핵"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "완료됨"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "진행중"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "대기열에 있음"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "이미 내려받는중"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "알수없거나 나쁜 임시 파일 형식입니다."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "전송됨"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "속도"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "진척"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "자료"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "우선권"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "상태"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "남은 시간"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "최종 완료"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "최종 받음"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "선택된파일을 지우시겠습니까?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "선택된파일을 지우시겠습니까?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "취소"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "자동"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "멈춤(&S)"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "중지(&P)"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "계속(&R)"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "완료된것 정리(&l)"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "모든 A4AF를 이 파일로 바꿈"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "모든 A4AF를 이 파일로 바꿈 (자동)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "모든 A4AF를 다른 파일로 바꿈"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "확장 옵션"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "미리보기"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "파일 상세 보기(&d)"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "모든 의견 보기"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "magnet URI를 클립보드로 복사"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "반응을 클립보드에 복사"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "할당되지않은"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "분류로 할당"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "파일 열기(&O)"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "새이름 넣으세요:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "파일 이름변경"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "내려받기 (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "미리보기"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, fuzzy, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "오류: 외부 재생기를 실행하지 못했습니다."
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "server.met 파일을 읽음: %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "오래된 내려받은 파일로부터 데이터를 읽어들임 (%u (%u의))"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "부분파일을 찾을 수 없음"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u 부분파일을 찾았음"
 msgstr[1] "%u 부분파일을 찾았음"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "내려받기 %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "이미 '%s' 파일을 내려받으려고 하고있음"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "이미 %s 파일을 가지고 있음"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "이미 %s 파일을 가지고 있음"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "링크의 알려지지 않은 프로토콜: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "외부연결 끊겼습니다."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "빈암호 때문에 외부연결이 불가능합니다."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "이 환경설정에서 외부연결은 불가능합니다."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "환경설정의 빈암호로 인해 외부연결이 거부되었습니다."
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "연결중인 클라이언트: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "알수없는 버젼"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "불확실한 외부연결 버젼 아이디, 이것은 바이너리와 호환되지 않습니다. 동일한 스냅삿으로부터 코어와 원격을 사용하세요."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "비정식 CVS 버젼으로부터 릴리즈된 버젼에 연결할수없습니다! *휴우* 있을 수 있었던 충돌을 막았습니다."
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "프로토콜 버젼 태그 없음"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "인증에 실패했습니다."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "유효하지않은 요청, 먼저 인증을 하세요."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "접근 허가되었습니다."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "허락되지않은 접속입니다. 연결이 끊깁니다."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "원격 부분파일 명령 실패: 파일해시를 찾을 수 없음: %s "
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "파일해시를 찾을 수 없음: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "이런! 명령코드 처리 오류!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "서버가 추가되지 않음"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "서버가 발견되지 않음: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "제거할 서버의 정의가 필요합니다."
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "원격 인터페이스로부터 웹검색은 좋지않은 선택입니다."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "검색중입니다. 금방 결과를 다시 가져옵니다."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "그래프가 비어있음."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "클라이언트는 세부 수준이 구성되지 않았습니다."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "이미 종료하는중입니다."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "외부연결: '%s' 링크를 추가합니다."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "파일을 찾을 수 없습니다."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "유효하지 않은 파일 이름입니다."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "파일이름을 변경할 수 없습니다."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad는 환경설정에서 비활성화되어 있습니다."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "이미 Kad에 연결되었습니다."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kad에 연결중..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kad로부터 연결이 끊겼습니다."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "유효하지 않은 실행코드(잘못된 프로토콜 버젼?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "알수없는 확장 '%s' ('%s'명령에 대해)\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "알수없는 명령 '%s' \n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2040,7 +1994,7 @@ msgstr ""
 "\n"
 "이 명령은 인수를 가질 수 없습니다.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2048,7 +2002,7 @@ msgstr ""
 "\n"
 "이 명령은 반드시 인수가 있어야 합니다.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2056,7 +2010,7 @@ msgstr ""
 "\n"
 "이 명령은 불완전합니다. 반드시 아래의 확장중 하나를 사용해야 합니다.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2064,11 +2018,11 @@ msgstr ""
 "\n"
 "가능한 확장:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "가능한 명령:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -2079,17 +2033,17 @@ msgstr ""
 "모든 명령은 대소문자를 구분하지 않습니다.\n"
 "<명령어>에 대한 자세한 정보를 얻으려면 'help <명령어>'를 입력하세요.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "응용프로그램에서 나감."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "도움말을 보여줍니다."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2097,7 +2051,7 @@ msgstr ""
 "명령어에 대한 도움말은, 'help <명령어>'를 입력하세요.\n"
 "모든 명령어 목록을 보려면, 'help'를 입력하세요.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2108,46 +2062,46 @@ msgstr ""
 "명령 목록을 위해 %s를 사용합니다.\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "문법 오류!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "명령 처리에 오류 발생 - 일어나면 안 됩니다! 버그 리포트를 하세요\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "이 명령은 반드시 변수가 있어야 합니다."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "유효하지 않은 인수입니다."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "불완전한 명령입니다."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "더 많은 도움말을 위해서는 '%s'를 입력하세요.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "이것은 %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "이것은 %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2155,7 +2109,7 @@ msgstr ""
 "\n"
 "클라이언트 생성중...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2164,7 +2118,7 @@ msgstr ""
 "\n"
 "좋아, 나가는중 %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2178,333 +2132,328 @@ msgstr ""
 "\n"
 "종료중...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "이 도움말을 보여줍니다."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "어뮬이 실행중인 호스트. (기본: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "외부연결을 위한 어뮬 포트. (기본: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "외부연결 암호"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "파일로부터 환경설정을 읽습니다."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "표준출력으로는 어떤 출력도 하지 않습니다."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "상세하게 - 디버그 메시지도 보여줍니다."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "프로그램 지역정보 (로케일, 언어)를 설정합니다."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "명령줄 설정을 환경설정 파일에 기록합니다."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "어뮬의 설정 파일에 기초하여 설정 파일을 생성합니다."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "프로그램 버전을 출력합니다."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "파일 세부내역"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% 완료"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "환영합니다!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "친구에게 접속함"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "연결 상태:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "통신망"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "카뎀리아"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "초기적재"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "탐색"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "친구"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "상세히 보기(&D)"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "친구 추가"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "친구 제거"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "메시지 보내기(&M)"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "파일 보기"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "친구 칸으로 확정함"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "선택한 친구들을 삭제하시겠습니까?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "선택한 친구들을 삭제하시겠습니까?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2512,11 +2461,11 @@ msgstr ""
 "하나 이상의 친구칸으로 설정이 허락되지않습니다\n"
 "단지 하나의 칸만 가능합니다."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "다중 선택"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2525,210 +2474,209 @@ msgstr ""
 "하나 이상의 친구칸으로 설정이 허락되지않습니다\n"
 "단지 하나의 칸만 가능합니다."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "사용자에게 메시지를 보내기"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "보낼 메시지:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "친구에서 삭제"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "메시지 보내기"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "파일을 교환"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "다른 파일을 요청"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "대기중인 올려주기: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "대기열에"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "올려주기"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "아무도"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "아니오"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "예"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "내려받기중..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "내려받기 %s"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "내려받기 (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "%s로부터 서버 목록를 내려받지 못함"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "%s로부터 서버 목록를 내려받지 못함"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "'ipfilter.dat' 와 'ipfilter_static.dat'의 IP 차단을 읽어옵니다."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "ipfilter.dat 파일 '%s'을 읽지 못했습니다. 알 수 없는 형식입니다."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "ipfilter.dat 파일 '%s'을 읽지 못했습니다, 파일을 열 수 없습니다."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u 개의 IP 범위를 '%s'로부터 읽었습니다. %u 개의 잘못된 줄은 무시했습니다."
 msgstr[1] "%u 개의 IP 범위를 '%s'로부터 읽었습니다. %u 개의 잘못된 줄은 무시했습니다."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u 개의 IP 범위를 '%s'로부터 읽었습니다. %u 개의 잘못된 줄은 무시했습니다."
 msgstr[1] "%u 개의 IP 범위를 '%s'로부터 읽었습니다. %u 개의 잘못된 줄은 무시했습니다."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2736,2147 +2684,2111 @@ msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "노드 (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "초기적재에 유효하지 않은 IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "초기적재에 유효하지 않은 포트"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "모든 항목을 채워주세요."
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "메시지"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "새로운 nodes.dat파일을 내려받으시겠습니까?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "현재노드는 제거되고 카뎀리아 연결이 다시 시작됩니다."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "계속할까요?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "카뎀리아: 검색어가 너무 짧습니다."
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, fuzzy, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u개의 Kad 접속을 읽었음"
 msgstr[1] "%u개의 Kad 접속을 읽었음"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad를 시작했습니다."
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "파일 이름"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "알수없는 버젼"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "경고: 외형 파일 '%s'(을)를 읽을 수 없습니다."
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "해시중"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "완료중"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "완료"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "중지됨"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "오류투성이"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "대기중"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "반드시 암호를 설정해야 합니다."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "잘못된 패스워드, MD5 해시가 아닙니다."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "연결 실패"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "외부연결 끊겼습니다."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "외부연결: 서버 응답 불량. 연결이 끊겼습니다."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "성공! 어뮬에 연결 되었습니다 "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "성공! 연결이 되었습니다."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "닫기"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "자르기"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "복사"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "붙이기"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "깨끗이"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "모두 선택"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "연결됨"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "연결됨"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Kad에 연결됨 (방화벽)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "서버 IP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "서버 IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "연결 안됨"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "클라이언트 정보"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "연결"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "어뮬 보이기"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "어뮬 숨기기"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "종료"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "무제한"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "어뮬 트레이 메뉴"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "올려주기: 없음"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "올려주기: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "내려받기: 없음"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "내려받기: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "내려받기 속도"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "올려주기 속도"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "별명: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "별명이 선택되지 않음!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "클라이언트 아이디: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "서버 이름: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "서버 IP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "아직 연결되지 않았습니다."
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "온라인 서명: 활성화"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "온라인 서명: 비활성화"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "올려주기 시간: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "전체 내려받기: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "전체 올려주기: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "ed2k 또는 magnet 링크를 코어에 추가합니다."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "친구에 추가"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "사건은 이곳에 보여집니다. 사건 목록의 전체를 보기위해 서버텝에 있는 로그파일을 참조하세요"
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "읽는중..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "접속되어있는 서버의 사용자 수는..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "사용자: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "현재 서버에 연결된 사용자들과 총 사용자수를 측정합니다."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "올려주기: 0.0 | 내려받기: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "현재 올려주기와 내려받기 비율을 평균합니다. 가능하다면 괄호안의 수는 클라이언트 통신으로부터의 추가자원을 의미합니다."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "연결상태와 활성화된 전송을 보여줍니다. 빨간 화살은 현재 연결되지 않았음을 의미하며, 노란 화살은 낮은아이디(방화벽)를 가지고 있다는 의미이고, 초록 화살은 높은아이디(최적의 연결 형태)를 가지고 있다는 의미입니다."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "연결안됨..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "현재 서버에 연결되었습니다."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "검색"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "이름:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "종류"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "지역"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "광역"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "확장 변수"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "필터링"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "파일 종류"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "어떤"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "압축"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "음악"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD이미지"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "그림"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "프로그램"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "문장"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "동영상"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "확장자"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "최소 크기"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "바이트"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "최대 크기"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "유효성"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "필터:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "필터링 결과"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "반전 결과"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "알려진 파일을 숨김"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "시작"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "추가"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "멈춤"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "내려받기"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "항목 초기화"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "결과"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "완료된 내려받기 정리"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "자료 유지"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "없음"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "일반"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "전체 이름 :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "메타파일 :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "해시"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "파일 크기 :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "전송"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "부분파일 상태 :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "마지막 부분이 완료 :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "찾은 자료 :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "전송된 자료 :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "부분파일 카운트 :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "가능함 :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "내려받기 활성화 시간: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "전송됨 :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "완료된 크기 :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "현명한 오류처리"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "오류로 잃어버림 :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "압축으로 얻음 :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.C.H에의해 저장된 패키지 :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "공유함: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "요청"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "허락된 요청"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "전송된 크기"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "공유 비율"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "완료된 자료"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "공유 파일"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", 올려주기: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "선택되지 않은"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "제목 :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "파일 이름"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "인계"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "정돈"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "적용"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "파일에 대한 의견/등급(내용은 모든 사용자가 볼 수 있습니다.)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "파일 품질"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "선택되지 않은"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "유효하지않은 / 손상된 / 가짜"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "나쁜"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "그저그런"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "좋은"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "아주좋은"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "만약 파일이 유용하지 않으면 파일 품질을 선택하거나 사용자에게 충고하세요."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Kad로부터 연결이 끊김"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "새롭게하다"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "내려받는중. 잠시만 기다려주세요..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "알수없는 크기"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "요구된 정보"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP 주소 :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "포트 :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "추가적 정보"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "사용자 이름 :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "추가"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "세션 평균"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "올려주기 속도"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "통계 트리"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "사용자 이름:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "사용자 해시:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "클라이언트 소프트웨어:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "클라이언트 버전:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP 주소:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "사용자 아이디:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "서버 IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "서버 이름:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "클라이언트에 전송"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "현재 요청:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "평균 올려주기율:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "평균 내려받기율:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "올려주기 (세션)"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "내려받기 (세션)"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "올려주기 (전체)"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "내려받기 (전체)"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "점수"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "내려받기/올려주기 변경자:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "안전한 인증:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "대기열에 있음"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "대기열 점수:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "별명"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "이것은 접속했을때 다른 사용자가 볼 수 있는 이름입니다."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "도구도움이 보여주기 이전의 지연시간."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "컨트롤에서 사용하는 언어를 설정합니다."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "시작할때 새 버젼이 있는지 확인"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "이것을 활성화하면 어뮬은 시작할때마다 새로운 버젼이 있는지 확인할것 입니다."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "최소화된 시작"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "이것은 어뮬을 시작할때 최소화를 가능하게 합니다."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "종료시 확인창"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "트레이아이콘 활성화"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "이것은 시스템 트레이(혹은 작업표시줄) 아이콘을 활성화/비활성화 합니다."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "트레이 아이콘으로 최소화"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "어뮬을 작업표시줄보다 시스템 트레이로 최소화 하도록 합니다."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "브라우저 선택"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "가능하면 새로운 탭을 생성함"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "가능하면 새로운 창을 여는것 대신 새로운 탭을 생성합니다."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "비디오 재생기"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "칸 배분"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "시작시 자동연결"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "끊겼을시 재연결"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "죽은서버 제거"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "재시도"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "목록"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "우선순위 시스템을 사용"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "연결할때 현명한 낮은아이디 검사를 사용"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "안전한 연결"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "정적목록내의 서버에만 연결"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "수동으로 추가된 서버에 높은 우선권 부여"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "멈춤 상태로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "자동 우선권으로 내려받기에 파일 추가"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "처음과 마지막 부분을 먼저 내려받음"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "동일한 분류로부터"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "원하는 최소한의 디스크공간을 입력하세요."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "희귀한 파일인 경우 10개의 자료 저장 (<20 자료)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "올려주기"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "자동 우선권으로 새로운 공유파일을 추가"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "삭제"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(하위폴더 전체를 공유하려면 폴더 아이콘상에서 오른쪽 버튼을 클릭)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "숨은파일 공유"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "그래프"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "갱신 지연 : 5 초"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "평균 그래프 시간 : 100 분"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "연결 그래프 크기 : 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "바탕"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "눈금"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "현재 내려받기"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "내려받기 운용 평균"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "내려받기 세션 평균"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "현재 올려주기"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "올려주기 운용 평균"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "활성화된 연결"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "시스템트레이 아이콘 속도바"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "현재 Kad-노드"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-노드 운용"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "선택"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "표시될 클라이언트 버젼의 수 (0=무제한)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! 경고 !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "최대 새연결 / 5 초"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "파일 버퍼 크기: 240000 바이트"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "올려주기 대기열 크기: 5000 클라이언트"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "서버 연결 갱신 간격: 사용않함"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "분류탭의 확장된 정보를 보여줌"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "제목에 전송률을 보여줌"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "수직방향 툴바"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "평평한"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "손님 접근 금지"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4884,11 +4796,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4898,856 +4810,856 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "공유 파일"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "비활성화 [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "bytes"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 #, fuzzy
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "bytes/s"
 msgstr[1] "bytes/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "초"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "분"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "시"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "일"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "전부"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "다른 모두"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "내려받음"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "멈춤"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "비디오"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "압축"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "문자"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "활성화"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "가져오는중 %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "내려받은 정보 파일로부터 기본적인 정보를 재생"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "대상 파일을 생성"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "오래된 내려받은 파일로부터 데이터를 읽어들임 (%u (%u의))"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "데이터 블럭을 새 내려받은 파일로 저장 (%u (%u의))"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "내려받은 파일 정보 자료를 재생"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "내려받기에 추가하고 새 부분파일을 저장"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "부분파일 가져오기"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "상태"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "파일 해시"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s(디스크: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "임시 내려받기를 위해 검색할 폴더를 선택하세요! (하위 폴더 포함)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "성공적으로 가져온 내려받기 파일을 삭제하겠습니까?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "자료를 삭제하겠습니까?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "오류: 부분파일을 생성하지 못했습니다.)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "%s로부터 met파일의 백업을 읽을려고 합니다."
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "오류: %s(%s)은 손상되었습니다. (잘못된 꼬리계수), 파일을 읽을수 없습니다."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "파일 정보를 복구하려고 하고있습니다..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "이름없는 파일을 복구합니다. - RecoveredFile.dat로 복구합니다."
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "모든 가능한 파일정보를 복구되었습니다. :D - 사용해 보세요..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "파일정보 복구가 불가능합니다. :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "%s(%s)을 열지 못했습니다."
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "부분파일을 저장하는 동안에 오류: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "부분파일을 저장하는 동안에 오류: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "%s에 대한 part.met.seeds 파일을 저장하지 못했습니다."
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "부분파일을 위해 %i 자료핵심을 저장되었습니다: %s(%s)"
 msgstr[1] "부분파일을 위해 %i 자료핵심을 저장되었습니다: %s(%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "부분파일을 위해 %i 자료핵심을 저장되었습니다: %s(%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "부분파일의 핵심파일(%s - %s)을 읽는중 오류: %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "손상된 부분(%d)이 발견되었습니다. (%d부분 파일 %s에 있는) - 파일해시결과 |%s| 파일해시 |%s|"
 msgstr[1] "손상된 부분(%d)이 발견되었습니다. (%d부분 파일 %s에 있는) - 파일해시결과 |%s| 파일해시 |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "완료된 부분(%i)이 발견되었습니다.  (%s에 있는)"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s의 재해시가 완료되었습니다."
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "내려받기 완료: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "내려받기 완료: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "파일 삭제: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "경고: 충분한 디스크공간이 없습니다! 파일 정지: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "%i 부분 내려받기는 파일이 손상되었습니다: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: 손상된 부분 %i를 복구했습니다. (%s의) -> 저장된 바이트: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "연결"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "폴더"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "서버"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "파일"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "보안"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "프록시"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "원격 조정"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "사건들"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "디버깅"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5763,35 +5675,35 @@ msgstr ""
 "이 설정들을 조정하지 않아도\n"
 "어뮬은 잘 동작할 것입니다."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "연결하고 있는 프록시 타입"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "암호를 검사중\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5799,51 +5711,51 @@ msgstr ""
 "변경사항을 활성화 하기위해 어뮬을 재시작해야 합니다:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP 포트가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "외부연결 끊겼습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "프로토콜 난독화"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5851,40 +5763,40 @@ msgstr ""
 "외부연결이 횔성화되어 있지만, 암호를 설정하지 않았습니다.\n"
 "외부연결은 유효한 암호가 설정되기전까지 활성화되지 않습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- 언어가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- 임시 폴더가 변경되었습니다.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "모든 통신망을 사용할수 없습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "유효하지 않은 프로토콜 버젼입니다"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5892,7 +5804,7 @@ msgstr ""
 "UDP 포트가 비활성화되어 있으면 Kad는 시작하지 않을 것입니다.\n"
 "UDP 포트를 활성화시키거나 Kad를 비활성화시키십시오."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5902,69 +5814,69 @@ msgstr ""
 "지금 바로 어뮬을 재시작해야 합니다.\n"
 "만일 재시작하지 않는다면, 나쁜 일이 일어나도 불평하지 마십시오.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "자동갱신이 시작됨"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "새로운 외부연결이 승인되었습니다."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5974,66 +5886,66 @@ msgstr ""
 "적어도 한개의 유효한 server.met파일을 가르키는 URL을 적으세요.\n"
 "URL을 입력하려면 채크박스 옆의 \"목록\"버튼을 클릭하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "임시 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "내려받은 파일"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "온라인 서명"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s하기 위한 폴더를 선택하세요."
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "비디오재생을 위한 브라우즈"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "브라우저 선택"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "실행할수 있는 %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "기본 설정"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6041,1236 +5953,1235 @@ msgstr ""
 "server.met파일을 내려받을 URL을 추가하세요.\n"
 "각 행에 오직 하나의 URL을 넣으세요."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "완료된 자료"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "상태:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "갱신 지연: %d 초"
 msgstr[1] "갱신 지연: %d 초"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "평균 그래프 시간: %d 분"
 msgstr[1] "평균 그래프 시간: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "연결 그래프 크기: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "파일 버퍼 크기: %d 바이트"
 msgstr[1] "파일 버퍼 크기: %d 바이트"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "올려주기 대기열 크기: %d 클라이언트"
 msgstr[1] "올려주기 대기열 크기: %d 클라이언트"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "서버 연결 갱신 주기: %d 분"
 msgstr[1] "서버 연결 갱신 주기: %d 분"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "서버 연결 갱신 주기: 비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "비활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "`%s' 사건에 명령을 실행"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "코어에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "코어 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "GUI에 명령 실행 활성화"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI 명령어:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "다음 변수들은 교체됩니다.:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "임시 폴더를 읽는중"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "공유 파일"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기는 무시됩니다.."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "검색 경고"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "주"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kad 검색 시도 중에 예기치 못한 에러: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "파일아이디"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "선택되지 않은"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "분류내 내려받기"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "이 파일의 추가주소를 더합니다."
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "삭제하려고하는 서버에 접속되어있습니다. 부디 먼저 연결을 끊으세요."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "취소"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "난독화된 서버들로의 연결이 모두 실패했습니다. 난독화없이 진행합니다."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "난독화된 서버들로의 연결이 모두 실패했습니다. 난독화없이 진행합니다."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "모든 서버 목록에 접속하지 못했습니다. 다른 서버를 만드세요."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "모든 서버 목록에 접속하지 못했습니다. 다른 서버를 만드세요."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "%s (%s:%i)에 연결되었습니다."
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "다음에 연결이 되었습니다: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "연결하는 동안 치명적 오류가 발생하였습니다. 인터넷 연결이 끊긴것 같습니다."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "%s(%s:%i)에 연결이 끊김."
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s(%s:%i)가 죽은것 같습니다."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s(%s:%i)가 가득찬것 같습니다."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, fuzzy, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "%d 초후에 서버로 자동 접속을 재시도"
 msgstr[1] "%d 초후에 서버로 자동 접속을 재시도"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "%s(%s:%i)에 연결하지 못했습니다."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "%s(%s:%i)에 접속을 시도하는데 시간이 지났습니다."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "server.met 파일을 읽음: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "server.met 파일을 찾을 수 없습니다.!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "server.met 파일 '%s' 을 읽지 못했습니다. 알 수 없는 형식입니다."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "server.met 파일을 열지 못했습니다!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met 파일이 손상됨, 유효하지 않는 버젼정보를 발견함: 0x%x, size %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "server.met에서 %i개의 서버가 발견됨"
 msgstr[1] "server.met에서 %i개의 서버가 발견됨"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d 서버가 추가됨"
 msgstr[1] "%d 서버가 추가됨"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "known.met 파일을 읽는동안 입출력 오류: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "서버 추가되지 않음: [%s:%d]은 유효한 포트가 정해지지 않았습니다."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "서버 추가되지 않음: [%s:%d]의 IP가 유효하지 않거나 차단되었습니다."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "서버 추가되지 않음: IP:포트[%s:%d]와 같은 서버가 목록에 있습니다."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "서버 추가됨: [%s:%d]서버 '%s'이름을 사용"
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "삭제하려고하는 서버에 접속되어있습니다. 부디 먼저 연결을 끊으세요."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "'%s'을(를) 열지 못했습니다."
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "server.met을 저장하지 못함!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "유효하지 않는 주소입니다."
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "%s로부터 서버 목록를 내려받지 못함"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "adrresses.dat에 유효한 server.met 자동갱신 주소가 없습니다."
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "%s로부터 서버 목록를 내려받지 못함"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "지역 서버가 IPFilter에 의해 차단되어, 다른 서버로 재연결 합니다."
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "서버 이름"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "주소"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "포트"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "설명"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "핑"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "사용자"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "정적"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "버젼"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "삭제하려는 서버에 연결되어 있습니다. 먼저 연결을 끊으세요. 서버는 삭제되지 않습니다."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(알수없는 이름)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "정적 서버 %s를 삭제하시겠습니까?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "서버 (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "서버"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "서버에 연결함"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Mark server as static"
 msgstr "정적인 서버를 만듦"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Mark server as non-static"
 msgstr "비정적인 서버를 만듦"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Mark servers as static"
 msgstr "정적인 서버를 만듦"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Mark servers as non-static"
 msgstr "비정적인 서버를 만듦"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove server"
 msgstr "서버를 삭제"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
 msgstr "서버를 삭제"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "모든 서버를 삭제"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "서버에 재접속"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "모든 서버를 삭제하시겠습니까?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "선택된 서버를 삭제하시겠습니까?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "선택된 서버를 삭제하시겠습니까?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "새로운 클라이어트 아이디는 %u임"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t이러한 대부분의 이유는 방화벽이나 라우터때문입니다."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "알수없는 서버 정보를 받았습니다! - 매우 짧음"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, fuzzy, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "새로운 서버 %d개를 받음"
 msgstr[1] "새로운 서버 %d개를 받음"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "서버목록 저장이 완료되었습니다."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "서버가 마지막 명령을 거부함"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "가짜 패킷을 서버로부터 받았습니다: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "서버로부터 패킷을 처리하는동안 조치할수 없는 오류가 생겼습니다: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "%s에 연결하기 위한 DNS 해석 쓰레드를 만들수 없음"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "서버 IP %s(%s)가 차단되었습니다. 연결할수 없습니다."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "프로토콜 난독화를 사용합니다."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "%s (%s - %s:%i) %s에 연결합니다."
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "%s 서버에 대한 DNS를 해석 할 수 없음: 연결할수 없습니다!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "어뮬 로그"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "서버 추가되지 않음: IP나 호스트이름이 지정되지 않았습니다."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "서버 추가되지 않음: 유효하지 않는 서버 포트가 지정되었습니다."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "아이디"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "연결 상태:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "연결됨"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "카뎀리아 상태:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "%s에 동작중"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "동작중"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "카뎀리아 상태:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "상태:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "연결 상태:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "연결 상태:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "방화벽 상태:"
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "친구가 없음"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "친구에게 접속함"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "친구에게 접속함"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "자료 유지"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "인덱스 파일을 찾을 수 없음:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "평균 사용자:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "평균 파일:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "동작되지 않음"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
 msgstr[1] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "서버가 발견되지 않음: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "사용자이름"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "내려받기 속도"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "올려주기 속도"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "가능함 :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "올려주기 상태"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "내려받기 상태"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "파일 이름"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "공유 파일"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "획득한 부분"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "폴더 경로"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "의견/등급 추가"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "의견/등급 편집"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "이름변경"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "컬렉션내의 파일을 전송목록에 추가"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "magnet URI를 클립보드로 복사(&U)"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "ED2k 링크를 클립보드에 복사(&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "유효한 자료 링크를 만들기 위해서 높은아이디가 필요합니다."
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "파일 이름"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "올려준 데이터 (세션 (전체)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "전체 추가자원 (패킷): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "파일 요청 추가자원 (패킷): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "자료 교환 추가자원 (패킷): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "서버 추가자원 (패킷): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad 추가자원(패킷): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "활성화된 올려주기: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "대기중인 올려주기: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "성공적인 전체 올려주기 세션 : %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "실패한 전체 올려주기 세션: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "평균 올려주기 시간: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "내려받은 데이터 (세션 (전체)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "발견된 자료: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "활성화된 내려받기 (큰 부분): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "세션 올려주기:내려받기 비율 (전체): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "재접속: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "첫 전송으로부터 시간: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "다음으로부터 서버에 연결됨: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "활성화된 연결 (평가): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "최대 연결 제한 접근함: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "평균 연결 (평가): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "최대 연결 (평가): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "클라이언트"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "알수없는 크기"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "차단됨"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "퇴장됨"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "전체: %i 알려진: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "동작중인 서버: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "실패한 서버: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "전체: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "삭제된 서버: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "차단된 서버: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "동작중인 서버의 사용자: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "동작중인 서버의 파일: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "전체 사용자: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "전체 파일: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "서버 할당: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "공유된 파일의 수: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "공유파일의 전체 크기: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "운영체제"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "받은게 없음"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "활성화된 연결 (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "유효하지 않음"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "결코"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "`%s' 명령(pid `%d')은 상태코드 `%d'로 종료되었습니다."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str>을 실행하고 종료합니다."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "유효하지 않은 IP 형식. xxx.xxx.xxx.xxx:xxxx를 사용하세요.\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 #, fuzzy
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "이 명령은 인수를 필요로합니다. 유효한 인수: 'all' 또는 숫자\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Processing by hash: "
 msgstr "파일숫자 %u 처리: %s"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Processing by filename: "
 msgstr "파일숫자 %u 처리: %s"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "유효한 숫자가 아님\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "유효한 해시가 아님 (길이는 정확히 32자여야 함)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7279,7 +7190,7 @@ msgstr "더 많은 도움말을 위해서는 '%s'를 입력하세요.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7288,89 +7199,87 @@ msgstr "더 많은 도움말을 위해서는 '%s'를 입력하세요.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "더 많은 도움말을 위해서는 '%s'를 입력하세요.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "내려받기 (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "알 수 없는 오류로 요청이 실패함."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "동작이 성공했습니다."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "다음과 같은 오류로 요청이 실패: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "클라이언트에 대한 IP 차단 %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "끔"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "켬"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "서버에 대한 IP 차단 %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "현재 IP 차단 수준은 %d입니다.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "%s %s %s에 연결됨"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "지금 연결중"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "방화벽됨"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "확인"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7379,7 +7288,7 @@ msgstr ""
 "\n"
 "내려받기:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7388,7 +7297,7 @@ msgstr ""
 "\n"
 "올려주기:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7397,7 +7306,7 @@ msgstr ""
 "\n"
 "대기열의 클라이언트:/t %d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7406,46 +7315,46 @@ msgstr ""
 "\n"
 "전체 자료:\t% d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[부분 파일]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "검색된 결과 갯수: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "서버로부터 알수없는 반응을 수신했습니다. 실행코드 =  %#x"
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "간단한 상태 정보를 보여줍니다."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "연결 상태를 보여줌, 현재 올려주기/내려받기 속도, 기타.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "전체 통계 구조도를 보여줍니다."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7458,51 +7367,51 @@ msgstr ""
 "0이나 생략은 '무제한'을 뜻합니다..\n"
 "예: 'statistics 5'는 각 클라이언트 종류의 상위 5가지 버전만 보여줍니다.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "주어진 대상을 다시 읽어들입니다."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "파일로부터 IP 차단 테이블을 다시 읽어들입니다."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "IP 차단 수준을 선택합니다."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "파일로부터 IP 차단 테이블을 다시 읽어들입니다."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "통신망에 연결합니다."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7514,36 +7423,36 @@ msgstr ""
 "IP는 점과 십진수의 IPv4 주소이거나, 해석 할 수 있는 DNS이름 이어야 합니다.\n"
 " "
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Kad에만 연결합니다."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "현재 연결되어있는 모든 통신망으로부터 연결을 끊습니다.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Kad에서만 연결을 끊습니다."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "ed2k 또는 magnet 링크를 코어에 추가합니다."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7554,52 +7463,52 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "설정값을 정합니다."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "IP 차단 설정을 합니다."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "클라이언트와 서버에 IP 차단을 사용합니다."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "클라이언트와 서버에 IP 차단을 사용하지 않습니다."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "클라이언트에 IP 차단을 활성/비활성화 합니다."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "클라이언트에 IP 차단을 사용합니다."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "클라이언트에 IP 차단을 사용하지 않습니다."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "서버에 IP 차단을 활성화/비활성화 합니다."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "서버에 IP 차단을 사용합니다."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "서버에 IP 차단을 사용하지 않습니다."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "IP 차단 수준을 선택합니다."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7607,80 +7516,80 @@ msgstr ""
 "유효한 차단 수준은 0-255범위여야 하고, 기본(초기)값은\n"
 "127입니다.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "대역폭 제한 설정합니다."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "이 명령에 주어지는 값은 킬로바이트/초 이어야 합니다..\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "올려주기 대역폭 제한 설정합니다."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "이 명령에 주어지는 값은 킬로바이트/초 이어야 합니다..\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "내려받기 대역폭 제한 설정합니다."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "이 명령에 주어지는 값은 킬로바이트/초 이어야 합니다..\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "설정값 가져와 보여줍니다."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "IP 차단 설정을 가져옵니다."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "서버와 클라이언트에서 IP 차단 상태를 가져옵니다."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "클라이언트에서만 IP 차단 상태를 가져옵니다."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "서버에서만 IP 차단 상태를 가져옵니다."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "IP 차단 수준을 선택합니다."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "대역폭 제한 가져옵니다."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Kad 검색을 수행합니다."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7699,48 +7608,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "광역 검색을 수행합니다."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "지역 검색을 수행합니다."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Kad 검색을 수행합니다."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "마지막 검색의 결과를 보여줍니다."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "검색의 진행을 보여줍니다."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "파일의 내려받기를 시작"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7748,344 +7657,341 @@ msgstr ""
 "마지막 검색으로부터 파일의 번호가 부여됩니다.\n"
 "예: 'download 12' 는 이전 검색에서 12번 번호를 가진 파일의 내려받기를 시작합니다.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "내려받기를 정지합니다."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "내려받기를 재시작합니다."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "내려받기를 취소합니다."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "내려받기의 우선순위를 설정합니다."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "내려받기의 우선순위를 낮음, 보통, 높음 또는 자동으로 설정합니다.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "우선순위를 낮음으로 설정합니다."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "우선순위를 보통으로 설정합니다."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "우선순위를 높음으로 설정합니다."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "우선순위를 자동으로 설정합니다."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "대기열/목록 보여줍니다."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "올려주기/내려받기 대기열, 서버 목록이나 공유된 파일 목록 보여줍니다.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "올려주기 대기열을 보여줍니다."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "내려받기 대기열을 보여줍니다."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "로그를 보여줍니다."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "서버 목록 보여줍니다."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "로그를 초기화합니다."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s'의 낡은 AICH 해시셋을 64b로 '%s'에 변환합니다."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "경고: 파일 이름 '%s'는 유효하지 않으며 '%s'로 변경되었습니다."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "경고: 파일 이름 '%s'는 이미 존재하며, 새 파일은 '%s'로 변경되었습니다."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "이 분류에 있는 모든 파일을 취소하고 삭제하시겠습니까?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "확인이 요청됨"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "매우 많은연결"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "다른 전부"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "보기 필터 선택"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "분류 추가"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "분류 수정"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "분류 삭제"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "알수 없는 파일의 해시설정이 요청되었습니다: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "파일의 올려주기를 재시작합니다: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "파일의 올려주기를 정지합니다: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "`%s' 명령을 실행하는데 실패했습니다. (`%s' 사건에대해)"
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "파일숫자 %u 처리: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "부분 해시를 요청했습니다. (오직 파일크기가 9.5 MB 보다 클때 사용)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> 존재하는 파일이 없음!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "환영합니다!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "설정값 입력"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "파일을 해시"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "이 파일의 추가주소를 더합니다."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "부분해시의 링크를 생성합니다."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "링크의 크기를 증가시키는 대신 새 파일 및 희귀한 파일을 빠르게 퍼지는 데에 도움을 줍니다."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "md4 파일 해시"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "저장"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "클립보드로 복사"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "aLinkCreator에 대하여"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "지금 복사할것은 아무것도 없습니다!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "열수 없음"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "제발, 파일이름을 비우지 마세요."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "지금 저장한것은 없습니다!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8097,168 +8003,160 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "해시중..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 #, fuzzy
 msgid "Cancelled !"
 msgstr "취소됨!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "%.2f 초만에 완료"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "이미 이 주소가 추가되어 있습니다!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "주소를 비우지 마세요."
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "%s를 열수없음."
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i 일 %i 시간 %i 분 %i 초"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02u일 %02u시 %02u분 %02u초"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02u시 %02u분 %02u초"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02u분 %02u초"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02u초"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, 어뮬 온라인 통계"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "wxCas 현재 실행시 최대 내려받기 속도"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "wxCas 이전 실행시부터 절대적 최대 내려받기 속도"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "초기화"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "시스템"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "자동갱신 멈춤"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "온라인 정적그림을 저장"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "온라인 정적그림을 프린트"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "환경 설정"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "wxCas에 대하여"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "자동갱신을 시작"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "자동갱신을 멈춤"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "자동갱신이 시작됨"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "통계 이미지를 저장"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "어뮬 온라인 통계"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8266,11 +8164,11 @@ msgstr ""
 "프린트하는데 문제가 있습니다.\n"
 "혹시 현재 프린터가 올바로 설정되지 않았나요?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "프린트함"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8288,404 +8186,393 @@ msgstr ""
 "\n"
 "GPL로 배포합니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "어어, 어뮬이 실행중이 아닙니다..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "어뮬은 실행중입니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "어뮬은 실행중이나 연결이 끊겨 있습니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "어뮬은 연결중..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "어어, 어뮬의 상태는 알수없음..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "어뮬 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " 위해 실행되고있는 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " 은 멈추어져 있습니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " 은 연결되지 않았습니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " 은 연결중..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " 무엇인가 이상하게 동작하고 있음, 확인 요망!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " 는 다음으로 연결중: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "끔"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr "켜졌습니다."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 #, fuzzy
 msgid " with "
 msgstr "] with "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "전체 내려받기: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", 올려주기: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "내려받기 세션: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "내려받기: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr "올려주기, kB/s: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "공유함: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr "대기열에있는 파일, 클라이언트: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "시간:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr "켬"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "시스템 부하 평균 (1-5-15 분): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "시스템 연속 작동 시간: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat 파일을 포함한 폴더"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "amulesig.dat 파일이 있는 폴더를 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "갱신율 초당 간격"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "매회 갱신할 때 통계 이미지를 생성합니다."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "통계 이미지를 생성하는것을 원하는 장소 폴더를 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "FTP 서버의 통계 이미지를 정기적으로 올려줍니다."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP 경로"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "FTP 서버의 URL을 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "FTP 서버에 통계 이미지가 위치할 폴더를 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "사용자"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "FTP 서버로 로그인하기 위한 사용자이름을 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "FTP 서버로 로그인하기 위한 암호를 이곳에 입력하세요."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP 갱신율 분당 간격"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "유효합니다"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "서명 파일이 있는 폴더"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "통계 이미지를 생성하는곳의 폴더"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "템플릿<str>을 읽음"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP 포트"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "gzip 압축 사용"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "손님 접근 허가"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "손님 접근 금지"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "어뮬 설정 파일 경로. DO NOT USE DIRECTLY!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP 해석자를 (권장되지 않는) 사용않함"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "각 요청의 PHP 페이지를 재컴파일함"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "어뮬 웹 서버"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "다음과 같은 오류로 요청 실패함: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "인덱스 파일을 찾을 수 없음:"
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "세션이 만료됨 - 로그인 요청중\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "세션 확인, 로그인 됨\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "세션 확인, 로그인 안됨\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "열린 세션 없음 - 로그인을 요청할 것임\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "세션이 생성됨 - 로그인 요청중\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "요청 처리중 [원본]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "암호를 검사중\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "암호 해시가 유효하지 않음\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "암호 맞음\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "암호 틀림\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "암호를 입력하지 않았습니다. 빈암호는 사용할수 없습니다.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "로그아웃이 요청됨\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "요청 처리중[redirected]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "연결 실패"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -21,26 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Rodyti aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule nuotolinio valdymo pultelis "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Ekrano kopija:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,79 +49,79 @@ msgstr ""
 "Autorinės teisės (C) 2003-2019 aMule komanda \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: p2p maršrutizavimas, paremtas XOR metrika.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Paleidus programą ieškoti naujesnės versijos"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Jungiamsi prie Kademlia..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nėra"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Įdėti draugą"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Įrašyti IP ir prievadas teisingi!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informacija"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Nurodyta naudotojo maišos f-ja klaidinga!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -130,48 +130,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Prisijungti nepavyko "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -180,183 +179,176 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Nepavyko atverti %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nuorodos šaltinių."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Nepavyko"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Atsiuntimas baigtas"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Pasikeitus parinktims aplinkos kalba buvo pakeista į sistemoje numatytą kalbą."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informacija"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "DĖMESIO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "KLAIDA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "žiniatinklio serverio pid yra %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nepavyko susieti prievadų su nurodytu adresu: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Prievadas %u neprieinamas. Gavote žemą ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -372,48 +364,48 @@ msgstr ""
 "\n"
 "Patikrinkite sistemines tinklo parinktis ir įsitikinkite, kad nurodytas prievadas atviras tiek išsiuntimui, tiek priėmimui."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo parašo failo"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nepavyko sukurti keičiamo aMule parašo failo"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Nurodyta lokalė jūsų kompiuteryje neįdiegta. (Dėmesio: šiaip ar taip vis tiek pabandysime naudoti nurodytą lokalę)."
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "aMule paleista pirmą kartą %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ši versija yra darbinė versija, atnaujinama kasdien, ir\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "todėl negalime garantuoti, kad ji nenulūš, nepadegs namų ar\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "nenumarins šuns. Bet šiaip ar taip ją naudoti turėtų būti saugu.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daugiau informacijos, pagalbos ir naujausias galutines versijas rasite mūsų\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "svetainėje https://amule-org.github.io arba IRC kanale #aMule serveryje irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nesikuklinkite pranešti rastas klaidas adresu https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -421,225 +413,221 @@ msgstr ""
 "Neteisingai nurodėte keičiamo parašo aplanką!\n"
 "Keičiamas parašas bus išjungtas tol, kol pakeisite parinktis."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Nepavyko paskirti disko vietos failui „%s“: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "KLAIDA: nepavyko atverti žurnalo failo"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "DĖMESIO: žurnalas tuščias. Kažkas čia ne taip."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Žurnalas išvalytas"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Serverio pranešimas: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Nepavyko atsiųsti mazgų sąrašo."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Nepavyko atverti atsiųstos versijos tikrinimo failo"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Sugadintas versijos tikrinimo failas"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Naudojate pasenusią aMule versiją!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ši aMule versija yra %i.%i.%i, o naujausia versija yra %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "DĖMESIO: ši aMule versija yra pasenusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Naudojate naują aMule versiją."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Nepavyko atsiųsti versijos tikrinimo failo"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Naudotojai: %s | Failai: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Naudotojai: eD2k: %s Kad: %s | Failai: eD2k: %s Kad: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Neparinktas joks tinklas"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "žemas ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "aukštas ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Prisijungta prie %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Jungiamasi prie %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Atsijungta nuo eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kademlia paleista."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kademlia sustabdyta."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Prisijungta prie Kademlia"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nepavyks prisijungti prie Kademlia tinklo, jei parinktyse yra išjungtas UDP prievadas."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kademlia tinklas išjungtas parinktyse, ryšys nebus užmezgamas."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "KLAIDA: aMule tarnyba negali būti naudojama jei išoriniai ryšiai yra išjungti. Norėdami įjungti išorinius ryšius arba naudokite normalią aMule, arba paleiskite amuled su parametru --ec-config, arba faile ~/.aMule/amule.conf nustatykite parametro „AcceptExternalConnections“ reikšmę lygią 1."
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "KLAIDA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s, sukurta eMule pagrindu."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Parinktys"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nėra"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -649,195 +637,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Jokio tinklo"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Prisijungti prie nutolusio aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Ryšys nutrūko"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Klausti prieš baigiant darbą"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -846,156 +827,146 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "Bandoma atstatyti failo informaciją..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Jungiamasi"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Baigėsi bandymo susijungti laikas %s (%s:%i)."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Prisijungti prie tinklo."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Viskas"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nepasiekiama"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Failas nerastas."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nežinoma"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (neteisinga eMule versija %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (neteisinga eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (neteisinga eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (paremta eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Slapyvardis: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Paprašė: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1003,7 +974,7 @@ msgstr[0] "Šio seanso failų statistika: priimta %d iš %d prašymo, %s persių
 msgstr[1] "Šio seanso failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 msgstr[2] "Šio seanso failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1011,120 +982,120 @@ msgstr[0] "Visų seansų failų statistika: priimta %d iš %d prašymo, %s persi
 msgstr[1] "Visų seansų failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 msgstr[2] "Visų seansų failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Paprašė nežinomo failo"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtras sulaikė %s žinutę (IP %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Naują žinutę atsiuntė %s (IP %s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų iš aplanko %s sąrašo –> atmesta"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "DĖMESIO: nepavyko atverti known.met."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "DĖMESIO: sugadintas known.met, klaidinga antraštė."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Nuskaitant known.met failą įvyko IO klaida: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Įrašant known.met failą įvyko klaida: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nauja kategorija"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Nurodykite atsiųstų failų aplanką"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Nurodykite kategorijos pavadinimą!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Nurodykite kategorijos kelią!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Nepavyko sukurti atsiųstų failų aplanko šiai kategorijai. Nurodykite teisingą kelią!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Pokalbis pradėtas: %s (%s:%u) – %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Prisijungta prie kliento ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Jungiamasi prie kliento ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Nepavyko prisijungti prie kliento arba ryšys nutrūko ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Užverti kortelę"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Užverti visas korteles"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Užverti kitas korteles"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Įdėti į draugus"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1132,7 +1103,7 @@ msgstr[0] "Kreditų failas įkeltas, rastas %u žinomas klientas"
 msgstr[1] "Kreditų failas įkeltas, rasti %u žinomi klientai"
 msgstr[2] "Kreditų failas įkeltas, rasta %u žinomų klientų"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1140,172 +1111,169 @@ msgstr[0] "– %u kliento kreditai nebegalioja!"
 msgstr[1] "– %u klientų kreditai nebegalioja!"
 msgstr[2] "– %u klientų kreditai nebegalioja!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Nerasta cryptkey.dat failo. Failas kuriamas."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Kliento savybės"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Žemas ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Aukštas ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Įjungta"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Palaikoma"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nepalaikoma"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Išjungta"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Prisijungta"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Neprisijungta"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Neužbaigta"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Kenkėjas"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Praėjo patikrinimą"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nepasiekiama"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų sąrašo –> suteikta"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų sąrašo –> atmesta"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Naudotojas %s (%u) paprašė dalinamų aplankų sąrašo –> suteikta"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Naudotojas %s (%u) paprašė dalinamų aplankų sąrašo –> atmesta"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų iš aplanko %s sąrašo –> suteikta"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų iš aplanko %s sąrašo –> atmesta"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Naudotojas %s (%u) dalinasi aplanku %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Naudotojas %s (%u) atsiuntė neprašytus dalinamų failų aplankus"
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Naudotojas %s (%u) atsiuntė neprašytą dalinamų failų sąrašą aplankui %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Naudotojas %s (%u) baigė siųsti dalinamų failų sąrašą"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Naudotojas %s (%u) atsiuntė neprašytą dalinamų failų sąrašą"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Naudotojas %s (%u) nesuteikė prieigos prie dalinamų aplankų/failų sąrašo"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Failo komentarai"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Vardas"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Failo pavadinimas"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Reitingas"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentaras"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kademlia paieška negalima, jei nepaleista Kademlia tarnyba"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Komentarų nėra"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1313,268 +1281,258 @@ msgstr[0] "%u komentaras"
 msgstr[1] "%u komentarai"
 msgstr[2] "%u komentarų"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Nepavyko iš %s atsiųsti serverių sąrašo"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Automatiškai (žemas)"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Automatiškai (normalus)"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Automatiškai (aukštas)"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Aukštas"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Labai aukštas"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Leidinys"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Klausiama"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Jungiamasi per serverį"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Eilė pilna"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Eilėje"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Atsiunčiama"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Laukiama maišos f-jos reikšmės"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nėra reikalingų dalių"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Žemam ID nepavyks prisijungti prie kito žemo ID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Per daug užmegztų ryšių"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Jungiamasi per Kademlia"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Perdaug Kademlia ryšių"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Užblokuota"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Ryšio klaida"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Nutolusi eilė pilna"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Senasis MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Naujasis MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Suderinamas su eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Vietinis serveris"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kademlia"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Keičiamasi šaltiniais"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Neveiklus"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Nuoroda"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Pilni šaltiniai"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Baigtos"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Dirbama"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "KLAIDA: trūksta laisvos disko vietos"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "KLAIDA: nerastas dalių failas"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERROR: IO klaida!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERROR: nepavyko!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Eilėje"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Jau siunčiama"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Nežinomas arba klaidingas laikino failo formatas."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Persiųsta"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sparta"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Eiga"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Šaltiniai"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritetas"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Būsena"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Likęs laikas"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Paskutinį kartą matyta pilna"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Paskutinį kartą siųsta"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Ar tikrai norite pašalinti pažymėtą failą?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Ar tikrai norite pašalinti pažymėtus failus?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1583,109 +1541,106 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatiškas"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Sustabdyti"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pauzė"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Tęsti"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "I&švalyti baigtus failus"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Visų naudotojų, turinčių šį failą, prašyti šio failo dabar pat"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Visų naudotojų, turinčių šį failą, prašyti šio failo automatiškai"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Visų naudotojų, turinčių šį failą, prašyti kito failo"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Papildomi veiksmai"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Peržiūra"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "&Rodyti failo savybes"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Rodyti komentarus"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopijuoti magneto URI į talpyklę"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopijuoti eD2k &nuorodą į talpyklę"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopijuoti atsakymą į talpyklę"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "Nepriskirti niekur"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Priskirti į kategoriją"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Atverti failą"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Įrašykite naują failo pavadinimą:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Pervadinti failą"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Atsiuntimai (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1694,47 +1649,47 @@ msgstr ""
 "Norėdami nebematyti šio įspėjimo kiekvienos peržiūros metu,\n"
 "parinktyse nurodykite pageidaujamą video grotuvą (numatytas yra %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Failo peržiūra"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "KLAIDA: nepavyko paleisti išorinio vaizdo grotuvo! Komanda: „%s“"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Įkeliamas server.met failas: %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Įkeliami duomenys iš seno atsiuntimo failo (%u iš %u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "KLAIDA: nepavyko įkelti atsarginės kopijos failo. Paieškokite https://github.com/amule-org/amule/discussions .part.met atstatymo būdų."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nerastas nei vienas dalių failas"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1742,50 +1697,50 @@ msgstr[0] "Rastas %u dalių failas"
 msgstr[1] "Rasti %u dalių failai"
 msgstr[2] "Rasta %u dalių failų"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Laikino aplanko failų sistema nemoka dirbti su dideliais failais."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Atsiųstų failų aplanko failų sistema nemoka dirbti su dideliais failais."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Atsiunčiama %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Failas %s jau buvo atsiųstas"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Failas %s jau buvo atsiųstas"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Nepavyko konvertuoti magnet nuorodos į eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Nežinomas protokolas arba nuoroda: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1793,256 +1748,255 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Klaidinga eD2k nuoroda! KLAIDA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Išoriniai ryšiai atjungti, nes slaptažodis tuščias!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Išoriniai ryšiai atjungti parinkčių faile"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "KLAIDA: nepavyko priimti išorinio ryšio"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Išorinis ryšys nepriimtas, nes parinktyse nurodytas tuščias slaptažodis!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Jungiasi klientas: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Nežinoma versija"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Klaidingos išorinių ryšių versijos, taip gali būti dėl skirtingų programų. Programos branduolį ir nutolusią aplinką naudokite kompiliuotą iš tos pačios pradinio kodo versijos."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nepavyks prie galutinės leidimo versijos prisijungti iš SVN versijos! Ech, buvo išvengta galimo programos lūžimo"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Neteisinga protokolo versija."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Trūksta protokolo versijos žymės."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Patvirtinimas nepavyko."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Klaidingas prašymas, iš pradžių turite būti atpažinti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Prieiga suteikta."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Bandymas gauti prieigą. Prieiga nesuteikta, ryšys nutrauktas."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Nutolusio dalinio failo komanda nepavyko. Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Failo maišos funkcija nerasta: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Oi! OpCode vykdymo klaida!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Serveris neįdėtas"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "serveris nerastas: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "Nurodykite serverį, kurį pašalinti"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k išjungtas parinktyse."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "www paieška iš nutolusios programos neturi prasmės."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Ieškoma. Tuoj bus gauti rezultatai!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Grafikui nėra duomenų."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Šis klientas nesuderintas pateikti tiek detalių."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Išorinis ryšys: gautas prašymas išjungti"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Jau išsijungiama."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Išoriniai ryšiai: įdedama nuoroda %s."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Failas nerastas."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Klaidingas failo pavadinimas."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nepavyko pervadinti failo."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kademlia išjungta parinktyse."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Prie eD2k jau prisijungta."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Jungiamasi prie eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Prie Kademlia jau prisijungta."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Jungiamsi prie Kademlia..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Visi tinklai išjungti."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Atsijungta nuo eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Atsijungta nuo Kademlia."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Išorinis ryšys: gautas klaidingas opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Klaidingas opcode (bloga protokolo versija?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Nežinomas plėtinys %s (komandai %s).\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Nežinoma komanda %s.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2050,7 +2004,7 @@ msgstr ""
 "\n"
 "Ši komanda neturi kintamųjų.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2058,7 +2012,7 @@ msgstr ""
 "\n"
 "Šiai komandai reikia kintamojo.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2066,7 +2020,7 @@ msgstr ""
 "\n"
 "Ši komanda nebaigta, naudokite vieną iš plėtinių žemiau.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2074,11 +2028,11 @@ msgstr ""
 "\n"
 "Galimi plėtiniai:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Galimos komandos:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2089,17 +2043,17 @@ msgstr ""
 "Visoms komandoms svarbu raidžių dydis.\n"
 "Įrašę „%s <komanda>“ gausite išsamią informaciją apie <komandą>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Baigti programos darbą."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Rodyti pagalbą."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2107,7 +2061,7 @@ msgstr ""
 "Įrašę „help <komanda>“ gausite išsamią informaciją apie <komandą>.\n"
 "Įrašę „help“ gausite pilną komandų sąrašą.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2118,46 +2072,46 @@ msgstr ""
 "Įrašę „%s“ gausite komandų sąrašą\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Sintaksės klaida!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Apdorojant komandą įvyko klaida! To neturėjo niekada atsitikti! Prašome pranešti apie klaidą\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Ši komanda negali turėti parametrų."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Ši komanda privalo turėti parametrą."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Klaidingas kintamasis."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Komanda neužbaigta."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Įrašę „%s“ gausite išsamesnę pagalbą.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Tai %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Tai %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2165,7 +2119,7 @@ msgstr ""
 "\n"
 "Kuriamas klientas...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2174,7 +2128,7 @@ msgstr ""
 "\n"
 "Darbas baigiamas %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2188,331 +2142,326 @@ msgstr ""
 "\n"
 "Darbas baigiamas...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Rodyti šį pagalbos tekstą."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Mazgas, kuriame paleista aMule. Numatyta: 127.0.0.1"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule išorinių ryšių prievadas. Numatyta: 4712"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Išorinių ryšių slaptažodis."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Nuskaityti parinktis iš failo."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nepateikti išvesties į stdout įrenginį."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Rodyti išsamius pranešimus, negi klaidų taisymo pranešimus."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Nurodyti programos kalbą."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Komandų eilutės parinktis įrašyti į parinkčių failą."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Sukurti parinkčių failą pagal aMule parinkčių failą."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Atspausdinti programos versiją."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Failo savybės"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% baigta"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Sveikiname!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Prisijungta prie draugo"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Ryšio būklė:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Tinklas"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Inicializavimas"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ skaitymui!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Draugai"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Rodyti &išsamiau"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Įdėti draugą"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Pašalinti draugą"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Siųsti &žinutę"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Peržiūrėti failus"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Sukurti siuntimo kanalą draugui"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Ar tikrai pašalinti pažymėtą draugą?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Ar tikrai pašalinti pažymėtus draugus?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2520,11 +2469,11 @@ msgstr ""
 "Neleidžiama sukurti daugiau nei vieną siuntimo kanalą draugui.\n"
 "Buvo sukurtas tik vienas kanalas."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Pažymėta keletas"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2533,187 +2482,186 @@ msgstr ""
 "Neleidžiama sukurti daugiau nei vieną siuntimo kanalą draugui.\n"
 "Buvo sukurtas tik vienas kanalas."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Siųsti žinutę naudotojui"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Siųsti žinutę:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Pašalinti iš draugų"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Siųsti žinutę"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Keisti į šį failą"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "Ats. kitą failą"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Reitingas: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Atsiunčiamas kitas failas"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Laukiantys išsiuntimai: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "Eilėje"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Išsiuntimas"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Niekas"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Taip"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Atsiunčiama..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Atsiųsta"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Atsiuntimai (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Nepavyko iš %s atsiųsti serverių sąrašo"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Nepavyko iš %s atsiųsti serverių sąrašo"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Įkeliami IP filtrai ipfilter.dat ir ipfilter_static.dat."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Nepavyko įkelti ipfilter.dat failo „%s“, nepavyko suprasti failo formato."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Nepavyko įkelti ipfilter.dat failo „%s“, nepavyko atverti failo."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2721,7 +2669,7 @@ msgstr[0] "Įkeltas %u IP diapazonas iš „%s“."
 msgstr[1] "Įkelti %u IP diapazonai iš „%s“."
 msgstr[2] "Įkelta %u IP diapazonų iš „%s“."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2729,16 +2677,16 @@ msgstr[0] "%u klaidingas įrašas neįkeltas."
 msgstr[1] "%u klaidingi įrašai neįkelti."
 msgstr[2] "%u klaidingų įrašų neįkelta."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2746,56 +2694,52 @@ msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Mazgai (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Klaidingas inicializavimo IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Klaidingas inicializavimo prievadas"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Prašome užpildyti visus privalomus laukus"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Žinutė"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ar tikrai norite atsisiųsti naują nodes.dat failą?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Atsiuntus naują node.dat failą bus pašalinti dabartiniai mazgai ir bus iš naujo prisijungta prie Kademlia tinklo."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Tęsti?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: ieškomas žodis pernelyg trumpas"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2803,12 +2747,11 @@ msgstr[0] "Nuskaitytas %u Kad kontaktas"
 msgstr[1] "Nuskaityti %u Kad kontaktai"
 msgstr[2] "Nuskaityta %u Kad kontaktų"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2816,7 +2759,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2824,2075 +2767,2044 @@ msgstr[0] "Įrašytas %d Kad kantaktas"
 msgstr[1] "Įrašyti %d Kad kantaktai"
 msgstr[2] "Įrašyta %d Kad kantaktų"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad tinklas"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Failo pavadinimas"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Failo dydis"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Platinimo santykis"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Paprašyta"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Priimta"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Pilni šaltiniai"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Nežinoma versija"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Vykdoma maiša"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Patvirtinama"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Baigta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pristabdyta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Klaidinga"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Laukiama"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Turite įrašyti netuščią slaptažodį."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Klaidingas slaptažodis, ne MD5 maiša!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Ryšio klaida"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Nepavyko užmegzti išorinio ryšio. Gautas tuščias atsakymas."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Išorinis ryšys: neteisingas atsakymas iš serverio. Ryšys nutrauktas."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Pavyko! Užmegztas ryšys su aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Pavyko! Ryšys užmegztas."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "KLAIDA: nepavyko klausytis TCP prievado."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "KLAIDA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "DĖMESIO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Užverti"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Iškirpti"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Įterpti"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Pažymėti viską"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Prisijungta"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Prisijungta"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Prisijungta prie Kademlia (už ugniasienės)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "Serverio IP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Serverio IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Neprisijungta"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP prievadas: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP prievadas: neparuošta"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP prievadas: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP prievadas: neparuošta"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Kliento informacija"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Išsiuntimo apribojimas"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Atsiuntimo apribojimas"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Rodyti aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Slėpti aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Baigti"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Neribojama"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule dėklo meniu"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Spartos apribojimai:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Išs.: jokių"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Išs.: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Ats.: jokių"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Ats.: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Atsiuntimo sparta: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Išsiuntimo sparta: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Slapyvardis: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Slapyvardis nenurodytas!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Kliento ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Serverio pavadinimas: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Serverio IP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Neprisijungta"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Keičiamas parašas: įjungta"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Keičiamas parašas: išjungta"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Seanso trukmė: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Dalinami failai: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Klientai eilėje: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Iš viso atsiųsta: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Iš viso išsiųsta: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Įdėti eD2k arba magneto nuorodą į branduolį."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Įdėti į draugus"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Paspauskite norėdami įdėti eD2k nuorodą į teksto valdymą atsiuntimų eilėje."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Įvykių žurnalas. Pilną įvykių žurnalą galite rasti Serverių kortelėje."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Įkeliama..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Naudotojų skaičius serveryje, prie kurio prisijungėte..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Naudotojų: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Naudotojų skaičius dabartiniame serveryje ir apytikslis bendras naudotojų skaičius."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Išs.: 0,0 | Ats.: 0,0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Dabartinė vidutinė išsiuntimo ir atsiuntimo sparta. Jei įjungta papildoma parinktis skaičiai skliausteliuose nurodo išnaudojamą tarnybinį srautą."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Ryšio būklė ir aktyvūs siuntimai. Raudonos rodyklės žymi, kad ryšys neužmegztas, geltonos rodyklės žymi, kad gavote žemą ID (esate už ugniasienės), žalios rodyklės žymi, kad gavote aukštą ID (geriausia ryšio būklė)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Neprisijungta..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Dabartinis serveris."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Paieška"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Pavadinimas:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipas"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Vietinis"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globalus"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Papildomos parinktys"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrai"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Failo tipas"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Bet kas"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Supakuoti failai"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Garso failai"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD atvaizdai"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Paveiksliukai"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programos"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Teksto failai"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vaizdo failai"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Plėtinys"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min dydis"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Baitai"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maks dydis"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Skaičius"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtras:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtruoti rezultatus"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Apversti filtrą"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Slėpti žinomus failus"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Pradėti"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Daugiau"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Sustabdyti"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Atsiųsti"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Atstatyti laukelius"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Paieškos rezultatai"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Pašalinti iš sąrašo jau atsiųstus failus"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Pilni šaltiniai"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Nežinoma"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Bendra"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Pilnas pavadinimas:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met failas:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Maišos f-jos reikšmė:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Failo dydis:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Siuntimas"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Dalinio failo būsena:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Paskutinį kartą matytas pilnas:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Rasti šaltiniai:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Siunčiantys šaltiniai:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Dalių skaičius:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Pasiekiamos dalys:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Atsiuntimo aktyvi trukmė: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Persiųsta duomenų:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Atsiųstas kiekis:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Klaidų taisymo įrankis"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Dėl klaidų prarasta:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Sutaupyta supakuojant:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Klaidų taisymo įrankis pataisė paketų:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Dalinamasi: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Prašymai"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Patenkinti prašymai"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Persiųsta duomenų"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Dalinimo santykis"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Pilni šaltiniai"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Dalinami failai"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Išsiųsta: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nevertinta"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Pavadinimas:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Failo pavadinimai"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Pervadinti"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Išvalyti"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Įvykdyti"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Komentuokite ir įvertinkite failą (komentarą matys visi naudotojai)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Failo kokybė"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nevertinta"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Klaidinga/sugadinta"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Prasta"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Labai gera"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Gera"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Puiki"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Įvertinkite failą arba praneškite kitiems, kad failas sugadintas..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Atsijungta nuo Kademlia"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Atnaujinti"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Atsiunčiama, prašome palaukti..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Dydis nežinomas"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Būtina informacija"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP adresas:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Papildoma informacija"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Naudotojo vardas:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Įdėti"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistikos duomenų medis"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Naudotojo vardas:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Kliento programinė įranga:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Programinės įrangos versija:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP adresas:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Naudotojo ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Serverio IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Serverio pavadinimas:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Slėpimas:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Siuntimai naudotojui"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Dabartinis prašymas:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Vidutinė išsiuntimo sparta:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Vidutinė atsiuntimo sparta:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Išsiųsta (per šį seansą):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Atsiųsta (per šį seansą):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Išsiųsta (iš viso):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Atsiųsta (iš viso):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Reitingas"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Ats./išs. indeksas:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Saugus identifikatorius:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Eilėje"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Reitingas eilėje:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Slapyvardis"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Įrašykite vardą, kurį matys kiti su jumis užmezgę ryšį naudotojai."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Kiek sekundžių uždelsti prieš parodant patarimą užvedus pelę ant objekto."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Naudotojo aplinkos kalba."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Paleidus programą ieškoti naujesnės versijos"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Įjungus šią parinktį aMule kiekieną kartą paleidus programą patikrins ar nėra naujesnės programos versijos"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Paleidus nuleisti langą"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Jei ši parinktis įjungta, paleidus programą aMule langas bus iškart nuleistas žemyn."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Klausti prieš baigiant darbą"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Įjungti sistemos dėklo ženkliuką"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Ši parinktis įjungia ar išjungia sistemos dėklo ženkliuką."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Sumažinti į sisteminio dėklo ženkliuką"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Jei ši parinktis įungta, nuleidus aMule langą, programa bus sumažinta į sistemos dėklo ženkliuką, o ne į programų juostą."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Naršyklės parintys"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Jei įmanoma, atverti naują kortelę"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Įjungus šią parinktį, stengtis nurodytą puslapį atverti naujoje naršyklės kortelėje, o ne pagrindiniame naršyklės lange"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Vaizdo grotuvas"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Išsiuntimas"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Vieno ryšio sparta"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tai standartinis eD2k prievadas. Jis negali būti išjungtas."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Pradėjus darbą prisijungti automatiškai"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Nutrūkus ryšiui prisijungti vėl"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Pašalinti neatsiliepiantį serverį po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "bandymų"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Sąrašas"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Atnaujinti serverių sąrašą prisijungus prie serverio"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Atnaujinti serverių sąrašą prisijungus klientui"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Naudoti prioritetų sistemą"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Jungiantis naudoti išmoningą žemo ID tikrinimą"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Saugus jungimasis"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatiškai jungtis tik prie serverių iš pastovaus sąrašo"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Naudotojo įdėtiems serveriams nurodyti aukštą prioritetą"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Failus į atsiuntimo eilę įdėti pristabdytos būsenos"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Į atsiuntimo eilę įdedamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Visų pirma bandyti atsiųsti pirmą ir paskutinę failo dalį"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Siųsti tos pačios kategorijos failą"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Naujiems failams paskirti vietą diske"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Naujiems failams iš anksto paskirti vietą diske visam failui. Taip bus sumažinta fragmentacija"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Įjunkite, jei norite, kad aMule tikrintų laisvą vietą diske"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Įrašykite kiek diske palikti laisvos vietos."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Įrašyti 10 šaltinių retiems failams (mažiau nei 20 šaltinių)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Išsiuntimai"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Naujiems dalinamiems failams nurodyti automatinį prioritetą"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Pašalinti"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(spragtelėję dešiniu klavišu dalinsitės ir gilesniais paaplankiais)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Dalintis slepiamais failais"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikai"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Atnaujinimo dažnis: 5 s"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Vidurkių grafiko dydis: 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Ryšių grafiko skalė: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fonas"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rėmeliai"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Dabartinė atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Dabartinis atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Seanso atsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Dabartinė išsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Dabartinis išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Sistemos dėklo spartos indikatorius"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Dabartiniai Kademlia mazgai"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kademlia mazgų dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Rodomų klientų versijų skaičius (0 – neribojama)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "DĖMESIO!!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Per 5 s užmegzti ne daugiau ryšių, nei nurodyta"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Failo buferio dydis: 240000 baitai"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Išsiuntimo eilė: 5000 klientų"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Rodyti papildomą informaciją kategorijų kortelėse"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Rodyti siuntimo spartą failo pavadinime"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Mygtukus išdėstyti vertikaliai"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plokščia"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Išjungti svečio prieigą"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Svečio prieigos prie žiniatinklio serverio slaptažodis"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4900,11 +4812,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4914,486 +4826,486 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Išjungta [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "baitas"
 msgstr[1] "baitai"
 msgstr[2] "baitų"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "baitas/s"
 msgstr[1] "baitai/s"
 msgstr[2] "baitų/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "s"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min."
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "val."
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dienų"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "Viskas"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "Visa kita"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Neužbaigtos"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Sustabdyta"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vaizdo failai"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Supakuoti failai"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Teksto failai"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktyvios"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Įkeliama %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Laukiama pradinės informacijos iš atsiunčiamos informacijos failo"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Kuriamas paskirties failas"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Įkeliami duomenys iš seno atsiuntimo failo (%u iš %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Duomenų blokas įrašomas į naują atsiuntimo failą (%u iš %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Laukiama atsiuntimo failo šaltinių informacijos"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Įkeliamas atsiuntimo failas ir įrašomas naujas dalinis failas"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Įkelti dalių failus"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Būklė"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Maišos f-ja"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (diskas: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Įrašykite aplanką, kuriame ieškoti dalinai atsiųstų failų! Paaplankiai bus irgi apieškoti."
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Ar norite, kad sėmingai įkeltų failų pradiniai failai būtų pašalinti?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Pašalinti pradinius failus?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "KLAIDA: nepavyko sukurti dalių failo"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Bandoma įkelti met failo atsarginę kopiją iš %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "KLAIDA: nepavyko atverti part.met failo: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "KLAIDA: part.met failo dydis yra 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "KLAIDA: %s (%s) yra sugadintas (blogas žymių skaičius), failo įkelti nepavyks."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "KLAIDA: %s (%s) yra sugadintas (blogas žymių skaičius), failo įkelti nepavyks."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Bandoma atstatyti failo informaciją..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Atstatomas failas be pavadinimo. Atstačius jis bus pavadintas RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Atstatyta visa įmanoma failo informacija – bandoma naudoti failą..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Nepavyko atstatyti failo informacijos :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Nepavyko atverti %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "DĖMESIO: %s gali būti sugadintas (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "KLAIDA: įrašant dalių failą įvyko klaida: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "KLAIDA: įrašant dalių failą įvyko klaida: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Failui %s nepavyko įrašyti part.met.seeds failo"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5401,17 +5313,17 @@ msgstr[0] "Įrašytas %i platinantis šaltinis dalių failui %s (%s)"
 msgstr[1] "Įrašyti %i platinantys šaltiniai dalių failui %s (%s)"
 msgstr[2] "Įrašyta %i platinančių šaltinių dalių failui %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Įrašytas %i platinantis šaltinis dalių failui %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Nuskaitant dalių failo platinančių šaltinių failą įvyko klaida (%s – %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5419,353 +5331,353 @@ msgstr[0] "Aptikta klaidinga dalis (%d) %d dalies faile %s – failo rezultatų 
 msgstr[1] "Aptikta klaidinga dalis (%d) %d dalių faile %s – failo rezultatų maišos f-ja |%s| failo maišos f-ja |%s|"
 msgstr[2] "Aptikta klaidinga dalis (%d) %d dalių faile %s – failo rezultatų maišos f-ja |%s| failo maišos f-ja |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Aptikta baigta dalis (%i) %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Baigtas maišos f-jos reikšmės perskaičiavimas %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Baigiant siųsti %s įvyko netikėta klaida. Failas pristabdytas"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Atsiųsta: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Atsiųsta: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Šalinamas failas: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "DĖMESIO: atsiųstai daliai nepavyko apskaičiuoti maišos funkcijos – %s maišos reikšmės nebaigtos"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "DĖMESIO: atsiųstai daliai nepavyko apskaičiuoti maišos funkcijos – %s maišos reikšmės nebaigtos. Tokių dalykų neturi būti"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "Dėmesio: diske nepakanka laisvos vietos! Failas pristabdomas: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Atsiųsta sugadinta %i dalis: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "Klaidų taisymo įrankis: atstatyta sugadinta dalis %i %s –> išgelbėta %s baitų"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Paskiriama vieta"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Nepakanka laisvos vietos"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Atsiųsta"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Kanalas"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Aplankai"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveriai"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Failai"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Saugumas"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Atstovaujantis serveris"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Nutolęs valdymas"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Keičiamas parašas"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Įvykiai"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Taisymas"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5780,35 +5692,35 @@ msgstr ""
 "\n"
 "aMule puikiai veikia nieko nepakeitus šiame lange."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Atstovaujančio serverio, prie kurio jungsitės, tipas"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5816,51 +5728,51 @@ msgstr ""
 "Kad įsigaliotų šie pakeitimai, aMule reikia paleisti iš naujo:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "– pakeistas TCP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "– pakeistas UDP prievadas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Išorinis ryšys nutrauktas."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolo slėpimas"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5868,34 +5780,34 @@ msgstr ""
 "Įjungėte išorinius ryšius, bet parinktyse nenurodėte slaptažodžio.\n"
 "Kol nenurodysite slaptažodžio, išoriniai ryšiai nebus įjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "– kalba pakeista.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "– laikinų failų aplankas pakeistas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Visi tinklai išjungti."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neteisinga protokolo versija."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5903,7 +5815,7 @@ msgstr ""
 "Tiek eD2k, tiek Kademlia tinklai yra išjungti.\n"
 "Norėdami prisijungti įjunkite bent vieną iš šių tinklų."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5911,7 +5823,7 @@ msgstr ""
 "Nepavyks prisijungti prie Kademlia tinklo, nes išjungtas UDP prievadas.\n"
 "Arba įjunkite UDP prievadą, arba išjunkite Kademlia tinklą."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5921,69 +5833,69 @@ msgstr ""
 "Būtina paleisti aMule iš naujo.\n"
 "Jei dabar pat neperleisite aMule, nesiskųskite jei kas nors bus ne taip.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Naujas išorinis ryšys priimtas"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5993,24 +5905,24 @@ msgstr ""
 "Įrašykite bent vieną server.met failo URL.\n"
 "Norėdami įrašyti URL, paspauskite mygtuką „Sąrašas“."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Laikini failai"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Atsiųsti failai"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Keičiami parašai"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Parinkite aplanką %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6018,42 +5930,42 @@ msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Parinkite video grotuvą"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Parinkite naršyklę"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Vykdomas failas %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Numatyta"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Keisti serverių sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6061,42 +5973,42 @@ msgstr ""
 "Įrašykite server.met failų URL.\n"
 "Vieną URL vienoje eilutėje."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Pilni šaltiniai"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Būsena:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6104,7 +6016,7 @@ msgstr[0] "Atnaujinimo intervalas: %d s"
 msgstr[1] "Atnaujinimo intervalas: %d s"
 msgstr[2] "Atnaujinimo intervalas: %d s"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6112,12 +6024,12 @@ msgstr[0] "Vidurkių grafiko trukmė: %d min."
 msgstr[1] "Vidurkių grafiko trukmė: %d min."
 msgstr[2] "Vidurkių grafiko trukmė: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Ryšių grafiko mastelis: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6125,7 +6037,7 @@ msgstr[0] "Failų buferio dydis: %d baitas"
 msgstr[1] "Failų buferio dydis: %d baitai"
 msgstr[2] "Failų buferio dydis: %d baitų"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6133,7 +6045,7 @@ msgstr[0] "Išsiuntimo eilės dydis: %d klientas"
 msgstr[1] "Išsiuntimo eilės dydis: %d klientai"
 msgstr[2] "Išsiuntimo eilės dydis: %d klientų"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6141,237 +6053,237 @@ msgstr[0] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[1] "Serverio ryšio atnaujinimo intervalas: %d min."
 msgstr[2] "Serverio ryšio atnaujinimo intervalas: %d min."
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serverio ryšio atnaujinimo intervalas: išjungta"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "Išjungti"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Įvykus „%s“ įvykiui įvykdyti komandą"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Įjungti komandos vykdymą branduolyje"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Branduolio komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Įjungti komandos vykdymą grafinėje aplinkoje"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Grafinės aplinkos komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Šie kintamieji bus pakeisti:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Skaitomas laikinų failų aplankas"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dalinami failai"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą. Įvestos viršutinės ribos nebus paisoma."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Dėmesio"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Pagrindinė"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k paieška negalima, jei eD2k tarnyba neužmezgė ryšio"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Vykdant Kademlia paiešką įvyko netikėta klaida: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Failo ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nevertinta"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Atsiunčiamą failą įdėti į kategoriją"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Šiam failui įdėti papildomus URL"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Ieškoti panašių failų (eD2k, vietiniame serveryje)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Pažymėti failą kaip jau žinomą"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Prie serverio, kurį norite pašalinti, esate šiuo metu prisijungę. Norėdami pašalinti serverį, iš pradžių turite atsijungti."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Atšaukti"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Nepavyko prisijungti nei prie vieno iš slepiamų serverių sąraše. Bandoma dar kartą neslepiant."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Nepavyko prisijungti nei prie vieno iš slepiamų serverių sąraše. Bandoma dar kartą neslepiant."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Nepavyko prisijungti nei prie vieno iš serverių sąraše. Bandoma dar kartą."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Nepavyko prisijungti nei prie vieno iš serverių sąraše. Bandoma dar kartą."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k tinklas išjungtas parinktyse, nebus jungiamasi."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Serverių sąraše nerasta tinkamų serverių įrašų"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Prisijungta prie %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Prisijungta: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Bandant prisijungti įvyko kritinė klaida. Gali būti, kad nėra interneto ryšio"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Ryšys nutrūko %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) neatsako, galbūt išjungtas."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) pilnas."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6379,48 +6291,48 @@ msgstr[0] "Po %d sekundės bus bandoma prisijungti prie serverio automatiškai"
 msgstr[1] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
 msgstr[2] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Prisijungti prie %s (%s:%i) nepavyko."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "KLAIDA: neteisingas lizdas (socket) baigiantis laiko limitui"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Baigėsi bandymo susijungti laikas %s (%s:%i)."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Įkeliamas server.met failas: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Nepavyko aptikti server.met failo!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Nepavyko įkelti server.met failo %s, aptikto failo formatas nesuprantamas."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Nepavyko atverti failo server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Failas server.met sugadintas, aptiktas klaidingas versijos įrašas: 0x%x, dydis %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6428,7 +6340,7 @@ msgstr[0] "server.met faile rastas %i serveris"
 msgstr[1] "server.met faile rasti %i serveriai"
 msgstr[2] "server.met faile rasta %i serverių"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6436,237 +6348,236 @@ msgstr[0] "%d serveris įdėtas"
 msgstr[1] "%d serveriai įdėti"
 msgstr[2] "%d serverių įdėta"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Nuskaitant known.met failą įvyko IO klaida: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serveris neįdėtas: [%s:%d] nurodytas klaidingas prievadas."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serveris neįdėtas: [%s:%d] IP adresas klaidingas arba nepraėjo filtro."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serveris neįdėtas: [%s:%d] toks serveris jau yra."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Serveris įdėtas: [%s:%d] pavadinimas %s."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Prie serverio, kurį norite pašalinti, esate šiuo metu prisijungę. Norėdami pašalinti serverį, iš pradžių turite atsijungti."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Nepavyko atverti %s"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Nepavyko įrašyti server.met failo!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Klaidingas URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Sėkmingai atsiųstas serverių sąrašas iš %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Faile „addresses.dat“ nerasta serverių sąrašo įrašų. Norėdami automatiškai atnaujinti sąrašą į šį failą įkelkite teisingą serverių sąrašo adresą."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Atsiųsti serverių sąrašą iš %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "DĖMESIO: automatiškam serverių sąrašo atnaujinimui pateiktas neteisingas URL: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Faile addresses.dat nerasta nei vieno teisingo server.met failo automatinio atsiuntimo URL"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Nepavyko iš %s atsiųsti serverių sąrašo"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Vietinis serveris filtruojamas IP filtro, jungiamasi prie kito serverio!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serverio pavadinimas"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresas"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Prievadas"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Aprašymas"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping trukmė"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Naudotojų skaičius"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statiškas"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versija"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Prie serverio, kurį norite pašalinti, esate šiuo metu prisijungę. Norėdami pašalinti serverį, iš pradžių turite atsijungti. Serveris kol kas nepašalintas."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(pavadinimas nežinomas)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ar tikrai norite pašalinti šį statišką serverį %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serveriai (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Serveris"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Prisijungti prie serverio"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Pažymėti, kad serveris statiškas"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Pažymėti, kad serveris nestatiškas"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Pažymėti, kad serveriai statiški"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Pažymėti, kad serveriai nestatiški"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Pašalinti serverį"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Pašalinti serverius"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Pašalinti visus serverius"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopijuoti eD2k nuorodas į talpyklę"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Prisijungti prie serverio iš naujo"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Ar tikrai norite pašalinti visus serverius?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Ar tikrai norite pašalinti pažymėtą serverį?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ar tikrai norite pašalinti pažymėtus serverius?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "KLAIDA: %s (%s) – %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "DĖMESIO: %s (%s) – %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Naujas kliento ID yra %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "DĖMESIO: gavote žemą ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tLabiausiai tikėtina, kad esate už ugniasienės ar maršrutizatoriaus."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Gauta nežinomo serverio informacija per trumpa!"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6674,182 +6585,182 @@ msgstr[0] "Aptiktas %d naujas serveris"
 msgstr[1] "Aptikti %d nauji serveriai"
 msgstr[2] "Aptikta %d naujų serverių"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Serverių sąrašo įrašymas baigtas."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Serveris atmetė paskutinę komandą"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Iš serverio %s gautas klaidingas paketas"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Apdorojant iš serverio %s gautą paketą įvyko nežinoma klaida"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Prisijungiant prie %s nepavyko sukurti DNS ryšio gijos"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Serverio IP %s (%s) nepraėjo filtro. Ryšys nebus užmezgamas."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "naudojamas protokolo slėpimas."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Prisijungta prie %s (%s – %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Nepavyko išsiaiškinti serverio %s DNS. Ryšys nebus užmezgamas!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule žurnalas"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serveris neįdėtas: nenurodytas IP adresas arba mazgo pavadinimas."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serveris neįdėtas: nurodytas neteisingas serverio prievadas."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k būsena:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Ryšio būklė:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Prisijungta"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia būsena:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Dirbama"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademlia būsena:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Būsena:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Ryšio būklė:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Ryšio būklė:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Ugniasienės būsena: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nėra draugo"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Prisijungta prie draugo"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Prisijungta prie draugo"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Rasti šaltiniai:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "Indekso failas nerastas: "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Naudotojų vidurkis:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Failų vidurkis:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Nepaleista"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6857,7 +6768,7 @@ msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6865,7 +6776,7 @@ msgstr[0] "Aptiktas %i žinomas dalinamas failai, %i nežinomų"
 msgstr[1] "Aptikti %i žinomi dalinami failai, %i nežinomų"
 msgstr[2] "Aptikta %i žinomų dalinamų failų, %i nežinomų"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6873,425 +6784,425 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "KLAIDA: bandoma dalintis %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "serveris nerastas: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Naudotojo vardas"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Išsiuntimo sparta"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Pasiekiamos dalys:"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Išsiuntimo būsena"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Atsiuntimo būsena"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Failo pavadinimas"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Dalinami failai"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Gautos dalys"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Kelias"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Įdėti komentarą/įvertinimą"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Keisti komentarą/įvertinimą"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Pervadinti"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Failus iš kolekcijos įkelti į siuntimo sąrašą"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopijuoti magneto &URI į talpyklę"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (&šaltinį)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (šaltinį su ši&fravimo parinktimis)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (&kompiuterio pavadinimą)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (kompiuterio pavadinimą su šif&ravimo parinktimis)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (&klaidų taisymo informaciją)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę (&klaidų taisymo informaciją)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Norėdami sukurti šaltinio nuorodą, privalote turėti aukštą ID"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Failo pavadinimas"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Išsiųsta duomenų (per seansą (iš viso)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Tarnybinis srautas iš viso (paketai): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Tarnybinis srautas failų prašymams (paketai): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Tarnybinis srautas šaltinių apsikeitimui (paketai):%s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Tarnybinis srautas serveriams (paketai): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kademlia tarnybinis srautas (paketai): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Šifravimo tarnybinis srautas (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktyvūs išsiuntimai: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Laukiantys išsiuntimai: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Iš viso sėkmingų išsiuntimų: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Iš viso nepavykusių išsiuntimų: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Vidutiniškai išsiuntimas trunka: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Atsiųsta duomenų (per seansą (iš viso)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Rasta šaltinių: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktyvūs atsiuntimai (dalys): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Seanso Išs./Ats. santykis (iš viso): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Vidutinė atsiuntimo sparta (seanso): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Vidutinė išsiuntimo sparta (seanso): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Didžiausia atsiuntimo sparta (seanso): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Didžiausia išsiuntimo sparta (seanso): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Ryšis pakartotinai užmegztas: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Pirmą kartą siųsta prieš: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Prisijungta prie serverio prieš: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktyvių ryšių skaičius (apytikriai): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Didžiausias leistinas ryšių skaičius pasiektas: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Vidutinis ryšių skaičius (apytikriai): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Daugiausia ryšių (apytikriai): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Naudotojai"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Dydis nežinomas"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Filtruota"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Užblokuota"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Iš viso: %i atpažinta: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Veikiantys serveriai: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Neveikiantys serveriai: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Iš viso: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Pašalinti serveriai: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtruoti serveriai: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Naudotojų kiekis veikiančiuose serveriuose: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Failų kiekis veikiančiuose serveriuose: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Iš viso naudotojų: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Iš viso failų: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Serverių užimtumas: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Dalinamų failų kiekis: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Bendras dalinamų failų dydis: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Vidutinis failo dydis: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operacinė sistema"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Negauta"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktyvūs ryšiai (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nėra"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Niekada"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Komanda „%s“, kurios pid „%d“, baigė darbą pranešdama būsenos kodą „%d“."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Įvykdyti <str> ir baigti darbą."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Neteisingas IP formatas. Naudokite xxx.xxx.xxx.xxx:xxxx formą\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Šiai komandai reikia kintamojo. Tinkami kintamieji: „all“ (viskas), failo pavadinimas arba skaičius.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Apdorojama pagal maišos f-jos reikšmę: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Apdorojama pagal failo pavadinimą: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Šiai komandai reikia kintamojo. Tinkami kintamieji: failo maišos f-jos reikšmė.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Neteisingas skaičius\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Neteisinga maišos funkcija (turi būti 32 simbolių dydžio)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7300,7 +7211,7 @@ msgstr "Įrašę „%s“ gausite išsamesnę pagalbą.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7309,89 +7220,87 @@ msgstr "Įrašę „%s“ gausite išsamesnę pagalbą.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Įrašę „%s“ gausite išsamesnę pagalbą.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Atsiuntimai (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Vykdant užduotį įvyko nežinoma klaida."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Užduotis įvykdyta sėkmingai."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Nepavyko įvykdyti prašymo. Gauta klaida: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP klientų filtras %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Išjungta"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Įjungta"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP serverių filtras %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Dabartinis IP filtro lygmuo %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Spartos apribojimai: išs: %u kB/s, ats: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Prisijungta prie %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Jungiamasi"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "ugniasienė"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "gerai"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7400,7 +7309,7 @@ msgstr ""
 "\n"
 "Atsiuntimai:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7409,7 +7318,7 @@ msgstr ""
 "\n"
 "Išsiuntimai:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7418,7 +7327,7 @@ msgstr ""
 "\n"
 "Klientai eilėje:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7427,46 +7336,46 @@ msgstr ""
 "\n"
 "Iš viso šaltinių:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Dalių failas]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Paieškos rezultatų kiekis: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Gautas nelauktas atsakymas iš serverio, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Rodyti trumpą būklės informaciją."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Rodyti ryšio būklę, dabartinę išsiuntimo ir atsiuntimo spartą ir pan.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Rodyti išsamų statistikos medį."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7479,11 +7388,11 @@ msgstr ""
 "Jei kintamojo nėra arba jo reikšmė 0, bus rodomos visos versijos (neribojama).\n"
 "Pavyzdžiui: „statistics 5“ rodys tik 5 populiariausias kiekvieno tipo kliento versijas.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Išjungti aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7492,40 +7401,40 @@ msgstr ""
 "Išjungti nutolusį programos branduolį (amule/amuled).\n"
 "Tekstinis klientas taipogi bus išjungtas, nes be branduolio jis neturi jokios prasmės.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Atnaujinti objektą."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Atnaujinti IP filtrų sąrašą iš failo."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Nurodyti filtravimo lygmenį."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Atnaujinti IP filtrų sąrašą iš failo."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Prisijungti prie tinklo."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7537,36 +7446,36 @@ msgstr ""
 "IP:prievadas. Bus prisijungta tik prie nurodyto serverio. IP turi būti taškais\n"
 "atskirtais dešimtainiais skaičiais užrašytas IPv4 adresas arba DNS srities pavadinimas."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Prisijungti tik prie eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Prisijungti tik prie Kademlia."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Atsijungti nuo tinklo."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Atsijungti nuo visų tinklų, prie kurių šiuo metu prisijungta.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Atsijungti tik nuo eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Atsijungti tik nuo Kademlia."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Įdėti eD2k arba magneto nuorodą į branduolį."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7583,52 +7492,52 @@ msgstr ""
 "\n"
 "Magneto nuorodoje turi būti eD2k maišos f-jos reikšmė ir failo dydis.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Nurodyti parinkties reikšmę."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Nurodyti IP filtro parinktis."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Įjungti klientų ir serverių IP filtravimą."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Išjungti klientų ir serverių IP filtravimą."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Įj./išj. klientų IP filtravimą."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Įjungti klientų IP filtravimą."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Išjungti klientų IP filtravimą."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Įj./išj. serverių IP filtravimą."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Įjungti serverių IP filtravimą."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Išjungti serverių IP filtravimą."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Nurodyti filtravimo lygmenį."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7636,80 +7545,80 @@ msgstr ""
 "Filtravimo lygmenys yra skaičiai nuo 0 iki 255.\n"
 "Numatytas lygmuo 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Nurodyti spartos apribojimus."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Šioms komandoms reikšmės nurodomos kilobaitais per sekundę.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Nurodyti išsiuntimo spartos apribojimą."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Šioms komandoms reikšmės nurodomos kilobaitais per sekundę.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Nurodyti atsiuntimo spartos apribojimą."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Šioms komandoms reikšmės nurodomos kilobaitais per sekundę.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Pateikti parinkties reikšmę."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Pateikti IP filtro parinktis."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Pateikti klientų ir serverių IP filtro būseną."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Pateikti tik klientų IP filtro būseną."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Pateikti tik serverių IP filtro būseną."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Nurodyti filtravimo lygmenį."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Pateikti spartos apribojimus."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Ieškoti Kademlia tinkle"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7728,48 +7637,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Ieškoti globaliai."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Ieškoti vietiniame serveryje"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Ieškoti Kademlia tinkle"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Pateikti paskutinės paieškos rezultatus."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Rodyti paieškos eigą."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Pradėti atsiųsti failą"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7777,82 +7686,82 @@ msgstr ""
 "Nurodykite failo numerį ankstesnės paieškos rezultate.\n"
 "Pavyzdžiui: „atsisiųsti 12“ reikš atsisiųsti failą nr. 12 iš ankstesnės paieškos rezultato.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pristabdyti atsiunčiamą failą."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Tęsti failo atsiuntimą."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Atšaukti failo atsiuntimą."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Nurodyti atsiuntimo prioritetą."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Nurodyti žemą, normalų, aukštą arba automatinį prioritetą.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Nurodyti žemą prioritetą."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Nurodyti normalų prioritetą."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Nurodyti aukštą prioritetą."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Nurodyti automatinį prioritetą."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Rodyti eiles/sąrašus."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Rodyti išsiuntimo/atsiuntimo eilę, serverių sąrašą arba dalinamus failus.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Rodyti išsiuntimo eilę."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Rodyti atsiuntimo eilę."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Rodyti žurnalą."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Rodyti serverių sąrašą."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Atnaujinti dalinamų failų sąrašą."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Atstatyti žurnalą."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Pasenusi komanda, geriau naudokite „%s“."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7861,262 +7770,259 @@ msgstr ""
 "Ši komanda pasenusi ir ateityje gali būti pašalinta.\n"
 "Geriau naudokite „%s“.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstinis klientas"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Senos klaidų taisymo maišos reikšmės keičiamos „%s“ keičiamos 64b „%s“."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "Dėmesio: failo pavadinimas %s yra klaidingas, todėl buvo pakeistas į %s."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "Dėmesio: failas %s jau yra, naujas failas pervadintas į %s."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Ar tikrai norite atšaukti ir pašalinti visus failus šioje kategorijoje?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Reikalaujama patvirtinimo"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Per daug užmegztų ryšių"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Visa kita"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Parinkite filtrą"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Įdėti kategoriją"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Keisti kategoriją"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Pašalinti kategoriją"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Gautas prašymas nežinomo failo maišos f-jai: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Tęsiame failos siuntimą: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Nutraukiamas failo siuntimas: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Nepavyko įvykdyti komandos „%s„ įvykiui „%s“."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Atsiuntimas baigtas"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Pilnas kelias iki failo."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Failo pavadinimas (be kelio iki jo)."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Failo eD2k maišos reikšmė."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Failo dydis baitais."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Visas atsiuntimo laikas."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Pradėtas naujas pokalbis"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Žinutės antraštė."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Trūksta laisvos vietos"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Disko skirsnis."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Baigiant siųsti failą įvyko klaida"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Apdorojamo failo numeris %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Pageidavote dalinių maišos rezultatų (naudojamų tik didesniems nei 9,5 MB failams)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s —> tokio failo nėra!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, aMule eD2k nuorodų kūrimo įrankis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Sveikiname!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Įvesties parametrai"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Pateikti failo maišos funkciją"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Šiam failui įdėti papildomus URL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Įrašykite failą, kuriam kursite eD2k nuorodą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Įrašykite URL, kurį pridėsite prie eD2k nuorodos. Gale pridėjus „/“ aLinkCreator pridės dabartinio failo pavadinimą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Kurti nuorodas su dalių maišos f-jomis"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Nauji ir reti failai bus platinamos sparčiau, bet nuoroda taps ilgesnė"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 failo maišos f-ja"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k failo maišos f-ja"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k nuoroda"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Įrašyti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopijuoti į talpyklę"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Atverti failą ir apskaičiuoti jo eD2k nuorodą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopijuoti apskaičiuotą eD2k nuorodą į talpyklę"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Įrašyti apskaičiuotą eD2k nuorodą į failą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Apie aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Nurodykite failą, kuriam skaičiuosite eD2k nuorodą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Kol kas nėra ką kopijuoti!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Nurodykite failą apskaičiuotai eD2k nuorodai"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Nepavyko atverti "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Įrašykite failo pavadinimą"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Kol kas nėra ką įrašyti!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8136,167 +8042,159 @@ msgstr ""
 "\n"
 "Platinama pagal GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Skaičiuojamos maišos f-jos reikšmės..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Atšaukta!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Atlikta per %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Šis URL jau įdėtas!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Įrašykite URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Nepavyko atverti %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i d. %i val. %i min. %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02ud %02uv %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uv %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule dabartinė statistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Didžiausia ats. sparta nuo wxCas paleidimo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Pati didžiausia ats. sparta per praeitus wxCas seasus"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Perkrauti"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Sustabdyti automatinį atnaujinimą"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Įrašyti dabartinės statistikos grafiką"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Spausdinti dabartinės statistikos grafiką"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Parinktys"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Apie wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Paleisti automatinį atnaujinimą"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatinis atnaujinimas sustabdytas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automatinis atnaujinimas paleistas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Įrašyti statistikos grafiką"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule dabartinė statistika"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8304,11 +8202,11 @@ msgstr ""
 "Spausdinant įvyko klaida.\n"
 "Gali būti, kad spausdintuvas nėra tinkamai suderintas."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Spausdinama"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8326,403 +8224,392 @@ msgstr ""
 "\n"
 "Platinama pagal GPL licenciją"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oi! aMule nepaleista..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule paleista"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule paleista, bet ryšys neužmegztas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule užmezga ryšį..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oi! aMule būsena nežinoma..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " vykdoma "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " sustabdyta!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ryšys neužmegztas!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " užmezga ryšį..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " elgiasi keistai, prašome patikrinti!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " užmezgė ryši su "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "išj"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " įj."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " su "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Išviso atsiųsta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Išsiųsta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Atsiųsta per šį seansą: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Atsiųsta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Išsiųsta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Dalinamasi: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " failas(ai), naudotojai eilėje: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Trukmė: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " – "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Vidutinis sistemos apkrovimas (per 1–5–15 min.): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Sistemos veikimo trukmė: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat failo aplankas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Įrašykite aplanką, kuriame yra amulesig.dat failas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Atnaujinimo intervalas sekudėmis"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Kurti statistikos grafiką po kiekvieno atnaujinimo"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Įrašykite aplanką, kuriame bus kuriamas statistikos grafikas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Periodiškai siųsti staitikos grafiką į FTP serverį"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP URL"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP kelias"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Įrašykite FTP serverio adresą"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Įrašykite FTP serverio aplanką, į kurį kelsite statistikos grafiką"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Vartotojas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Įrašykite vartotoją, kuriuo jungsitės prie FTP serverio"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Įrašykite vartotojo, kuriuo jungsitės prie FTP serverio, slaptažodį"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP atnaujinimo intervalas minutėmis"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Patvirtinti"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Aplankas, kuriame yra parašo failas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Aplankas, kuriame kuriamas statistikos grafikas"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Įkelti šabloną <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Žiniatinklio serverio HTTP prievadas"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "UPnP prievadus persiunti žiniatinklio serverio prievade"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP prievadas"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Pilnos prieigos prie žiniatinklio serverio slaptažodis"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Svečio prieigos prie žiniatinklio serverio slaptažodis"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Įjungti svečio prieigą"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Išjungti svečio prieigą"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Įkelti/įrašyti žiniatinklio serverio parinktis iš/į nutolusio aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule parinkčių failas. NENAUDOKITE TIESIOGIAI!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Išjungti PHP interpretatorių (pasenusi)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Kiekvieną kartą perkompiliuoti PHP puslapius"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule www serveris"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "Priimtas žiniatinklio kliento ryšys\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Vykdant užduotį įvyko klaida: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indekso failas nerastas: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Seansas baigėsi – prašoma prisijungti iš naujo\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Seansas pradėtas, priega gauta\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Seansas pradėtas, priega negauta\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Seansas nepradėtas – bus prašoma prisijungti\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Seansas sukurtas – prašoma prisijungti\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Apdorojamas prašymas [pradinis]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Slaptažodžio maišos funkcija neteisinga\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Slaptažodis priimtas\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Neteisingas slaptažodis\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Neįrašėte slaptažodžio. Tuščias slaptažodis neleidžiamas.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Prašoma atsijungti\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Apdorojamas prašymas [persiųstas]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Prisijungti nepavyko "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,25 +17,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "Par aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -43,76 +43,76 @@ msgstr ""
 "Autortiesības (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Vienādranga (P2P) maršrutēšana, pamatojoties uz XOR (izslēdzošā VAI) metriku.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Autortiesības (c) 2002-2011 Petars Majmunkovs ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Vietne:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forums:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Dokumentācija:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Problēmas:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Noklikšķiniet, lai pārbaudītu, vai nav pieejama jaunāka versija."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Pārbaudīt atjauninājumus"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "Pārbauda atjauninājumus…"
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "Jūs izmantojiet jaunāko versiju."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ir pieejama jauna (%s) versija:"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr ""
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Jums jāievada derīga IP adrese un ports!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informācija"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -121,47 +121,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Uzstādīt"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -170,103 +169,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule uzstādīta"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Palaist no jauna tagad"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Vēlāk"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Pašlaik aizver galveno programmu…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Iznīcina amuleweb procesu ar pid '%d' … "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Neizdevās"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Pārtrauc amuleweb procesu ar pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Iznīcina amuleapi procesu ar pid '%d' … "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informācija"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -274,71 +270,67 @@ msgstr ""
 "\n"
 "EC iestatījumi"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "BRĪDINĀJUMS"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "KĻŪDA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -348,269 +340,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Šī ir pirmā reize, kad aMule %s palaista"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Šī ir ikdienas (atjaunina katru dienu) testa versija, tāpēc\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "mēs negarantējam, ka tā neko nesabojās, nenodedzinās jūsu māju\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "vai nenogalinās jūsu suni. Bet tā jebkurā gadījumā *vajadzētu* būt droša lietošanā.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Plašāka informācija, atbalsts un jaunās versijas ir pieejamas mūsu vietnē\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io vai mūsu IRC kanālā #aMule vietnē irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nekautrējieties ziņot par problēmām https://github.com/amule-org/amule/issues vietnē"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "KĻŪDA: nevar atvērt žurnāldatni"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "BRĪDINĀJUMS: žurnāldatne ir tukša. Te kaut kas nav kā vajag :-(."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servera ziņojums: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Jūs izmantojiet novecojušu aMule versiju!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Jūsu aMule versija — %i.%i.%i un jaunākā versija — %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Jaunāko aMule versiju vienmēr var iegūt https://github.com/amule-org/amule/releases/latest vietnē"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "BRĪDINĀJUMS: Jūsu aMule versija ir novecojusi: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Šī ir jaunākā aMule versija."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Neizdevās lejupielādēt versijas pārbaudes datni"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Lietotāji: %s | Datnes: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Lietotāji: E: %s K: %s | Datnes: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "ar zemu ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "ar augstu ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Pieslēgts %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Pieslēdzas %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Atslēgts no eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Pieslēgts Kad (veiksmīgi)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Pieslēgts Kad (aiz ugunsmūra)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "KĻŪDA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Pieejama jauna versija"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -625,191 +613,184 @@ msgstr ""
 "\n"
 "Vai vēlaties atvērt lejupielādes lapu?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vai tiešām vēlaties aizvērt %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -818,455 +799,442 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Pieslēdzas…"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Neizdevās pieslēgties. Nevar izveidot savienojumu ar %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Pieslēgties tīklam."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Jau %d. mēģinājums atjaunot savienojumu: pieslēdzas %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Gatavs"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Nederīga saite vai jau ir sarakstā."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nezināms"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Neizdevās iegūt lietotāja '%s' kopīgoto datņu sarakstu"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Viltus eMule %#x versija)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Iesauka: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pieprasīts: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Jauns ziņojums no '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Ievadiet Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Jauna kategorija"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Atlasiet mapi, kur saglabāt ienākošās datnes"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Pieslēgts klientam ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Pieslēdzas klientam ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Aizvērt cilni"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Aizvērt visas cilnes"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Aizvērt pārējās cilnes"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Zems ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Augsts ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Atspējots"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Pieslēgts"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Atslēgts"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Sliktais čalis"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Datnes komentāri"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Lietotājvārds"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Datnes nosaukums"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Vērtējums"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentārs"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Nav komentāru"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1274,750 +1242,736 @@ msgstr[0] "%u komentāri"
 msgstr[1] "%u komentārs"
 msgstr[2] "%u komentāri"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Izlaidums"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Pieslēdzas caur serveri"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Rinda pilna"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Rindā"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lejupielādē"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nav vajadzīgo daļu"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Pārāk daudz savienojumu"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Pieslēdzas caur Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Bloķēts, Aizliegts, Izraidīts, Izslēgts"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Savienojuma kļūda"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Saite"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Pabeigta"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "KĻŪDA: Krātuvē vairs nav vietas"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "KĻŪDA: part.met datne nav atrasta"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "KĻŪDA: ievadizvades (I/O) kļūda!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "KĻŪDA: Neizdevās!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Rindā"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Jau lejupielādē"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Daļa"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Ātrums"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Avoti"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritāte"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Statuss"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Atlikušais laiks"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Pēdējo reizi datne bija pilnībā pieejama"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Priekšskatījums"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Rādīt visus komentārus"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopēt eD2k saiti starp&liktuvē"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "Atsaukt piešķirto kategoriju"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lejupielādes (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Datnes priekšskatījums"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Lejupielādē no %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nederīga eD2k saite! KĻŪDA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Pieslēdzas klientam: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Nezināma versija"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Nederīga protokola versija."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Trūkst protokola versijas birka."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Jau pieslēgts eD2k tīklam."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Pieslēdzas eD2k…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Jau pieslēgts Kad tīklam."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Pieslēdzas Kad…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Atslēgts no eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Atslēgts no Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Pieejamās komandas:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2025,23 +1979,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2049,59 +2003,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2110,2661 +2064,2619 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Datnes informācija"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Pieslēdzas draugam"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Savienojumi"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Tīkli"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Iespējot UPnP maršrutētāja portu pāradresāciju"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Draugi"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Noņemt no draugu saraksta"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Sūtīt ziņoju&mu"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Skatīt datnes"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Izveidot drauga izdalīto spraugu"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Sūtīt ziņojumu"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Augšupielādē"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nē"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Jā"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Lejupielādē…"
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Ziņojums"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Vai turpināt?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: meklēšanas atslēgvārds ir pārāk īss"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad tīkls"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Datnes nosaukums"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Datnes izmērs"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Skaitļo kontrolsummu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Pabeidz"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Pabeigts"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Gaida"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "KĻŪDA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Aizvērt"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Izgriezt"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopēt"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Ielīmēt"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Notīrīt"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Atlasīt visas"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Pieslēgts (aiz ugunsmūra)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Serveris: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "Servera IP adrese: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP adrese: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP ports: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP ports: Nav gatavs"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP ports: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP ports: Nav gatavs"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Augšupielādes ātruma ierob."
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Lejupielādes ātruma ierob."
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Iziet"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Ātruma ierobežojumi:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Augšupielādes ierob.: Nav"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Augšupielādes ierob.: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Lejupielādes ierob.: Nav"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Lejupielādes ierob.: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Lejupielādes ātrums: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Augšupielādes ātrums: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Iesauka: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Klienta ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Servera nosaukums: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Servera IP adrese: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Ielādē…"
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Lietotāju skaits serverī, kam esiet pieslēdzies …"
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Lietotāji: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "↑Augšup.: 0.0 | ↓Lejup.: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Serveris, kuram šobrīd esiet pieslēdzies."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Meklēt"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nosaukums:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Paplašinājums"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Minimālais izmērs"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Baiti"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maksimālais izmērs"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Pieejamība"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Apturēt"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultāti"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Datnes izmērs :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Pieprasījumi"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Kopīgotās datnes"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr "Vidējais augšupielādes ātrums:"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Ilgums :"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Bitu pārraides ātrums :"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Kodeks :"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Izpildītājs :"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Nosaukums :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Komentārs/Datnes vērtējums (teksts būs redzams visiem lietotājiem)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Datnes kvalitāte"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nav novērtēta"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Nederīga / Bojāta / Viltota"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Slikta"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Pienācīga"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Laba"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Izcila"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Novērtēt datni vai dot citiem lietotājiem mājienu, ka datnes nosaukums ir maldinošs un tā saturs neatbilst nosaukumam …"
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Atslēgts no Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Atsvaidzināt"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Lejupielādē, lūdzu, uzgaidiet …"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Nezināms izmērs"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Nepieciešamā informācija"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP adrese :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Ports :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Papildinformācija"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Lietotājvārds :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Pievienot"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Augšupielādes ātrums"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Lietotājvārds:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Klienta programma:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Klienta programmas versija:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP adrese:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Lietotāja ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Servera IP adrese:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Servera nosaukums:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Vidējais augšupielādes ātrums:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Vidējais lejupielādes ātrums:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Augšupielādēti (šajā sesijā):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Lejupielādēti (šajā sesijā):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Augšupielādēti (pavisam kopā):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Lejupielādēti (pavisam kopā):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Rindas pozīcija:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Iesauka"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - vairāku operētājsistēmu Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Vārds, kas tiks rādīts lietotājiem, kad pieslēdzas jums."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Valoda: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Regulāri pārbaudīt atjauninājumus"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Iespējojot šo, tiks veikta aMule jaunākās versijas pārbaude, kad palaiž programmu"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekundes"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video atskaņotājs"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Datu pārraides ierobežojumi"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Augšupielādes (Izejošais)"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Katram klientam (vienam savienojumam) izdalītais spraugas"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Porti"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Kad palaiž, automātiski pieslēgties"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Atkārtoti pieslēgties, kad zaudēts savienojums"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Noņemt mirušo serveri pēc"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "mēģinājumiem"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Saraksts"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Atjaunināt serveru sarakstu, kad pieslēdzas serverim"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Iestatīt pašrocīgi pievienotos serverus kā augstas prioritātes"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Augšupielādes"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Iespējot"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Iegūt garuma / bitu pārraides ātruma / kodeka infomāciju no kopīgotajām audio un video datnēm"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Noņemt"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Automātiski uzraudzīt kopīgoto mapju izmaiņas"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafiki"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Krāsas: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fons"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Režģis"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Atlasīt"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! BRĪDINĀJUMS !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datnes bufera izmērs: 240000 baiti"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plakana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4772,11 +4684,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4786,837 +4698,837 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "baiti sekundē"
 msgstr[1] "baits sekundē"
 msgstr[2] "baiti sekundē"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sekundes"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minūtes"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "stundas"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dienas"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Datnes kontrolsumma"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Lejupielādēta"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Savienojums"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mapes"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveri"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Datnes"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Drošība"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Saskarne"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Starpniekserveris"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Notikumi"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5626,73 +5538,73 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Parole"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5700,140 +5612,140 @@ msgstr ""
 "Jūsu automātiskās atjaunināšanas serveru saraksts ir tukšs.\n"
 "'Kad palaiž, automātiski atjaunināt serveru sarakstu' iestatījums tiks atspējots."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Nederīga regulārā izteiksme"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5841,100 +5753,100 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistēmas"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Rediģēt serveru sarakstu"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -5942,241 +5854,241 @@ msgstr[0] "Datnes bufera izmērs: %d baiti"
 msgstr[1] "Datnes bufera izmērs: %d baits"
 msgstr[2] "Datnes bufera izmērs: %d baiti"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI komanda:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Datnes ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Ilgums"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Bitu pārraides ātrums"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Kodeks"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopēt eD2k saiti starpliktuvē"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jūs pašlaik neesiet pieslēgts serverim, kas atbalsta saistīto datņu meklēšanas funkciju"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Pieslēgts %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "Šķiet, ka %s (%s:%i) miris."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "Šķiet, ka %s (%s:%i) pilns."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6184,48 +6096,48 @@ msgstr[0] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm
 msgstr[1] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundes"
 msgstr[2] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Pieslēgties %s (%s:%i) neizdevās."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6233,7 +6145,7 @@ msgstr[0] "Atrasti %i serveri server.met datnē"
 msgstr[1] "Atrasts %i serveris server.met datnē"
 msgstr[2] "Atrasti %i serveri server.met datnē"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6241,425 +6153,424 @@ msgstr[0] "Pievienoti %d serveri"
 msgstr[1] "Pievienots %d serveris"
 msgstr[2] "Pievienoti %d serveri"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Kļūda: 'server.met' datne ir bojāta: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Jūs esiet pieslēdzies serverim, kuru mēģiniet dzēst. Lūdzu, vispirms atslēdzieties."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Nederīga URL adrese"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servera nosaukums"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adrese"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Ports"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Apraksts"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping atbildes laiks"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Lietotāji"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versija"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Jūs esiet pieslēdzies serverim, kuru mēģiniet dzēst. Lūdzu, vispirms atslēdzieties. Serveris NETIKA dzēsts."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serveri (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Serveris"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "Serveris %s (%s) noraidīja pieteikšanos (nav piešķirts klienta ID). Atslēdzas."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Pieslēdzas %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule "
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Pieslēgts"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia statuss:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia klienta ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nav nepieciešams draugs - TCP ports ir atvērts"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nav nepieciešams draugs - UDP ports ir atvērts"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nav neviena drauga"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Pieslēdzas draugam"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Savienots ar draugu %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6667,416 +6578,416 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Lietotājvārds"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Izcelsme"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Pievienot komentāru/vērtējumu"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Rediģēt komentāru/vērtējumu"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Pārdēvēt"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Augšupielādēti šajā sesijā (Pavisam kopā): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Kopējais pakalpojuma trafiks (Paketes): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Datņu pieprasījumu trafiks (Paketes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Avotu apmaiņas trafiks (Paketes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Serveru trafiks (Paketes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad tīkla trafiks (Paketes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Šifrēšanas trafiks (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktīvas augšupielādes: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Pieslēgts serverim kopš: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienti"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Nezināms: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operētājsistēma"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktīvi savienojumi (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nekad"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7084,7 +6995,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7092,102 +7003,100 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Lejupielādēt datni: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "IZSLĒGTS"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "IESLĒGTS"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Datu pārraides ierobežojumi: ↑Augšup.: %u kB/s, ↓Lejup.: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Pieslēgts %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Pašlaik pieslēdzas"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "aiz ugunsmūra"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7196,53 +7105,53 @@ msgstr ""
 "\n"
 "Klienti rindā:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7251,46 +7160,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Pieslēgties tīklam."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7298,35 +7207,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Pieslēgties tikai eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Pieslēgties tikai Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Atslēgties no tīkla."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Tiks atslēgi visi pašlaik pieslēgtie tīkli.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Atslēgties tikai no eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Atslēgties tikai no Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7337,121 +7246,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Iestatīt datu pārraides ierobežojumus."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Iestatīt augšupielādes datu pārraides ātruma ierobežojumu."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Iestatīt lejupielādes datu pārraides ātruma ierobežojumu."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Iegūt un parādīt iestatījuma vērtību."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Iegūt datu pārraides ierobežojumu iestatījumus."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7470,383 +7379,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Apturēt lejupielādi."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Turpināt lejupielādi."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Atcelt/Dzēst lejupielādi."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Iestatīt lejupielādes prioritāti."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Rādīt augšupielādes rindu."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Rādīt lejupielādes rindu."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Skatīt žurnālu."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Rādīt serveru sarakstu."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Pievienot kategoriju"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Rediģēt kategoriju"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Dzēst kategoriju"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 datnes kontrolsumma"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k datnes kontrolsumma"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k saite"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Saglabāt"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopēt starpliktuvē"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Atvērt"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Saglabāt kā"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7858,177 +7764,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Skaitļo kontrolsummu…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02usek."
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Atiestatīt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Saglabāt statistikas attēlu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8039,376 +7937,365 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule darbojas, bet atslēgta no tīkla"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule pieslēdzas…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " darbojas "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " pieslēdzas…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " ir pieslēgts "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "izslēgts"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " ar "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Laiks: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Lietotājs"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP ports"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Pārbauda paroli\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (nepieciešams)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Darbvirsmas saīsne"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "Palaist aMule, kad es piesakos"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Noņemt"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Dzēst lietotāja datus (konfigurācijas datni, ED2K serverus, Kad mezglus, part datnes)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "Uzstāda aMule programmas datnes (nepieciešams)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Izveido aMule saīsni uz darbvirsmas."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Automātiski palaidīs aMule, kad pašreizējais lietotājs, kas uzstāda aMule, pieteiksies (katra lietotāja atsevišķs iestatījums)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Dzēš aMule programmas datnes, Sākt izvēlnes un darbvirsmas saīsnes, automātiskās startēšanas un programmas pievienošanas/noņemšanas ierakstus (nepieciešams)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Neatgriezeniski dzēš pašreizējā lietotāja %APPDATA%\\aMule mapi (satur aMule.conf datni, ED2K serveru sarakstu, Kad mezglus, part datnes, IP filtrus, draugu sarakstu). Neatķeksējiet, ja vēlaties saglabāt savus iestatījumus."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8416,7 +8303,7 @@ msgstr ""
 "Izskatās, ka aMule, kas uzstādīta $INSTDIR mapē, darbojas.\n"
 "Lūdzu, aizveriet aMule (un aMuleD / aMuleGUI) un mēģiniet vēlreiz."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8424,11 +8311,11 @@ msgstr ""
 "Izskatās, ka aMule pakalpojums (amuled.exe), kas uzstādīts $INSTDIR mapē, darbojas.\n"
 "Lūdzu, apturiet to un mēģiniet vēlreiz."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Noņem iepriekš uzstādīto aMule versiju $0 mapē…"
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8436,11 +8323,11 @@ msgstr ""
 "Nevarēja noņemt iepriekš uzstādīto aMule versiju $0 mapē.\n"
 "Lūdzu, aizveriet visus darbojošos aMule procesus un mēģiniet vēlreiz, jeb pašrocīgi noņemiet iepriekšējo versiju."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet noņemšanas programmu."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Toon aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule controle op afstand "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,7 +44,7 @@ msgstr ""
 "'Alle-Platformen' p2p client gebaseerd op eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -53,79 +53,79 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Een deel van aMule is gebaseerd op \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing gebaseerd op de XOR-metric.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Website:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Controleer op nieuwe versie bij het starten"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Verbinding met Kad wordt gemaakt..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Niet beschikbaar"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Voeg een vriend toe"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "U moet een geldig IP-adres en poortnummer invoeren!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informatie"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "De aangegeven gebruikers-hash is niet geldig!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -134,49 +134,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Na applicatienaam"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Verbinding mislukt "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -185,103 +184,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Kon bestand ED2KLinks niet openen."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link terwijl u een laag id hebt."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Hoofdapp wordt nu afgesloten..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Mislukt"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt afgesloten ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Amuleweb-instantie met pid '%d' wordt gedood ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Kern wordt afgesloten."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule is afgesloten."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Geheugen debug resultaten voor het afsluiten van aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "De taalinstelling is veranderd naar de systeemstandaard vanwege een configuratiewijziging. Sorry."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +285,70 @@ msgstr ""
 "\n"
 "EV-configuratie"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "WAARSCHUWING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "FOUT"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webserver draait met pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kon geen poorten koppelen aan het opgegeven adres: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Poort %u is niet beschikbaar. U krijgt een LAAG ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +363,48 @@ msgstr ""
 "\n"
 "Controleer uw netwerk en zorg ervoor dat de poort open is voor in- en uitgaand verkeer."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Kon bestand met online handtekening niet maken"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Kon aMule OnlineHandtekening Bestand niet maken"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "De gekozen taalinstelling lijkt niet geïnstalleerd te zijn op uw pc. (Let op: Ik probeer het toch in te stellen)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dit is de eerste keer dat u aMule %s draait"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Dit is een testversie, dagelijks geupdatet, en\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "we geven geen garantie dat het niks kapot maakt of uw huis in brand steekt,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "of uw hond doodt. Maar het *zou* veilig moeten zijn om het te gebruiken.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meer informatie, ondersteuning en niuwe versies kunnen gevonden worden op onze homepage,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "op https://amule-org.github.io, of op ons IRC-kanaal #amule op irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Bugs kunt u altijd melden op https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,224 +412,220 @@ msgstr ""
 "De map voor online-handtekeningbestanden die u heeft opgegeven is ONGELDIG!\n"
 " OnlineSignature is UITGESCHAKELD totdat u dit verbetert in voorkeuren."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Toewijzen schijfruimte voor bestand '%s' mislukt: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FOUT: kan logbestand niet openen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "WAARSCHUWING: logboekbestand is leeg. Er is iets mis."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Logboek is gewist"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Server-bericht: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Download van %s overgeslagen, omdat gevraagd bestand niet nieuwer is."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Kon nodelijst niet downloaden."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Kon gedownload versie controle bestand niet openen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Beschadigd bestand voor versiecontrole"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "U gebruikt een verouderde versie van aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Uw aMule-versie is %i.%i.%i en de nieuwste versie is %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "WAARSCHUWING: Uw aMuled-versie is verouderd: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "U heeft de nieuwste aMule-versie."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Kon bestand voor versiecontrole niet downloaden"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Gebruikers: %s | Bestanden: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Gebruikers: E: %s K: %s | Bestanden: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Geen netwerken geselecteerd"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "met Laag ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "met Hoog ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Verbonden met %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Verbinden met %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Verbinding verbroken met eD2K"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad gestart."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad gestopt."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Verbonden met Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad-netwerk kan niet gebruikt worden als de UDP-poort is uitgeschakeld in voorkeuren, wordt niet gestart."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "FOUT: aMule daemon kan niet gebruikt worden wanneer externe verbindingen uitgeschakeld zijn. Gebruik, om Externe Verbindingen in te schakelen, of een normale aMule, start amuled met de optie --ec-config of stel de waarde van \"AcceptExternalConnections\" in op 1 in het bestand ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "FOUT: Een geldig wachtwoord is nodig om gebruik te maken van externe verbindingen, en aMule daemon kan niet gebruikt worden zonder externe verbindingen. Om aMule daemon to draaien, moet u het veld \"ECPassword\" in het bestand ~/.aMule/amule.conf een juiste waarde geven. Voer amuled uit met de vlag --ec-config om het wachtwoord in te stellen. Meer informatie is te vinden op https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - timer wordt gestart"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Kan Pid-bestand niet aanmaken"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dit is aMule %s gebaseerd op eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,192 +635,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Geen netwerk"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule besturing op afstand"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Fatale fout: Kon Core Timer niet aanmaken"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Verbind met amule op afstand"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Verbinding kwijt"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Vraag bevestiging bij afsluiten"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -841,727 +822,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Fatale fout: Kon Poll Timer niet aanmaken"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Naar de gebeurtenislus..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Aan het verbinden..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "GUI EV gebeurtenisafhandelaar op afstand"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Verbinding mislukt. Kon niet verbinden met %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Wordt afgesloten"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Poging tot verbinden met %s (%s:%i) gaf timeout."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Verbind met het netwerk."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Verbinding mislukt. Kon niet verbinden met %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Klaar"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Alle"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Niet beschikbaar"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Bestand niet gevonden."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ongeldige link of al op de lijst."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Op zoek naar buddy voor laag-ID-verbinding"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Nep eMule versie %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Nep eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Nep eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (gebaseerd op eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Bijnaam: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Aangevraagd: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bestandsstatistieken voor deze sessie: Geaccepteerd %d van %d aanvraag, %s overgebracht\n"
 msgstr[1] "Bestandsstatistieken voor deze sessie: Geaccepteerd %d van %d aanvragen, %s overgebracht\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bestandsstatistieken voor alle sessies: Geaccepteerd %d van %d aanvraag, %s overgebracht\n"
 msgstr[1] "Bestandsstatistieken voor alle sessies: Geaccepteerd %d van %d aanvragen, %s overgebracht\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Aangevraagd bestand is onbekend"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Bericht van '%s' gefilterd (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nieuw bericht van '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst van niet-bestaande map '%s' op -> Genegeerd"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "WAARSCHUWING: %s kan niet geopend worden."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "WAARSCHUWING: Geannuleerde-bestandenlijst beschadigd, bevat ongeldige header."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO-fout bij het lezen van bestand %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Fout bij het bewaren van bestand %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nieuwe categorie"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Kies een map voor binnenkomende bestanden"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "U moet een naam opgeven voor de categorie!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "U moet een pad opgeven voor de categorie!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Kon binnenkomende map niet aanmaken voor categorie. Geef een geldig pad op."
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Chat-sessie begonnen: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Verbonden met Client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Verbinden maken met Client ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Kon niet Verbinden met client / Verbinding verbroken ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** U heeft de captcha-controle gehaald en de gebruiker heeft uw bericht ontvangen. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Uw antwoord op de captcha was fout en uw bericht is genegeerd. U kunt een nieuwe captcha aanvragen door een nieuw bericht te sturen. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Sluit tabblad"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Sluit alle tabbladen"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Sluit andere tabbladen"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Voeg toe aan vrienden"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Creditfile geladen, %u client is bekend"
 msgstr[1] "Creditfile geladen, %u clients zijn bekend"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Credits verlopen voor %u client!"
 msgstr[1] " - Credits verlopen voor %u clients!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Geen 'cryptkey.dat' bestand gevonden, wordt aangemaakt."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Client details"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Laag-ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hoog ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Ondersteund"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Niet ondersteund"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbonden"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Niet verbonden"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f KB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Niet compleet"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Slechterik"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Gecontroleerd - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Niet beschikbaar"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst op -> Geaccepteerd"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst op -> Geweigerd"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-mappenlijst op -> Toegestaan"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-mappenlijst op -> Geweigerd"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst van map '%s' op -> geaccepteerd"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst van map '%s' op -> geweigerd"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Gebruiker %s (%u) deelt map '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Gebruiker %s (%u) stuurde niet-opgevraagde gedeelde mappen."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Gebruiker %s (%u) stuurde gedeelde-bestandenlijst van map '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Gebruiker %s (%u) heeft gedeelde-bestandenlijst gestuurd"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Gebruiker %s (%u) stuurde ongewild gedeelde-bestandenlijst"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Gebruiker %s (%u) weigerde toegang tot gedeelde mappen/bestanden-lijst"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Bestand commentaren"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Waardering"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Commentaar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad-zoekopdracht kan niet worden uitgevoerd als Kad niet draait"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Op zoek naar buddy voor laag-ID-verbinding"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Geen commentaren"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u commentaar"
 msgstr[1] "%u commentaren"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Client %s geband voor het sturen van %s beschadigde gegeven van in totaal %s voor het bestand '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Kon landgegevens niet laden voor '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [La]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Ho]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoog"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Heel hoog"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Vrijgeven"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Vragend"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Verbinden via server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Wachtrij vol"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In wachtrij"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloaden"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Ontvangen van hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Geen benodigde delen"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Kan laag-ID niet verbinden met laag-ID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Te veel verbindingen"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Verbinding maken via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Te veel Kad-verbindingen"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Geband"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Verbindingsfout"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Wachtrij op Afstand is vol"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Oude MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nieuwe MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule-compatible"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Lokale server"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Bron uitwisseling"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passief"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Link"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Bron seeds"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Zoekresultaat"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Compleet"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Bezig"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "FOUT: Onvoldoende schijfruimte"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "FOUT: Partmet niet gevonden"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "FOUT: IO-fout!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "FOUT: Mislukt!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "In wachtrij"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Wordt al gedownload"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Onbekend of fout tempbestand formaat."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Deel"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Overgebracht"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Snelheid"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Voortgang"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Bronnen"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteit"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Overgebleven tijd"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Laatst compleet gezien"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Laatste overdracht"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Weet u zeker dat u het geselecteerde bestand wilt verwijderen?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Weet u zeker dat u de geselecteerde bestanden wilt verwijderen?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1570,109 +1528,106 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stop"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pauzeer"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "Ve&rder gaan"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Verwijder comp&lete"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Wissel elk A4AF nu uit met dit bestand"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Wissel elk A4AF uit met dit bestand (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Wissel elk A4AF nu uit met de andere bestanden"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Uitgebreide opties"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Bekijk bestand &details"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Bekijk alle commentaren"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopieer magnet-URI naar klembord"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopieer eD2k &link naar klembord"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopieer feedback naar klembord"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "verwijder toewijzing"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Toewijzen aan catgorie"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Open het bestand"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Voer een nieuwe naam voor dit bestand in:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Naam wijzigen"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1681,349 +1636,348 @@ msgstr ""
 "Om deze waarschuwing te voorkomen bij elk voorbeeld\n"
 "dient u uw video afspeelprogramma in te stellen bij voorkeuren (standaard is %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Voorbeeld"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FOUT: Opstarten externe mediaspeler mislukt! Commando: '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Deelbestand %u van %u wordt bewaard"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Alle deelbestanden bewaard."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Tijdelijke bestanden worden geladen van %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Deelbestand %u van %u wordt geladen"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "FOUT: Laden van backupbestand misukt. Zoek op https://github.com/amule-org/amule/discussions naar .part.met hersteloplossingen."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Alle deelbestanden geladen."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Geen deelbestanden gevonden"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u deelbestand gevonden"
 msgstr[1] "%u deelbestanden gevonden"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Bestandssysteem voor tijdelijke map kan grote bestanden niet verwerken."
 
 # Translate 'Incoming directory'?
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Bestandssysteem voor binnenkomende map kan grote bestanden niet verwerken."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Downloaden van %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "U probeert het bestand '%s' al te downloaden"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "U heeft het bestand '%s' al"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "U heeft het bestand '%s' al"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "U probeert het bestand %s al te downloaden"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Kan magnet-link niet omzetten naar eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Onbekend protocol in link: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ongeldige eD2k-link! FOUT: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Client verstuurde pakket nadat authenticatie mislukte."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Externe verbinding gesloten."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Externe verbindingen uitgeschakeld vanwege leeg wachtwoord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Externe verbindingen uitgeschakeld in configuratiebestand"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nieuwe externe verbinding geaccepteerd"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FOUT: kon nieuwe externe verbinding niet accepteren"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Externe verbinding geweigerd vanwege leeg wachtwoord bij voorkeuren!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Client verbinden: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Onbekende versie"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorrecte EV-versie ID, mogelijk niet compatible. Gebruik kern en op afstand van dezelfde snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "U kunt niet verbinden met een release-versie vanaf een willekeurig ontwikkelingssnapshot! *zucht* mogelijke crash voorkomen"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Ongeldige protocolversie."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Ontbrekend label van protocolversie."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Authenticatie mislukt: ongeldige hash opgegeven als EV-wachtwoord."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Authenticatie mislukt: verkeerd wachtwoord."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Authenticatie mislukt: ontbrekend wachtwoord."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Ongeldig verzoek, authenticeer eerst."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Toegang verleend."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Foutmelding \"%s\" verzonden naar client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Poging tot ongeautoriseerde toegang van %s. Verbinding gesloten."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Deelbestand-commando op afstand mislukt: Bestands-hash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Bestandshash niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OEPS! OpCode verwerkingsfout!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Server niet toegevoegd"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "server niet gevonden: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "moet de te verwijderen server opgeven"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "WebSearch vanaf afstand is zinloos."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Bezig met zoeken. Haal de resultaten op over een momentje!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Geen punten voor grafiek."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Uw client is niet geconfigureerd voor dit niveau van details."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Externe verbinding: afsluiten aangevraagd"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Al bezig met afsluiten."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExterneVerb: link '%s' wordt toegevoegd."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ongeldige link of al op de lijst."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Bestand niet gevonden."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Ongeldige bestandsnaam."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Kon naam van bestand niet wijzigen."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad is uitgeschakeld in voorkeuren."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Al verbonden met eD2K."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Aan het verbinden met eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Al verbonden met Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Verbinding met Kad wordt gemaakt..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Alle netwerken zijn uitgeschakeld."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Verbinding met eD2K verbroken."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Verbinding met Kad verbroken."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Externe verbinding: ongeldige opcode ontvangen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ongeldige opcode (verkeerde protocolversie?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Onbekende extensie '%s' van het '%s' commando.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Onbekend commando '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2031,7 +1985,7 @@ msgstr ""
 "\n"
 "Dit commando heeft geen argumenten.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2039,7 +1993,7 @@ msgstr ""
 "\n"
 "Dit commando moet een argument hebben.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2047,7 +2001,7 @@ msgstr ""
 "\n"
 "Dit commando is niet compleet, u moet een van onderstaande uitbreidingen gebruiken.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2055,11 +2009,11 @@ msgstr ""
 "\n"
 "Beschikbare uitbreidingen:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Beschikbare commando's:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2070,17 +2024,17 @@ msgstr ""
 "Alle commando's zijn hoofdlettergevoelig.\n"
 "Type '%s <command>' om gedetailleerde info te krijgen over <command>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Sluit het programma af."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Toon help."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2088,7 +2042,7 @@ msgstr ""
 "Om help te krijgen over een commando, type 'help <commando>'.\n"
 "Om de volledige commando lijst te krijgen type 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2099,46 +2053,46 @@ msgstr ""
 "Gebruik '%s' voor commandolijst\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Syntax-fout!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Fout bij het verwerken van commando - zou nooit mogen gebeuren! Rapporteer deze bug, a.u.b.\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Dit commando heeft geen parameters."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Dit commando moet een parameter hebben."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Ongeldig argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Dit is een incompleet commando."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Type '%s' voor meer help.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Dit is %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Dit is %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2146,7 +2100,7 @@ msgstr ""
 "\n"
 "Aanmaken van client...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2155,7 +2109,7 @@ msgstr ""
 "\n"
 "Ok, %s wordt afgesloten...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2170,331 +2124,326 @@ msgstr ""
 "\n"
 "Bezig met afsluiten...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Toon deze helptekst."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host waar aMule draait. (standaard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules poort voor externe verbindingen. (standaard: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Externe verbinding wachtwoord."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Lees configuratie uit bestand."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Print geen uitvoer naar stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Wees uitgebreid - toon ook foutopsporingsberichten."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Stelt programma-locale (taal) in."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Schrijf opties op de opdrachtregel naar configuratiebestand."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Maakt configuratiebestand gebaseerd op aMules configuratiebestand."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Toon programma-versie."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Bestandsdetails"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% voltooid"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Welkom!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Aan het verbinden met buddy"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Verbindingsstatus:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Netwerken"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standaard TCP-poort "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Uitgebreide UDP-poort (Kad / globaal zoeken) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Schakel UPnP voor router portforwarding in"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "U probeert het bestand %s al te downloaden"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Auto-update serverlijst bij het opstarten"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Kon vriendenlijst-bestand 'emfriends.met' niet lezen!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Vrienden"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Laat &Details zien"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Voeg een vriend toe"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Verwijder vriend"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Verstuur &Message"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Bekijk bestanden"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Maak vriendenslot"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Weet u zeker dat u de geselecteerde vriend wilt verwijderen?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Weet u zeker dat u de geselecteerde vrienden wilt verwijderen?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2502,11 +2451,11 @@ msgstr ""
 "U kunt maximaal één vriendenslot instellen.\n"
 " Slechts één slot is toegekend."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Meerdere selectie"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2515,206 +2464,205 @@ msgstr ""
 "U kunt maximaal één vriendenslot instellen.\n"
 " Slechts één slot is toegekend."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Verstuur bericht naar gebruiker"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Bericht om te versturen:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Verwijder uit vriendenlijst"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Verstuur bericht"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Wissel uit naar dit bestand"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In wachtrij: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Al om een ander bestand gevraagd"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Wachtende op upload-slot"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "In wachtrij: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Aan het uploaden"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Geen"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nee"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Downloaden..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP-download geannuleerd"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "De URL om te downloaden mag niet leeg zijn"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d bytes gedownload"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "De URL %s leverde op: %i - Fout (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-download geannuleerd"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Download van nieuwe GeoIP.dat van %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Download van bestand GeoIP.dat mislukt, update wordt gestopt."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Kon bestand %s niet verwijderen, update wordt gestopt."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Kon bestand %s niet hernoemen, update wordt gestopt."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s succesvol geüpdatet"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Fout bij het updaten van GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Kon %s niet downloaden van %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "IP-filters 'ipfilter.dat' en 'ipfilter_static.dat' worden geladen."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Kon ipfilter.dat bestand '%s' niet laden, onbekend formaat."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Kon ipfilter.dat bestand '%s' niet laden, kon bestand niet openen."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u IP-reeks geladen van '%s'."
 msgstr[1] "%u IP-reeksen geladen van '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u misvormde regel is genegeerd."
 msgstr[1] "%u misvormde regels zijn genegeerd."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Kon nieuw bestand %s niet hernoemen, update wordt gestopt."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP-filter is klaar"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2722,877 +2670,845 @@ msgstr ""
 "Bootstrap van \n"
 "bekende clients"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodes (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ongeldig ip om van te bootstrappen"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Ongeldige poort om van te bootstrappen"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Vul alle benodigde velden in"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Bericht"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Weet u zeker dat u een nieuw nodes.dat bestand wilt downloaden?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Dat zal uw huidige nodes verwijderen en de Kademlia verbinding opnieuw starten."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Verder gaan?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: zoekwoord te kort"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Zoekwoord staat al op de zoeklijst: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Kon bestand nodes.dat niet lezen - te oud. Deze versie (0) wordt niet meer ondersteund."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u Kad-contact gelezen"
 msgstr[1] "%u Kad-contacten gelezen"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Geen contacten gevonden, bootstrap of download een nodes.dat bestand."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Slechts %d Kad-contact beschikbaar, nodes.dat niet beschreven"
 msgstr[1] "Slechts %d Kad contacten beschikbaar, nodes.dat niet beschreven"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d Kad-contact geschreven"
 msgstr[1] "%d Kad-contacten geschreven"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad netwerk"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Bestandsgrootte"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Deelverhouding"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Aangevraagd"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Geaccepteerd"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Complete bronnen"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "WAARSCHUWING: Bekende-bestandenlijst beschadigd, bevat ongeldige header."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Kon vermelding in bekende-bestandenlijst niet laden, bestand kan beschadigd zijn"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ongeldige vermelding in bekende-bestandenlijst, bestand kan beschadigd zijn: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Onbekende fout %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Kon foutbeschrijving niet verkrijgen voor fout %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Aan het hashen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Voltooien"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Compleet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Foutief"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Wachten"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "U moet een niet-leeg wachtwoord opgeven."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Ongeldig wachtwoord, geen MD5-hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Verbindingsfout"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Externe verbinding gesloten."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EV-verbinding mislukt. Leeg antwoord."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Externe verbinding: slecht antwoord, handshake mislukt. Verbinding verbroken."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Succes! Verbinding gemaakt met aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Gelukt! Verbinding gemaakt."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Externe verbinding: toegang geweigerd omdat: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Externe verbinding: handshake mislukt."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "FOUT: Kon niet luisteren op TCP-poort."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "FOUT: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Knippen"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Verbonden"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Verbonden"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Verbonden met Kad (firewalled)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "Server-IP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Server-IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Niet verbonden"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP-poort: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP-poort: Niet gereed"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP-poort: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP-poort: Niet gereed"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Client informatie"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Uploadgrens"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Downloadgrens"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Toon aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Verberg aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Afsluiten"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Onbegrensd"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule systeemvak-menu"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Snelheidsgrenzen:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Geen"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Geen"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Downloadsnelheid: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Uploadsnelheid: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Bijnaam: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Geen bijnaam geselecteerd!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Client-ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Server-naam: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "Server-IP: "
 
 # msgstr "Verbinden"
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Niet verbonden"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online handtekening: Ingeschakeld"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online handtekening: Uitgeschakeld"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Uptime: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Gedeelde bestanden: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clients in wachtrij: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Totaal gedownload: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totaal geupload: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Voeg een eD2k- of magnet-link toe aan de kern."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Voeg toe aan vrienden"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Klik hier om de eD2k-link in de tekstinvoer toe te voegen aan uw downloadwachtrij."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Gebeurtenissen worden hier getoond. Voor een complete lijst van gebeurtenissen, bekijk de log in de Servers-tab."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Laden ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Aantal gebruikers op de server waar u mee verbonden bent ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Gebruikers: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Gebruikers verbonden met de huidige server en een schatting van het totale aantal gebruikers."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Huidige gemiddelde upload- en downloadsnelheden. Indien ingeschakeld geven de getallen tussen haakjes de overhead door client-communicatie aan."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Toont de verbonden status en actieve overdrachten. Rode pijlen geven aan dat u nu niet verbonden bent, gele pijlen geven aan dat u een laag ID (door firewall) hebt en groene pijlen geven aan dat u een hoog ID (het optimale verbindingstype) hebt."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Niet verbonden ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Server nu mee verbonden."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Naam:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokaal"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globaal"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Uitgebreide parameters"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filters"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Alles"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archieven"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Geluid"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Images"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Afbeeldingen"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programma's"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Teksten"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Video's"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Uitbreiding"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min grootte"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Max grootte"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Beschikbaarheid"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filter resultaat"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Resultaat omkeren"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Verberg bekende bestanden"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Meer"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Velden leegmaken"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultaten"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Verwijdert complete downloads"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Bestandsbronnen:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/B"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Algemeen"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Volledige naam :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-Bestand :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Bestandsgrootte :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overdracht"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Deelbestandstatus :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Laatst compleet gezien :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Gevonden bronnen :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Bronnen overdragen :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Bestandsdeel-teller :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Beschikbaar :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Actieve downloadtijd: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Overgedragen :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Volledige grootte :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligente corruptieafhandeling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Verloren door beschadiging :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Gewonnen door compressie :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pakketten gered door I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Deelt: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Aanvragen"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Geaccepteerde aanvragen"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Overgebrachte gegevens"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Deelverhouding"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Complete bronnen"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Gedeelde bestanden"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Upload: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Niet beoordeeld"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Bestandsnamen"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Neem over"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Opruimen"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Toepassen"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Geef bestand commentaar/waardering (tekst is zichtbaar voor alle gebruikers)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3600,1269 +3516,1265 @@ msgstr ""
 "Voor een film kunt iets zeggen over de lengte, het verhaal, de taal ...\n"
 "en als het nep is kunt u dat vertellen aan de andere gebruikers van aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Bestandskwaliteit"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Niet beoordeeld"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Onbruikbaar / beschadigd / nep"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Matig"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Redelijk"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Goed"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Uitstekend"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Kies de bestandswaardering of adviseer gebruikers als het bestand ongeldig is ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Verbinding met Kad verbroken"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Verversen"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Downloaden, even geduld..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Onbekende grootte"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Benodigde informatie"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-adres :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Poort :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Extra informatie"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Gebruikersnaam :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Toevoegen"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Uploadsnelheid"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistiekenboom"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Gebruikersnaam:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Gebruikershash:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Client software:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Client versie:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-adres:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Gebruikers-ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Server-IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Server-naam:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Maskering:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Overdrachten naar client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Huidige aanvraag:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Gemiddelde uploadsnelheid:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Gemiddelde downloadsnelheid:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Geupload (sessie):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Gedownload (sessie):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Geupload (totaal):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Gedownload (totaal):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scores"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DL/UP-verhouding:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Veilige identiteit:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Wachtrij positie:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Wachtrij score:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Bijnaam"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - de multi-platform Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Dit is de naam die andere gebruikers zien wanneer ze met u verbinden."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Taal: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "De vertraging voordat tooltips worden getoond."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Dit specificeert de taal waarin aMule wordt getoond."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Controleer op nieuwe versie bij het starten"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ingeschakeld zorgt dit ervoor dat aMule bij het starten controleert op een nieuwe versie"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Start geminimaliseerd"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Als u dit inschakelt zal aMule zichzelf minimaliseren bij het starten."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Vraag bevestiging bij afsluiten"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Laat aMule om bevestiging vragen alvorens af te sluiten."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Schakel systeemvak-pictogram in"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Dit schakelt het systeemvak (of taakbalk) pictogram in/uit."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Verberg applicatievenster wanneer op de sluitknop wordt geklikt"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimaliseer naar systeemvak"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Deze optie zorgt er voor dat aMule geminimaliseerd wordt naar het systeemvak, i.p.v. naar de taakbalk."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Toon een melding wanneer een download klaar is"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Wanneer dit ingeschakeld is zal aMule een melding tonen wanneer een download klaar is."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Tooltip vertragingstijd: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "seconden"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Browserselectie"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Open in nieuw tabblad indien mogelijk"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Open de webpagina, indien mogelijk, in een nieuw tabblad in plaats van in een nieuw venster"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videospeler"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Bandbreedtegrenzen"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Slot-toewijzing"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Poorten"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dit is de standaard eD2k-poort en kan niet uitgeschakeld worden."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-poort voor server aanvragen (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Deze UDP-poort wordt gebruikt voor uitgebreide eD2k-aanvragen en het Kad-netwerk"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-Poort (optioneel):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Max bronnen per bestand aan het downloaden:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autoverbind bij het opstarten"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Verbind opnieuw bij verbroken verbinding"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Verwijder dode server na"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "pogingen"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lijst"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Update serverlijst bij het verbinden met een server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Update serverlijst wanneer een client verbindt"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Gebruik prioriteitssysteem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Gebruik slimme laag-ID controle bij verbinden"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Veilig verbinden"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoverbind alleen met servers in statische lijst"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Zet handmatig toegevoegde servers op hoge prioriteit"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Voeg bestanden aan downloads toe in pauze-modus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Voeg bestanden aan downloads toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Probeer eerste en laatste delen eerst te downloaden"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Start volgend gepauzeerd bestand als een bestand compleet is"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Uit dezelfde categorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "In alfabetische volgorde"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Wijst schijfruimte toe voor nieuwe bestanden, beperkt hierdoor fragmentatie"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stop downloads als de vrije schijfruimte bedraagt "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecteer dit als u wilt dat aMule uw schijfruimte controleert"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Voer hier de gewenste min schijfruimte in."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Bewaar 10 bronnen van zeldzame bestanden (<20 bronnen)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Voeg nieuwe gedeelde bestanden toe met automatische prioriteit"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligente corruptieafhandling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Geavanceerde I.C.H. vertrouwt elke hash (niet aanbevolen)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Verwijder"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Rechtermuisklik op mappictogram om recursief te delen)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Deel verborgen bestanden"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafieken"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Update-vertraging : 5 seconden"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tijd voor gemiddeldengrafiek: 100 minuten"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Schaal verbindingengrafiek: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Schaal downloadgrafiek:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Schaal uploadgrafiek:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Kleuren: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Raster"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Huidige download"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Lopend gemiddelde download"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Sessie gemiddelde download"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Huidige upload"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Lopend gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systeemvak-pictogram met snelheidsbalk"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-nodes huidig"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-nodes draaiende"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Selecteer"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Boom"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Aantal getoonde client-versies (0=onbegrensd)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! WAARSCHUWING !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Max nieuwe verbindingen / 5 seconden"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Grootte van bestandsbuffer : 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Grootte van uploadwachtrij: 5000 clients"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Server-verbinding verversingsinterval: Uitschakelen"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Schakel standby-modus van computer uit"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Gebruik skin: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Toon \"Snelle eD2k-links afhandelaar\" in elk venster."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Geef uitgebreide informatie weer op categorie-tabs"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Toon applicatieversie op titel"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Toon overdrachtsnelheden op titel"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Voor applicatienaam"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Na applicatienaam"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Toon overhead bandbreedte"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Verticale knoppenbalk"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Downloadwachtrij bestanden"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Toon voortgangspercentage"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Toon voortgangsindicator"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Weiger gasttoegang"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Gastwachtwoord voor webserver"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4870,11 +4782,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4884,519 +4796,519 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Uitgeschakeld [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/sec"
 msgstr[1] "bytes/sec"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "seconden"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minuten"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "uren"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagen"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "alle"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "alle anderen"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleet"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Gestopt"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archief"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Actief"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Gebruikte configdir: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Wachten tot deelbestand-conversiethread sterft..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Bezig met importeren van %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Tijdelijke map wordt gelezen"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Basisinformatie van download infobestand wordt opgehaald"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Doelbestand wordt aangemaakt"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Data van oud downloadbestand wordt geladen (%u van %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Data-blok wordt bewaard in nieuw enkel downloadbestand (%u van %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Bron downloadbestand informatie wordt opgehaald"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Download wordt toegevoegd en nieuw deelbestand bewaard"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importeer deelbestanden"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Status"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Bestandshash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Schijf: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Kies een map om te doorzoeken naar tijdelijke downloads! (onderliggende mappen worden meegenomen)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Wilt u dat de bronbestanden van succesvol geïmporteerde bestanden verwijderd worden?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Verwijder bronnen?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "FOUT: Kon deelbestand niet aanmaken"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Proberen backup van met-bestand te laden van %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "FOUT: Kon part.met bestand niet openen: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "FOUT: part.met bestand heeft grootte 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "FOUT: Ongeldige part.met bestandsversie: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "FOUT: %s (%s) is beschadigd (verkeerde tags: %s), kan bestand niet laden."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "FOUT: %s (%s) is beschadigd (verkeerde tagcount), kan bestand niet laden."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Poging om bestandsinfo te herstellen..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Naamloos bestand herstellen - zal proberen om het te herstellen als RecoverdFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Alle beschikbare bestandsinfo hersteld :D - Poging om het te gebruiken..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Kon bestandsinfo niet herstellen :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Kon %s (%s) niet openen"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "WAARSCHUWING: %s is mogelijk beschadigd (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "FOUT bij het bewaren van deelbestand: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "IO-fout bij het bewaren van deelbestand: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Kon bestand part.met.seeds niet bewaren voor %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i bron seed voor deelbestand bewaard: %s (%s)"
 msgstr[1] "%i bron seeds voor deelbestand bewaard: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Kan seed-bestand voor deelbestand niet lezen: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fout bij het lezen van deelbestands seeds-bestand (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Beschadigd deel (%d) gevonden in %d deelbestand %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Beschadigd deel (%d) gevonden in %d delen bestand %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Compleet deel (%i) gevonden in %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Klaar met opnieuw hashen %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Onverwachte fout tijdens het voltooien van %s. Bestand gepauzeerd"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Klaar met downloaden: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5405,307 +5317,307 @@ msgstr ""
 "Klaar met downloaden:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Verwijderen van bestand: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "WAARSCHUWING: Kan gedownload deel niet hashen - incomplete hashset voor '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FOUT: Kan gedownload deel niet hashen - hashset incompleet (%s). Dit zou nooit mogen gebeuren"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOB bij het hashen van gedownload deel %u met lengte %u (max %u) van deelbestand '%s' met lengte %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "WAARSCHUWING: Niet voldoende vrije schijfruimte! Pauzeren van bestand: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Gedownload deel %i is beschadigd in bestand: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: beschadigd deel %i van %s hersteld -> Bespaarde bytes: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Toewijzen"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Onvoldoende schijfruimte"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Gedownload"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Verbinding"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mappen"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servers"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Beveiliging"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filters"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Besturing op afstand"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online handtekening"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Foutopsporing"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5715,15 +5627,15 @@ msgstr ""
 "    %PARTFILE - volledig pad naar het bestand\n"
 "    %PARTNAME - alleen bestandsnaam"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5739,35 +5651,35 @@ msgstr ""
 "aMule zal goed draaien zonder deze instellingen\n"
 "te wijzigen."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Kon Cfg niet verbinden met widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Cfg naar widget met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Het type proxy waarmee u verbinding maakt"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Kon data niet overdragen van Widget naar Cfg met ID %d en sleutel %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Controleren van wachtwoord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5775,41 +5687,41 @@ msgstr ""
 "aMule moet opnieuw gestart worden om deze veranderingen toe te passen:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP-poort veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Poort voor externe verbinding is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Acceptatie voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Interface voor externe verbinding veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Ondersteuning voor Protocol-obfuscatie is veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5817,7 +5729,7 @@ msgstr ""
 "Uw Auto-update serverlijst is leeg.\n"
 "'Auto-update serverlijst bij het opstarten' wordt uitgeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5825,33 +5737,33 @@ msgstr ""
 "U hebt externe verbindingen ingeschakeld maar geen wachtwoord ingesteld.\n"
 "Externe verbindingen kunnen niet ingeschakeld worden tenzij een geldig wachtwoord is ingesteld."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Taal veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Tijdelijke map veranderd.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-netwerk ingeschakeld.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ongeldige protocolversie."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5859,7 +5771,7 @@ msgstr ""
 "Zowel het eD2K als het Kad-netwerk zijn uitgeschakeld.\n"
 "U kun niet verbinden tot u minimaal een netwerk inschakelt."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5867,7 +5779,7 @@ msgstr ""
 "Kad zal niet starten als uw UDP-poort is uitgeschakeld.\n"
 "Schakel de UDP-poort in of schakel Kad uit."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5877,69 +5789,69 @@ msgstr ""
 "U MOET aMule nu opnieuw starten.\n"
 "Als u dat niet doet moet u niet klagen als er iets misgaat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Automatisch verversen gestart"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Map voor tijdelijke downloadbestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Wachtwoord ingesteld en externe verbindingen ingeschakeld."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5949,66 +5861,66 @@ msgstr ""
 "Vul minimaal een URL naar een geldig server.met bestand in.\n"
 "Klik op de knop \"Lijst\" hiernaast om een URL in te voeren."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Tijdelijke bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Binnenkomende bestanden"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online handtekeningen"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Kies een map voor %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Blader naar videospeler"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selecteer browser"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Uitvoerbare%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systeemstandaard"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Bewerk serverlijst"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6016,1207 +5928,1206 @@ msgstr ""
 "Voeg hier URL's toe om server.met bestanden te downloaden.\n"
 "Slechts één url per regel."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Complete bronnen"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Update-vertraging: %d seconde"
 msgstr[1] "Update-vertraging: %d seconden"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tijd voor gemiddeldengrafiek: %d minuut"
 msgstr[1] "Tijd voor gemiddeldengrafiek: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Schaal verbindingengrafiek: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Grootte van bestandsbuffer: %d byte"
 msgstr[1] "Grootte van bestandsbuffer: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Grootte van uploadwachtrij: %d client"
 msgstr[1] "Grootte van uploadwachtrij: %d clients"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Server-verbinding verversingsinterval: %d minuut"
 msgstr[1] "Server-verbinding verversingsinterval: %d minuten"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Server verbinding verversingstijd: Uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Voer commando uit bij gebeurtenis '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Schakel uitvoeren van commando's in kern in"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Kerncommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Schakel uitvoeren van commando's in GUI in"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI commando:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "De volgende variabelen worden vervangen:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Gedeelde mappen"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Laad gedeelde-bestandenlijst opnieuw."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Gedeelde mappen"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegeerd."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Zoekwaarschuwing"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Standaard"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2K-zoekopdracht kan niet worden uitgevoerd als eD2K niet draait"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Geen zoekwoord opgegeven voor zoeken in Kad - afbreken"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Onverwachte fout bij Kad-zoekopdracht: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Bestands-ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Niet beoordeeld"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Download in categorie"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Verkrijg %s voor dit bestand"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Zoek gelijkwaardige bestanden (eD2k, lokale server)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Markeer als bekend bestand"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopieer eD2k-link naar klembord"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "U bent verbonden met de server die u probeert te verwijderen. Vebreek eerst de verbinding."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Geannuleerd"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nieuw"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Kon niet verbinden met een geobfusceerde server. Nogmaals proberen zonder obfuscatie."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Kon niet verbinden met een geobfusceerde server. Nogmaals proberen zonder obfuscatie."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Kon niet verbinden met een server in de lijst. Nogmaals proberen."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Kon niet verbinden met een server in de lijst. Nogmaals proberen."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2K-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Geen geldige servers om mee te verbinden gevonden in serverlijst"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Verbonden met %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Verbinding gemaakt met: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Fatale fout bij het proberen te verbinden. Internetverbinding kan uit zijn"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Verbinding verbroken met %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) lijkt dood te zijn."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) lijkt vol te zijn."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatische verbinding naar server zal in %d seconde opnieuw proberen"
 msgstr[1] "Automatische verbinding naar server zal in %d seconden opnieuw proberen"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Verbinden met %s (%s:%i) is mislukt."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "FOUT: Socket ongeldig op timeoutcheck"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Poging tot verbinden met %s (%s:%i) gaf timeout."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Te laat resultaat van DNS-lookup ontvangen, wordt genegeerd."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Laden van server.met bestand: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Bestand server.met niet gevonden!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Kon server.met bestand '%s' niet laden, onbekend formaat."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Kon server.met niet openen!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met bestand beschadigd, ongeldig versielabel gevonden: 0x%x, grootte %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i server in server.met gevonden"
 msgstr[1] "%i servers in server.met gevonden"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d server toegevoegd"
 msgstr[1] "%d servers toegevoegd"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Fout: het bestand 'server.met' is beschadigd: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "IO- fout bij het lezen van 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Server niet toegevoegd: [%s:%d] bevat geen geldige poort."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Server niet toegevoegd: Het IP van [%s:%d] is gefilterd of ongeldig."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Server niet toegevoegd: Server met IP:Poort [%s:%d] al gevonden in lijst."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Server toegevoegd: Server op [%s:%d] met naam '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "U bent verbonden met de server die u probeert te verwijderen. Vebreek eerst de verbinding."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Kon '%s' niet openen"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Kon server.met niet opslaan!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Ongeldige URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Downloaden van serverlijst vanaf %s voltooid"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Geen serverlijstadres gevonden in 'addresses.dat'. Plaats een geldig serverlijstadres in dit bestand om uw serverlijst automatisch te updaten"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Begin downloaden serverlijst van %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "WAARSCHUWING: ongeldige URL opgegeven voor het auto-updaten van servers: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Geen geldige server.met auto-download url in addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Kon serverlijst niet downloaden van %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "De lokale server wordt door de IP-filters weggefilterd, er wordt verbonden met een andere server!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Server-naam"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adres"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Poort"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Beschrijving"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Gebruikers"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statisch"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versie"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "U bent verbonden met een server die u probeert te verwijderen. Verbreek eerst de verbinding. De server is NIET verwijderd."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Onbekende naam)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Weet u zeker dat u de statische server %s wilt verwijderen"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servers (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Verbind met server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Markeer server als statisch"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Markeer server als niet-statisch"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markeer servers als statisch"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markeer servers als niet-statisch"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Verwijder server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Verwijder servers"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Verwijder alle servers"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopieer eD2k-links naar klembord"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Verbind opnieuw met server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Weet u zeker dat u alle servers wilt verwijderen?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Weet u zeker dat u de geselecteerde server wilt verwijderen?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Weet u zeker dat u de geselecteerde servers wilt verwijderen?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "FOUT: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "WAARSCHUWING: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Nieuwe client-ID is %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "WAARSCHUWING: U heeft een laag ID gekregen!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tDit komt waarschijnlijk omdat u achter een firewall of router zit."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tVoor meer informatie, bekijk https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Onbekende serverinfo ontvangen! - te kort"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d nieuwe server ontvangen"
 msgstr[1] "%d nieuwe servers ontvangen"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Bewaren van server-lijst compleet."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Server keurde laatste opdracht af"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Fout pakket ontvangen van server: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Onafgehandelde fout bij het verwerken van pakket van de server: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Kan DNS-thread niet aanmaken voor het verbinden met %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Server-IP %s (%s) is gefilterd.  Wordt niet mee verbonden."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "maakt gebruik van protocol-obfuscatie."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Verbinding wordt gemaakt met %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Kan dns niet vinden voor server %s: Kan niet verbinden!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule log"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Server niet toegevoegd: Geen IP of hostnaam opgegeven."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Server niet toegevoegd: Ongeldige server-poort opgegeven."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k-status:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Verbindingsstatus:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Verbonden"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia Status:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Draaiend in LAN-modus"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Draaiende"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia client-ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Verbindingsstatus:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - open TCP-poort %d in uw router of firewall"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP-verbindingsstatus:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - open UDP-poort %d in uw router of firewall"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Firewalled status: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "No buddy nodig - TCP-poort open"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "No buddy nodig - UDP-poort open"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Geen buddy"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Aan het verbinden met buddy"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Verbonden met buddy op %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Geïndexeerde bronnen :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Geïndexeerde zoekwoorden:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Geïndexeerde notities:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Geïndexeerde systeembelasting:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Gemiddelde gebruikers:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Gemiddelde bestanden:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Niet draaiende"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Bestand %s wordt toegevoegd aan gedeelde bestanden"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "%i bekend gedeeld bestand gevonden, %i onbekend"
 msgstr[1] "%i bekende gedeelde bestanden gevonden, %i onbekend"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "FOUT: Poging om %s te delen"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Gedeelde map niet gevonden, wordt overgeslagen: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Geen deelbare bestanden gevonden in map: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Gebruikersnaam"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Downloadsnelheid"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uploadsnelheid"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Beschikbare delen"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Uploadstatus"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Download status"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Oorsprong"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Lokale bestandsnaam"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Deelt bestandenlijst"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Ontvangen delen"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Pad naar map"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Voeg commentaar/waardering toe"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Bewerk commentaar/waardering"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Voeg bestanden in verzameling toe aan overdrachtenlijst"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopieer magnet &URI naar klembord"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopieer eD2k-link naar klembord (&Source)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopieer eD2k-link naar klembord (Bron) (&With Crypt options)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopieer eD2k-link naar klembord (&Hostnaam)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopieer eD2k-link naar klembord (Hostnaam) (Met &Crypt opties)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopieer eD2k-link naar klembord (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopieer eD2k-link naar klembord (&AICH-info + bron)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "U heeft een Hoog ID nodig om een geldige bronlink te maken"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Bestandsnaam op afstand"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Geuploade data (sessie (totaal)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Totale overhead (pakketten): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Overhead van bestandsaanvraag (Pakketten): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Overhead van bron uitwisseling (Pakketten): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Server overhead (Pakketten): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad overhead (pakketten): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Crypt overhead (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Actieve uploads: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Wachtende uploads: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Totaal van succesvolle upload-sessies: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Totaal van mislukte upload-sessies: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Gemiddelde uploadtijd: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Gedownloade data (sessie (totaal)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Gevonden bronnen: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Actieve downloads (blokken): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Sessie UL:DL verhouding (totaal): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Gemiddelde downloadsnelheid (Sessie): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Gemiddelde uploadsnelheid (Sessie): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Max downloadsnelheid (Sessie): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Max uploadsnelheid (Sessie): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Hernieuwde verbindingen: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tijd sinds eerste overdracht: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Verbonden met server sinds: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Actieve verbindingen (schatting): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Grens bereikt van max verbindingen: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Gemiddelde verbindingen (schatting): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Aantal piekverbindingen (schatting): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clients"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Onbekend: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Gefilterd: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Geband: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Totaal: %i Bekend: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Werkende servers: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Mislukte servers: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Totaal: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Verwijderde servers: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Gefilterde servers: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Gebruikers op werkende servers: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Bestanden op werkende servers: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Totaal gebruikers: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Totaal bestanden: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Server-bezetting: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Aantal gedeelde bestanden: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Totale grootte van gedeelde bestanden: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Gemiddelde bestandsgrootte: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Besturingssysteem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Niet ontvangen"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Actieve verbindingen (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Niet beschikbaar"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nooit"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Commando `%s' met pid `%d' is geëindigd met statuscode '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Voer <str> uit en sluit af."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Ongeldig IP-formaat: Gebruik xxx.xxx.xxx.xxx:xxxx\n"
 
 # Translation 'argument'?
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Dit commando heeft een argument nodig. Geldige argumenten: 'all', bestandsnaam, of een getal.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Verwerken per hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Verwerken per bestandsnaam: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Dit commando heeft een argument nodig. Geldige argumenten: een bestands-hash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Niet een geldig nummer\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Geen geldige hash (lengte moet precies 32 tekens zijn)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7227,7 +7138,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7238,7 +7149,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7246,82 +7157,80 @@ msgstr ""
 "Geen zoektype opgegeven.\n"
 "Typ 'help search' om helptekst te lezen.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Downloadbestand: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Aanvraag mislukt met een onbekende fout."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Bewerking was succesvol."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Aanvraag mislukte met de volgende fout: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP-filteren van clients is %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "UIT"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "AAN"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP-filteren van servers is %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Huidige IP-filter niveau is %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Bandbreedtegrenzen: Upload: %u kB/s, Download: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Verbonden met %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Aan het verbinden"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "firewalled"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7330,7 +7239,7 @@ msgstr ""
 "\n"
 "Download:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7339,7 +7248,7 @@ msgstr ""
 "\n"
 "Upload:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7348,7 +7257,7 @@ msgstr ""
 "\n"
 "Clients in wachtrij:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7357,46 +7266,46 @@ msgstr ""
 "\n"
 "Totale bronnen:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartBestand]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Aantal zoekresultaten: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Voortgang zoeken: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Voortgang zoeken niet beschikbaar"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Ongeldig antwoord van de server ontvangen, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Toon korte statusinformatie."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Toon verbindingsstatus, huidige up-/downloadsnelheden, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Toon volledige statistiekenboom."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7410,11 +7319,11 @@ msgstr ""
 "\n"
 "Voorbeeld: 'statistics 5' toont alleen de bovenste 5 versies van elk client-type.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Sluit aMule af."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7424,35 +7333,35 @@ msgstr ""
 "Dit sluit ook de textclient af, omdat die onbruikbaar is zonder een\n"
 "draaiende kern.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Laad gegeven object opnieuw."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Laad gedeelde-bestandenlijst opnieuw."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Laad IP-filtertabel opnieuw."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Laad huidige IP-filtertabel opnieuw."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Update IP-filtertabel van URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Als de URL wordt weggelaten wordt de URL uit de voorkeuren gebruikt."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Verbind met het netwerk."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7464,35 +7373,35 @@ msgstr ""
 "server te verbinden. Het IP moet een decimaal IPv4-adres met punten zijn,\n"
 "of een DNS-naam."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Verbind alleen met eD2K."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Verbind alleen met Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Verbreek verbinding met het netwerk."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Dit verbreekt de verbinding met alle netwerken waarmee nu verbinding is.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Verbreek alleen verbinding met eD2K."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Verbreek alleen verbinding met Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Voeg een eD2k- of magnet-link toe aan de kern."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7510,51 +7419,51 @@ msgstr ""
 "\n"
 "De magnet-link moet de eD2k-hash en bestandsgrootte bevatten.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Stel een voorkeurswaarde in."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Stel voorkeuren voor IP-filter in."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Schakel IP-filteren van zowel clients als servers in."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Schakel IP-filteren van zowel clients als servers uit."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Schakel IP-filteren van clients in/uit."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Schakel IP-filteren van clients in."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Schakel IP-filteren van clients uit."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Schakel IP-filteren van servers in/uit."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Schakel IP-filteren van servers in."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Schakel IP-filteren van servers uit."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Selecteer IP-filter-niveau."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7562,73 +7471,73 @@ msgstr ""
 "Geldige filterniveau's zijn in de reeks 0-255, en de standaard (initiele)\n"
 "waarde is 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Stel bandbreedtegrenzen in."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "De waarde gegeven aan deze commando's moet in kilobytes/sec zijn.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Stel upload bandbreedtegrens in."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "De opgegeven waarde moet in kilobytes/sec zijn.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Stel download bandbreedtegrens in."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "De opgegeven waarde moet in kilobytes/sec zijn.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Verkrijg en toon een voorkeurswaarde."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Verkrijg voorkeuren voor IP-filter."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Verkrijg status van IP-filter voor zowel clients als servers."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Verkrijg status van IP-filter alleen voor clients."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Verkrijg status van IP-filter alleen voor servers."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Verkrijg niveau van IP-filter."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Verkrijg bandbreedtegrenzen."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Voer een zoekopdracht uit."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7647,44 +7556,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Voer een globale zoekopdracht uit."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Voer een lokale zoekopdracht uit"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Voer een kad zoekopdracht uit"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Toon de resultaten van de laatste zoekopdracht."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Toon de voortgang van een zoekopdracht."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Begin met downloaden van een bestand"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7692,80 +7601,80 @@ msgstr ""
 "Het nummer van een bestand uit de laatste zoekopdracht moet gegeven worden.\n"
 "Voorbeeld: 'download 12' begint het bestand met nummer 12 uit de vorige zoekopdracht te downloaden.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pauzeer download."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Verder gaan met download."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Download annuleren."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Stel downloadprioriteit in."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Stel prioriteit van een download in op laag, normaal, hoog of automatisch.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Stel prioriteit in op laag."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Stel prioriteit in op normaal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Stel prioriteit in op hoog."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Stel prioriteit in op automatisch."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Toon wachtrij/lijsten."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Toon upload/download-wachtrij, server-lijst of gedeelde-bestandenlijst.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Toon upload-wachtrij."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Toon download wachtrij."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Toon logboek."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Toon server-lijst."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Toon gedeelde-bestandenlijst."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Logboek wissen."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Verouderd commando, gebruik '%s' in plaats hiervan."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7774,264 +7683,261 @@ msgstr ""
 "Dit is een afgekeurd commando, en kan in de toekomst verwijderd worden.\n"
 "Gebruik '%s' in de plaats.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstclient"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Oude AICH-hashsets in '%s' worden omgezet in 64b in '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "WAARSCHUWING: De bestandsnaam '%s' is ongeldig en is gewijzigd in '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "WAARSCHUWING: Het bestand '%s' bestaat al, bestandsnaam van nieuw bestand gewijzigd in '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Weet u zeker dat u wilt annuleren en alle bestanden in deze categorie verwijderen?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Bevestiging nodig"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Enkel 99 categorieën worden ondersteund."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Te veel categorieën!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Alle anderen"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Selecteer filter"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Voeg categorie toe"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Bewerk categorie"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Verwijder categorie"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset opgevraagd voor onbekend bestand: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Verder gaan met uploads van bestand: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Stoppen van upload van bestand: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Kon commando `%s' niet uitvoeren bij gebeurtenis `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Download voltooid"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Het volledige pad naar het bestand."
 
 # re-check this
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "De naam van het bestand zonder het pad-gedeelte."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "De eD2k-hash van het bestand."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "De grootte van het bestand in bytes."
 
 # Recheck last word
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Cumulatieve download activiteitsduur."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nieuwe chatsessie begonnen"
 
 # ambiguous in EN, check translation
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Afzender bericht."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Geen schijfruimte meer"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Schijfpartitie."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Fout bij completeren"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Bestand nummer %u wordt verwerkt: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "U heeft om deel-hashes gevraagd (alleen gebruikt voor bestanden > 9,5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Niet bestaand bestand !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, de aMule eD2k-linkmaker"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Welkom!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Invoerparameters"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Bestand om te hashen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Voeg optionele URLs toe aan dit bestand"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Voer hier het bestand in waarvan u de eD2k-link wilt laten berekenen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Voer hier de URL in die u wilt toevoegen aan de eD2k-link: Voeg / toe aan het eind om aLinkCreator de huidige bestandsnaam toe te laten voegen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Maak link met deel-hashes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Help om nieuwe en zeldzame bestanden sneller te verspreiden, ten koste van een verhoogde linkgrootte"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 Bestands-hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k-bestands-hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k-link"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopieer naar klembord"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Openen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Open een bestand om zijn eD2k-link te berekenen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopieer berekende eD2k-link naar klembord"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Opslaan als"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Bewaar berekende eD2k-link naar bestand"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Over aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Selecteer het bestand waarvoor u de eD2k-link wilt laten berekenen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Kan het klembord niet openen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Er is nu niets om te kopiëren !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Selecteer het bestand voor uw berekende eD2k-link"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Kon niet openen "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Voer een niet-lege bestandsnaam in"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Er is nu niets om te bewaren !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8051,167 +7957,159 @@ msgstr ""
 "\n"
 "Uitgegeven onder de GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Aan het hashen..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator is aan het werk voor u"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "MD4-hash word berekend..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "eD2k-hashes worden berekend..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Afgebroken !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Gedaan in %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "U heeft deze URL al toegevoegd !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Voer een niet-lege URL in"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Kon %s niet openen"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Geen geheugen beschikbaar voor het berekenen van de ed2k-hash."
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dag(en) %i uur %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uu %0umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uu %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxcas, aMule online statistieken"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Maximum DL snelheid sinds wxCas draait"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolute maximum DL snelheid tijdens vorige keren dat wxCas draaide"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Leegmaken"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Systeem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Stop automatisch verversen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Bewaar afbeelding van online statistieken"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Print Online Statistieken figuur"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Voorkeursinstellingen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Over wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Begin automatisch verversen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatisch verversen gestopt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Automatisch verversen gestart"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Bewaar afbeelding van statistieken"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule Online Statistieken"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8219,11 +8117,11 @@ msgstr ""
 "Er was een probleem tijdens het printen.\n"
 "Misschien is uw printer niet goed ingesteld?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Aan het printen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8241,403 +8139,392 @@ msgstr ""
 "\n"
 "Uitgegeven onder de GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh oh, aMule draait niet..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule draait"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule draait, maar is niet verbonden"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule maakt verbinding..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh oh, aMule status is onbekend..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " draait "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " is gestopt !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " is niet verbonden !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " is aan het verbinden..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " doet iets raars, controleer het !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " is verbonden met "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "uit"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " is aan "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " met "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Totale download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Sessie download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Deelt: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " bestand(en), clients in wachtrij: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tijd: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " aan "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Gemiddelde systeembelasting (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Systeem uptime: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Map die het bestand amulesig.dat bevat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Voer hier de map in waar uw amulesig.dat bestand is"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Tijd tussen de verversingen in seconden"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Genereer een statusafbeelding bij elke verversing"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Voer hier de map in waar u de statistiekenafbeedling wilt laten genereren"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Upload uw status-afbeelding regelmatig naar een FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP-url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP-pad"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Voer hier de URL in van uw FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Voer hier de map in waar uw statusafbeelding op de FTP-server moet komen"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Gebruiker"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Voer hier de gebruikersnaam in om in te loggen op uw FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Voer hier het wachtwoord in om in te loggen op uw FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Tijd tussen de FTP-updates in minuten"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Controleer"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Map die uw handtekeningbestand bevat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Map waar de afbeelding van statistieken gegenereerd moet worden"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Laadt template <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Webserver HTTP-poort"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Gebruik UPnP portforwarding voor webserver-poort"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP-poort"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Wachtwoord voor volledige toegang tot webserver"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Gastwachtwoord voor webserver"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Sta gasttoegang toe"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Weiger gasttoegang"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Laad/bewaar webserverinstellingen van/naar aMule op afstand"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule configuratiebestand pad. NIET DIRECT GEBRUIKEN!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Schakel PHP-interpreter uit (verouderd)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Compileer PHP-pagina's opnieuw bij elke aanvraag"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule webserver"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "webclient verbinding geaccepteerd\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "FOUT: kan verbinding van webclient niet accepteren\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Aanvraag mislukt met de volgende fout: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indexbestand niet gevonden: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sessie verlopen - inloggen wordt aangevraagd\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessie ok, ingelogd\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessie ok, niet ingelogd\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Geen sessie geopend - login wordt aangevraad\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessie aangemaakt - inloggen wordt aangevraagd\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Aanvraag wordt verwerkt [origineel]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Geen wachtwoord opgegeven, login wordt niet toegestaan."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Wachtwoord-hash ongeldig\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Wachtwoord is ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Wachtwoord-fout\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "U heeft geen wachtwoord ingevoerd. Een leeg wachtwoord is niet toegestaan.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Uitloggen aangevraagd\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Aanvraag wordt verwerkt [omgeleid]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Verbinding mislukt "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -21,26 +21,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Syne aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule fjernkontroll"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Bilete:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -49,79 +49,79 @@ msgstr ""
 "Opphavsrett (c) 2003-2019 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: P2P brukarruting bygd på XOR metric.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sjå etter ny utgåve ved oppstart"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Koplar til Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Legg til ein kamerat"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Du må skrive inn ein gangbar IP og port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informasjon"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Den innskrivne brukarhashen er ikkje gyldig!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -130,48 +130,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Oppkopling mislukka "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -180,183 +179,176 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Greidde ikkje å opne %s·(%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k lenkje medan du har ein lågid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Mislukka"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Nedlasting fullført"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Dine lokale innstilingar har vorte endra til opprinnelege systeminnstillingar på grunn av konfigurasjonsending. Beklager."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Stadfesting av avslutting"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ÅTVARING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "FEIL"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "vevtenar køyrer på pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Greidde ikkje å knyte portar til adressa: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port·%u er ikkje tilgjengeleg. Du vil få LågID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +363,48 @@ msgstr ""
 "\n"
 "Sjekk nettverket ditt for å vere viss på at porten er open for inn- og utgåande trafikk."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Greidde ikkje å lage OnlineSigfil"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Greidde ikkje å lage aMule si OnlineSigfil."
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Dei valte lokale innstillingane ser ikkje ut til å vere installerte på maskina di. (Merk: Eg freistar å setje dei likevel)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Dette er første gongen du køyrer aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Denne utgåva er ei testutgåve, oppdatert dagleg, og\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi gir ingen garanti for skade eller nedbrenning av huset ditt,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller drep hunden din. Men det *burde* vere trygt å nytte uansett.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Meir informasjon, brukarstøtte og nye utgåver kan verte funne på heimesida vår.\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "på https://amule-org.github.io, eller på IRC-kanalen vår #aMule·på·irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Vér god å rapportere feil til https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,225 +412,221 @@ msgstr ""
 "Mappa spesifisert for nettsignaturar er UGANGBAR!\n"
 " Nettsignaturar vert DEAKTIVERT fram til du ordnar det i innstillingar."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Henting av diskplass for fila '%s' mislukka: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FEIL: Greier ikkje å opne loggfila"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ÅTVARING: loggfila er tom. Noko er gale."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Loggen har vorte nullstilt"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Tenarmelding: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Klarte ikkje å laste ned nodelista."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Klarte ikkje å opne den nedlaste utgåvesjekkfila"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Korrupt utgåvesjekkfil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Du nyttar ei utdatert utgåve av aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Di utgåve av aMule er %i.%i.%i og den siste utgåva er %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ÅTVARING: Utgåva di av aMule er utdatert: %i.%i.%i·<·%li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Utgåva di av aMule er oppdatert."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Klarte ikkje å laste ned utgåvesjekkfila"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Brukarar: %s | Filer: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Brukarar: E %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Ingen valde nettverk"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "med LågID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "med HøgID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Tilkopla %s·%s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Koplar til %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Fråkopla eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad starta."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad stogga."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Tilkopla Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad kan ikkje nyttast dersom UDP-porten er deaktivert i innstillingar. Startar ikkje."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad-nettverket er deaktivert i innstillingar. Koplar ikkje til."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "FEIL: aMule daemon kan ikkje nyttast dersom eksterne koplingar er deaktiverte. For å aktivere eksterne koplingar må du anten nytte vanleg aMule, starte amuled med valet --ec-config eller set lykelen \"AcceptExternalConnections\" til 1 i fila ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "Feil: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dette er aMule %s basert på eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Innstillingar"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -648,195 +636,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Kople til aMule over nettet"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Kopling mista"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Stadfest avslutting"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -845,730 +826,707 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "Freistar å hente fram att filinformasjon..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Koplar til"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Tilkoplingsfreisting til %s·(%s:%i)·gjekk over tida."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Kople til nettverket."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Alle"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Fil ikkje funne."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukjend"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMuleutgåve %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Falsk eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x·(basert på eMule·v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Brukarnamn: %s·ID:·%u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Etterspurt: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistikk for denne økta: Godkjende %d av %d etterspurnad, %s overført\n"
 msgstr[1] "Filstatistikk for denne økta: Godkjende %d av %d etterspurnader, %s overført\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistikk for alle økter: Godkjende %d av %d etterspurnad, %s overført\n"
 msgstr[1] "Filstatistikk for alle økter: Godkjende %d av %d etterspurnader, %s overført\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Etterspurt ukjend fil"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Melding filtrért frå '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Ny melding frå '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Brukar·%s (%u)·etterspurte·lista·over·delte·filer·for·katalogen·%s ->·nekta"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ÅTVARING: known.met let seg ikkje opne."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ÅTVARING: Kjendfillista er korrupt; inneheld ugangbar overskrift."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO feil underlesing av known.met fila: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Feil under lagring av known.met fila: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Ny kategori"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Vél ei mappe for innkomande filer"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Du må skrive inn eit namn på kategorien!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Du mp skrive inn ein sti for kategorien!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Greidde ikkje å skape innkomande katalog for kategorien. Vér god å skrive inn ein gangbar sti!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Lynmeldingsøkt starta: %s·(%s:%u)·-·%s·%s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "***·Tilkopla klient·***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "***·Koplar til klient·***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Greidde ikkje å kople til klient / Kopling mista ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Stengje faneblad"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Stengje alle faneblad"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Stengje andre faneblad"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Legg til kameratar"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Kredittfil lasta, %u kjend klient"
 msgstr[1] "Kredittfil lasta, %u kjende klientar"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Kredittar forelda for %u klient!"
 msgstr[1] " - Kredittar forelda for %u klientar!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Inga 'cryptkey.dat' fil funne - opprettar."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Klientdetaljar"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LågID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøgID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Støtta"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Ikkje støtta"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Deaktivert"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Tilkopla"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Fråkopla"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f·kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Ikkje ferdig"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Kjeltring"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Granska - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Brukar %s·(%u) etterspurde liste over dei delte filene dine -> Godteke"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Brukar·%s (%u)·etterspurde·liste·over·dei·delte·filene·dine·-> Nekta"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Brukar %s·(%u) etterspurte lista di over delte katalogar -> Godteke"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Brukar·%s (%u)·etterspurte·lista·di·over·delte·katalogar·->·Nekta"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Brukar %s·(%u) etterspurte lista over delte filer for katalogen %s·-> godteke"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Brukar·%s (%u)·etterspurte·lista·over·delte·filer·for·katalogen·%s ->·nekta"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Brukar %s·(%u) deler katalogen %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Brukar %s·(%u) sende ikkje etterspurte delte kataloger."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Brukar %s·(%u) sende liste over delte filer for katalogen %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Brukar %s·(%u) er ferdig med å sende liste over delte filer"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Brukar%s·(%u) sende ikkje etterspurt liste over delte filer"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Brukar %s·(%u) nekta tilgang til delte kataloger/filer"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Filkommentarar"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Brukarnamn"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Verdi"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Du kan ikkje søkje på Kad dersom Kad ikkje køyrer"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ingen kommentarar"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u kommentar"
 msgstr[1] "%u kommentarar"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Greidde ikkje å laste ned tenarlista frå %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Lå]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto·[No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto·[Hø]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høg"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Svært høg"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Offentleggjering"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Spør"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Koplar til gjennom tenar"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Kø full"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kø"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lastar ned"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Tek imot hashsett"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Ingen naudsynte delar"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Greier ikkje å kople LågID til LågID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "For mange koplingar"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Koplar til gjennom Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "For mange kadkoplingar"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Nekta"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Koplingsfeil"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Fjern kø full"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Gamal MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Ny MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMulekompatibel"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Lokal tenar"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Kjeldeutveksling"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiv"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Lenkje"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Kjeldefrø"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ferdig"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "I framdrift"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "FEIL: Tom for diskplass"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "FEIL: Delfil ikkje funne"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "FEIL: Mislukka IO!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "FEIL: Mislukka!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "I kø"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Lastar allereie ned"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Ukjend eller dårleg format på tempfil."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Fart"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Framdrift"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kjelder"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Attståande tid"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Sist sett komplett"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Sist motteke"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Er du viss på at du vil slette den valde fila?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Er du viss på at du vil slette dei valte filene?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1577,462 +1535,458 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatisk"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "%Stopp"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pause"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Hald fram"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Ta bort ferdige"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Byt alle A4AF til denne fila no"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Byt alle A4AF til denne fila (auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Byt alle A4AF til anna fil no"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Utvida innstillingar"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Førehandssyning"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Syn fil&detaljar"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Syn alle kommentarar"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopiér magnet URI til utklippstavla"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopier eD2k &lenka til utklippstavla"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiér tilbakemelding til utklippstavla"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "ortildele"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Vel kategori"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Opne fila"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Skriv nytt namn på denne fila:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Døyp om fil"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f·kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d·%H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Nedlastingar (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr "Vel ein videospelar i innstillingar for å hindre at denne åtvaringa kjem opp ved kvar førehandssyning (%s er standard)"
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Førehandssyning"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEIL: Greidde ikkje å starte ekstern mediespelar! Kommando: '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Lastar server.met fila: %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Lastar data frå gamal nedlastingsfil (%u·av·%u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "FEIL: Greidde ikkje å laste tryggleikskopifila. Søk https://github.com/amule-org/amule/discussions for løysingar på attskaping av part.met filer."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Ingen delfiler funne"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Fann %u delfil"
 msgstr[1] "Fann %u delfiler"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Filsystemet for mellombelse filer greier ikkje å handsame store filer."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Filsystemet i mappa for innkomande filer greier ikkje å handsame store filer."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Lastar ned %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Du freistar allereie nedlasting av fila '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Du har allereie fila: '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Du har allereie fila: '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Kan ikkje konvertere magnetlenkje til eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Ukjend lenkjeprotokoll for: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ugangbar eD2k lenkje! FEIL: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Ekstern kopling lukka."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Eksterne koplingar deaktiverte på grunn av tomt passord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Eksterne koplingar deaktiverte i konfigurasjonsfila"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEIL: greidde ikkje å ta imot ei ny ekstern kopling"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ekstern kopling nekta på grunn av tomt passord i innstillingar!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Koplar til klient: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Ukjend utgåve"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Ikkje rett EC utgåve ID: det kan vere binær inkompatibilitet. Bruk core og remote frå same snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan ikkje kople til ei utgivingsutgåve frå ei vilkårleg SVN utgåve! *sukk* mogleg krasj unngått"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Ugyldig protokullutgåve."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Manglande merkelapp for protokollutgåve."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Godkjenning mislukka."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Ugyldig etterspurnad, du treng godkjenning først."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Tilgang innvilga."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Uaotorisert freisting på tilgang. Kopling lukka."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Kommando for fjern delfil mislukka: Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Filhash ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OPS! Handsamingsfeil i OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Tenar ikkje lagd til"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "tenar ikkje funnen: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "treng å velje tenar for fjerning"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k er deaktivert i innstillingar"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nettsøk frå fjern adresse gir ikkje meining."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Søk i framdrift. Hentar inn att resultata om ein augneblink!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Ingen punkt for graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Klienten din er ikkje konfigurert for dette detaljnivået."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Ekstern kopling: avslutting etterspurt"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Avsluttar allereie."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Eksternkopling: legg til lenkje '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Fil ikkje funne."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Ikkje gangbart filnamn."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ikkje i stand til å døype om fila."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad er deaktivert i innstillingar."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Allereie tilkopla eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Koplar til eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Allereie tilkopla Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Koplar til Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Fråkopla eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Fråkopla Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ekstern kopling: ugangbar opkode motteken: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Ikkje gangbar opkode (feil protokollutgåve?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Ukjend forlenging·'%s'·for·'%s'·kommandoen.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Ukjend kommando '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2040,7 +1994,7 @@ msgstr ""
 "\n"
 "Denne kommandoen kan ikkje ha eit argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2048,7 +2002,7 @@ msgstr ""
 "\n"
 "Denne kommandoen må ha eit argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2056,7 +2010,7 @@ msgstr ""
 "\n"
 "Denne kommandoen er ikkje komplett; du må nytte ein av forlengjarane under.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2064,11 +2018,11 @@ msgstr ""
 "\n"
 "Tilgjengelege forlengjarar:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Tilgjengelege kommandoar:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2079,17 +2033,17 @@ msgstr ""
 " Alle kommandoar kan utførast med store og små bokstavar.\n"
 "Skriv '%s <kommando>'for meir opplysningar om <kommando>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Avsluttar programmet."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Syne hjelp."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2097,7 +2051,7 @@ msgstr ""
 "For å få hjelp til ein kommando, skriv 'help·<kommando>'.\n"
 "For full kommandoliste, skriv 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2108,46 +2062,46 @@ msgstr ""
 "Bruk·'%s'·for·kommandoliste\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Syntaksfeil!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Handsamingsfeil av kommando - burde aldri skje! Vér god å rapportere feilen\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Denne komamndoen må ha eit parameter."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Ugangbart argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Denne kommandoen er ikkje komplett."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Skriv '%s'·for å få meir hjelp.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Dette er %s·%s·%s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Dette er %s·%s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2155,7 +2109,7 @@ msgstr ""
 "\n"
 "Opprettar klient...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2164,7 +2118,7 @@ msgstr ""
 "\n"
 "Ok,·avsluttar·%s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2178,331 +2132,326 @@ msgstr ""
 "\n"
 "Avsluttar...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Syne denne hjelpeteksten."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Vert der aMule køyrer (standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule sin port for eksternkopling (standard: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Passord for eksternkopling."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Les innstillingar frå fil."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Ikkje skriv ut data til stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Vér utførleg - syne óg avfeilingsmeldingar,"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Set programspråk."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Skriv kommandolinjealternativa til konfigurasjonsfila."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Lagar konfigurasjonsfil basert på aMule si konfigurasjonsfil."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Skriv programutgåve."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Fildetaljar"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%%·ferdig"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f·kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Velkomen!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Tilkopla kamerat"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Tilkoplingsstatus:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Nettverk"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Eigenoppstart"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Automatisk oppdatering av tenarlista ved oppstart"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bla"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Greidde ikkje å opne venelista 'emfriends.net' for lesing!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Vener"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Syn &detaljar"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Legg til ein ven"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Ta bort ven"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Send &melding"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Sjå filer"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Opprett venekopling"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Er du viss på at du vil slette den valde venen?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Er du viss på at du vil slette dei valde venene?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2510,11 +2459,11 @@ msgstr ""
 "Det er ikkje tillate å opprette meir enn ei venekopling.\n"
 " Berre ei venekopling vart oppretta."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Fleirval"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2523,210 +2472,209 @@ msgstr ""
 "Det er ikkje tillate å opprette meir enn ei venekopling.\n"
 " Berre ei venekopling vart oppretta."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Send melding til brukar"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Melding å sende:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Fjerne frå kameratar"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Send melding"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Byt til denne fila"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR:·%u·(%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Spurt etter anna fil (A4AF)"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Ventande opplastingar: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "I kø"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Opplasting"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nei"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Lastar ned..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Lasta ned"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Nedlastingar (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Greidde ikkje å laste ned tenarlista frå %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Greidde ikkje å laste ned tenarlista frå %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Lastar ipfiltra 'ipfilter.dat'·og·'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Greidde ikkje å laste inn ipfilter.dat fila '%s' - ukjend filformat."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Greidde ikkje å laste inn ipfilter.dat fila '%s' - greidde ikkje å opne fila."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Lasta %u IP-rekkje frå '%s'."
 msgstr[1] "Lasta %u IP-rekkjer frå '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u vanskapt linje vart forkasta."
 msgstr[1] "%u vanskapte linjer vart forkasta."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2734,2150 +2682,2114 @@ msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noder (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ikkje gangbar IP for eigenoppstart"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Ikkje gangbar port for eigenoppstart"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Vér god å fylle ut alle naudsynte felt"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Melding"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Er du viss på at du vil laste ned ei ny nodes.dat fil?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Å gjere dette vil fjerne dine novérande noder og starte Kademlia på nytt."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Halde fram?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: for kort søkjeord"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Las %u kadkontakt"
 msgstr[1] "Las %u kadkontaktar"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Skreiv %d kadkontakt"
 msgstr[1] "Skreiv %d kadkontaktar"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad nettverk"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Filnamn"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Filstorleik"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Delingsrate"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Etterspurt"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Godkjend"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Komplette kjelder"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Ukjend utgåve"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Ferdigstiller"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Ferdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Feilaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ventar"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Du må skrive inn eit passord som ikkje er tomt."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Feil passord! Ikkje MD5 hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Oppkoplingsfeil"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Ekstern kopling lukka."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC kopling feila. Tomt svar."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Ekstern kopling: Dårleg svar frå tenar. Kopling stengd."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Vellukka! Kopling til aMule er oppretta "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Vellukka! Kopling oppretta."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Ekstern kopling: Tilgang nekta fordi:"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "FEIL: Greidde ikkje lytte til TCP port."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "FEIL: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ÅTVARING: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Stengje"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiér"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Lim inn"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Frigjer plass"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Vél alle"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Tilkopla"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Tilkopla"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Tilkopla Kad (brannmura)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "TenarIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Tenar IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Ikkje tilkopla"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP:·%s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP port: Ikkje klar"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP port: Ikkje klar"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Klientinformasjon"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Opplastingsgrense"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Nedlastingsgrense"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Syne aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Gøyme aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Avslutt"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ubegrensa"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule traumeny"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Fartsgrenser:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "OL: Inga"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "OL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "NL: Ingen"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "NL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Nedlastingsfart: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Opplastingsfart: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Kallenamn: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Ikkje valt kallenamn!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "KlientID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Tenarnamn: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "TenarIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Ikkje tilkopla"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Nettsignatur: Aktivert"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Nettsignatur: Deaktivert"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Oppetid: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Delte filer: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Klientar i kø: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Totalt NL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totalt OL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Legg til ei eD2k eller magnetlenkje  til kjernen"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Legg til kameratar"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Klikk her for å leggje til eD2k lenkja "
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Hendingar visast her. Sjå i loggen under Tenarar for å sjå alle hendingane."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Lastar ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Tal på brukarar på tenaren du er tilkopla ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Brukarar: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Brukarar tilkopla den aktuelle tenaren or eit overslag over det totalt antalet brukarar."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Opp:·0.0·|·Ned:·0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Novérande gjennonmsnittleg opplastings- og nedlastingsrater. Dersom aktivért vil tala i parantés syne dataoverskotet frå klientkommunikasjon."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Syner novérande sratus og aktive overføringar. Raude piler syner at du ikkje er tilkopla akkurat no, gule piler syner at du har ein låg ID (brannmura) og grøne piler syner at du har ein høg ID (Denbeste tilkoplingstypen)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ikkje tilkopla ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Novérande tilkopla tenar."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Søk"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Namn:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Sort"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokal"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Utvida parameter"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrerer"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Filtype"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arkiv"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Lyd"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-bilete"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Bilete"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Program"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Tekstar"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videoar"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Filetternamn"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min storleik"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maks storleik"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Tilgjenge"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrér resultat"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Snu resultat"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Gøyme kjende filer"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Meir"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Nedlasting"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Nullstill felta"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultat"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Ryddar bort ferdige nedlastingar"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Komplette kjelder"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "I/T"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Generelt"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Fullt namn :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "metfil :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Filstorleik :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overføring"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Delfilstatus :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Sist sett komplett :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Funne kjelder :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Overfører kjelder :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Fildelstal :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Tilgjengeleg:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Aktiv nedlastingstid: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Overført :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Ferdig storleik :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Korrupsjonshandsaming"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Tapt gjennom korrupsjon :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Vunne gjennom komprimering :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pakkar lagra av I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Deler: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Etterspurnader"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Godtekne etterspurnader"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Overførte data"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Delingssamsvar"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Komplette kjelder"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Delte filer"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr " Opplasting: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Ikkje gitt verdi"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Tittel :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Filnamn"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Overtaking"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Opprensking"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Utfør"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Kommentér/verdigjé fila (Teksten vert synleg for alle brukarar)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Filkvalitet"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Ikkje gitt verdi"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Ugyldig / Korrupt /Falsk"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Dårleg"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Middels"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "God"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Utmerka"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Vél filverdi eller gje melding til andre brukarar dersom fila er falsk ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Fråkopla Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Oppfrisk"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Lastar ned, vér god å vente ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Ukjend storleik"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Naudsynt informasjon"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-adresse :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Tilleggsinformasjon"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Brukarnamn :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Legg til"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Opplastingsfart"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistikktre"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Brukarnamn:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Brukarhash:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Klientmjukvare:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Klienten si utgåve:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-adresse:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "BrukarID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Tenar IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Tenarnamn:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Tåkelegging:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Overføringar til klient"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Novérande etterspurnader:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Gjennomsnittleg opplastingsfart:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Gjennomsnittleg nedlastingsfart:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Opplasta (økt):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Lasta ned (økt)"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Opplasta (totalt):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Lasta ned (totalt)"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scorar"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "NL/OL endringsfaktor:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Sikker identifikasjon:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "I kø"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Køscore"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Kallenamn"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Dette er namnet andre brukarar vil sjå når dei koplar til  maskina di."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Forseinkinga før ein syner verktytips."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Dette vel språket som vert nytta på kontrollane."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Sjå etter ny utgåve ved oppstart"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Aktivering av denne vil få aMule til å sjå etter ei ny utgåve ved oppstart."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Start minimert"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Aktivering av denne minimerer aMule ved oppstart."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Stadfest avslutting"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Aktivér trauikon"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Dette aktiverer/deaktiverer ikonet i systemtrauet (eller oppgåvelinja)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimér til trauikon"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Akrivering av denne vil få aMule til å minimere seg til systemtrauet og ikkje til oppgåvelinja."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Nettlesarval"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Opne nytt faneblad dersom mogleg"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Opne ny nettside i nytt faneblad i staden for nytt vindauge når mogleg"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videospelar"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Opplasting"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Opningsdistribusjon"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dette er standardporten for eD2k og kan ikkje deaktiverast"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automatisk tilkopling ved oppstart"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Kople til dersom fråkopla"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Ta bort daude tenarar etter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "freistnader"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Oppdater tenarlista ved oppkopling til ein tenar"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Oppdater tenarlista når ein klient koplar til"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Bruk prioritetssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Bruk smart LågID sjekk ved tilkopling"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Trygg tilkopling"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatisk tilkopling berre til tenarar i statisk liste"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Gje høg prioritet til manuelt tillagde tenarar"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Legg filer til nedlasting i pausemodus"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Legg filer til nedlasting med autoprioritet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Prøv å laste ned første og siste del først"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Frå same kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Hent diskplass for nye filer"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Hentar diskplass for heile nye filer, og reduserer fragmentering"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Vel denne dersom du vil at aMule skal sjekke om du har nok diskplass"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Skriv inn mimimum ønska diskplass."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Lagre 10 kjelder til sjeldne filer (< 20 kjelder)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Opplastingar"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Legg til nye delte filer med autoprioritet"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Høgreklikk på mappeikonet for å dele underkatalogar)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Dele gøymde filer"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafar"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Oppdateringsforseinking: 5 sek"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tid for gjennomsnittleg graf: 100 min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Koplingsgrafskala: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rutenett"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Last ned novérande"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Last ned køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Last ned øktgjennomsnitt"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Opplasting no"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Gjennomsnittleg køyrande opplasting"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktive koplingar"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Fartslinje i ikontrauet"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kadnodar no"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Køyrande kadnodar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Velje"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Tal på klienutgåver synt (0=uinnskrenka)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ÅTVARING !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maks nye koplingar / 5 sek"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbufferstorleik: 240000·bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Storleik på opplastingskø: 5000 klientar"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktiver"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Syne utvida informasjon i kategorifaneblad"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Syne overføringsfart i tittellinja"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktylinjeorientering"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Flat"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Nekt gjestetilgang"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Gjestepassord for vevtenar"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4885,11 +4797,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4899,854 +4811,854 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Delte filer"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Deaktivert [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/sek"
 msgstr[1] "bytes/sek"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sekund"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minutt"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "timar"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagar"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "alle"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "alle andre"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Uferdig"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Stogga"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arkiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importerer %s:·%s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Les mellombels mappe"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Hentar grunnleggjande informasjon frå nedlastingsinformasjonfil"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Lagar målfil"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Lastar data frå gamal nedlastingsfil (%u·av·%u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Lagrer datablokk til ei einaste nedlastingsfil (%u·of·%u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Hentar informasjon frå nedlastingsfilkjelde"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Legg til nedlasting og lagrar ny delfil"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importér delfiler"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Tilstand"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Filhash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s·(Disk:·%s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Vér god å velje ei katalog til å søkje på mellombelse nedlastingar! (underkatalogar vil verte inkluderte)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Vil du slette kjeldefilene til vellukka importerte nedlastingar?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Ta bort kjelder?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "FEIL: Greidde ikkje å lage delfil"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Freistar å laste tryggleikskopi av met-fila frå %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "Feil: Greidde ikkje å opne mart.met fila: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "FEIL: part.met fila har ein storleik på 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "FEIL: %s (%s) er korrupt (feil merkelappstal), greidde ikkje å laste fila."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "FEIL: %s (%s) er korrupt (feil merkelappstal), greidde ikkje å laste fila."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Freistar å hente fram att filinformasjon..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Attskaper fil utan namn - freistar å attskape ho som RecoverdFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Attskapte all tilgjengeleg filinformasjon :D - Freistar å nytte den..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Ikkje i stand til å attskape filinformasjon :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Greidde ikkje å opne %s·(%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ÅTVARING: %s kan vere korrupt (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "FEIL under lagring av delfila: %s·(%s·==>·%s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "FEIL under lagring av delfila: %s·(%s·==>·%s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Greidde ikkje å lagre part.met.seeds fila for %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Lagra %i kjeldefrø for delfila: %s (%s)"
 msgstr[1] "Lagra %i kjeldefrø for delfila: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Lagra %i kjeldefrø for delfila: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Feil i lesing av delfila si kjeldefil (%s·-·%s):·%s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Fann korrupt del (%d) i %d delfil %s - Filresultathash |%s| Filhash | %s"
 msgstr[1] "Fann korrupt del (%d) i %d deler i fila %s - Filresultathash |%s| Filhash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Fann ferdig del (%i)·i·%s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Ferdig med omhashing av %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Uventa feil ved fullføring av %s. Sette fila på pause"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Ferdig med å laste ned: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Ferdig med å laste ned: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Slettar fila: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ÅTVARING: Greier ikkje å hashe nedlasta del - hashsett ikkje komplett for '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEIL: Greier ikkje å hashe nedlasta del - hashsett ikkje komplett (%s). Dette burde aldri skje"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ÅTVARING: Ikkje nok ledig diskplass! Set fila %s på pause"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Nedlasta del %i er korrupt i fila: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Attskapte korrupt del %i·for·%s·->·Lagra bytes:·%s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Hentar plass"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Ikkje nok diskplass"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Lasta ned"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Kopling"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Katalogar"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Tenarar"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Tryggleik"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Fjernkontrollar"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Nettsignatur"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Hendingar"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Melde om feil"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5762,35 +5674,35 @@ msgstr ""
 "aMule køyrer fint utan justering av nokon av\n"
 "desse innstillingane."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Typen vikar du koplar til"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Sjekkar passord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5798,51 +5710,51 @@ msgstr ""
 "aMule·treng omstart for å gjere endringane moglege:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "-·TCP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "-·UDP-porten endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Ekstern kopling lukka."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolltåkeleggjing"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5850,34 +5762,34 @@ msgstr ""
 "Du har aktivert eksterne koplingar, men har ikkje skrive inn eit passord.\n"
 "Eksterne koplingar kan ikkje aktiverast utan eit gyldig passord."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Språk endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Mellombels mappe endra.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Alle nettverk er deaktiverte."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Ugyldig protokullutgåve."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5885,7 +5797,7 @@ msgstr ""
 "Både eD2k og kadnettverket er dekativert.\n"
 "Du vil ikkje klare å kople til før du aktiverer minst eitt av dei."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5893,7 +5805,7 @@ msgstr ""
 "Kad kan ikkje starte dersom UDP-porten er deaktivert.\n"
 "Aktivér UDP-porten eller deaktivér Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5903,69 +5815,69 @@ msgstr ""
 "Du MÅ starte om att aMule no.\n"
 "Ikkje klag dersom du ikkje gjer dette og du får problem.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Autooppfrisking starta"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Du freistar allereie nedlasting av fila %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ny ekstern kopling akseptert"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5975,66 +5887,66 @@ msgstr ""
 "Vér god og fylle ut ein URL som peikar til ei gyldig server.met fil.\n"
 "Klikk på knappen \"Liste\" ved denne boksen for å skrive inn ein URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Mellombelse filer"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Innkomande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Nettsignaturar"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Vel ei mappe for %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Bla etter videospelar"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Vél nettlesar"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Køyrbar%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Handsame tenarlista"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6042,1225 +5954,1224 @@ msgstr ""
 "Skriv inn URL`en for å laste ned server.met filer.\n"
 "Berre ein URL på kvar linje."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Komplette kjelder"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Oppdateringspause: %d sekund"
 msgstr[1] "Oppdateringspause: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid for gjennomsnittleg graf: %d minutt"
 msgstr[1] "Tid for gjennomsnittleg graf; %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Koplingsgrafskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbufferstorleik: %d byte"
 msgstr[1] "Filbufferstorleik: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Opplastingskøstorleik: %d klient"
 msgstr[1] "Opplastingskøstorleik: %d klientar"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 msgstr[1] "Oppfriskingsinterval på tenarkoplingar: %d minutt"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Oppfriskingsintervall for tenarkopling: Deaktivert"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "deaktivere"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Køyr kommando på `%s' hending"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Aktivér kommandokøyring i kjernen"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Kjernekommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Aktivér kommandokøyring på drakt"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Draktkommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Følgjande variablar vert erstatta:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Les mellombels mappe"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte filer"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Søkeåtvaring"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Hovud"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k søk kan ikkje gjennomførast dersom eD2k ikkje er tilkopla"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Uventa feil oppstod under søk på Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FilID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Ikkje gitt verdi"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Nedlasting i kategori"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Legg til valfrie URL`ar for denne fila"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Søk beslekta filer (eD2k, lokal tenar)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Merk som kjend fil"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopier eD2k lenkje til skrivebordet"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du er tilkopla tenaren du freistar å slette. Vér god å kople frå først."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Avbryt"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Greidde ikkje å kople til alle tåkelagde tenarar i lista. Freistar ein gong til utan tåkelegging."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Greidde ikkje å kople til alle tåkelagde tenarar i lista. Freistar ein gong til utan tåkelegging."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Greidde ikkje å kople til alle tenarane i lista. Freistar ein gong til."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Greidde ikkje å kople til alle tenarane i lista. Freistar ein gong til."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k nettverket deaktivert i innstillingar, koplar ikkje til"
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Ingen gangbare tenarar funne i tenarlista"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Tilkopla %s·(%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Kopling oppretta på: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Alvorleg feil i oppkopling. Internett kan vere nede"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Mista kopling til %s·(%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s·(%s:%i) ser ut til å vere daud."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s·(%s:%i) ser ut til å vere full."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
 msgstr[1] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Tilkopling til %s·(%s:%i)·mislukka."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "FEIL: Ugangbar sokkel ved uttellingssjekk"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Tilkoplingsfreisting til %s·(%s:%i)·gjekk over tida."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Lastar server.met fila: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met fila ikkje funnen!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Greidde ikkje å laste inn server.met fila '%s' - ukjend filformat."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Greidde ikkje å opne server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met fila er korrupt, ugangbar merkelapp på utgåve: 0x%x,·storleik·%i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i tenar funne i server.met"
 msgstr[1] "%i tenarar funne i server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d tenar lagd til"
 msgstr[1] "%d tenarar lagde til"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "IO feil underlesing av known.met fila: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Tenar ikkje lagd til: [%s:%d] oppgir ikkje ein gangbar port."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Tenar ikkje lagd til: IP`en til [%s:%d] er filtrert eller ugangbar."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Tenar ikkje lagd til: Tenar med lik IP:Port [%s:%d] funne i lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Tenar lagd til: Tenar på [%s:%d] som nyttar namnet '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Du er tilkopla tenaren du freistar å slette. Vér god å kople frå først."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Greidde ikkje å opne '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Greidde ikkje å lagre server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Ugangbar URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Tenarlista ferdig nedlasta frå %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Inga tenarlistadresse funnen i 'addresses.dat'. Lim inn ei gangbar tenarlisteadresse i denne fila for å automatisk oppdatere tenarlista di"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Last ned tenarlista frå %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ÅTVARING: ikkje gangbar URL for automatisk oppdatering av tenarar: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Ugangbar autonedlastingsnettside for server.met i addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Greidde ikkje å laste ned tenarlista frå %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Lokal tenar er filtrert av ipfiltra - koplar til ein anna tenar!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Tenarnamn"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Addresse"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Skildring"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Brukarar"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statisk"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Utgåve"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Du er tilkopla ein tenar du freistar å slette. Vér god å kople frå først. Tenaren vart IKKJE sletta."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Ukjent namn)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Er du sikker på at du vil slette den statiske tenaren %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Tenarar (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Tenar"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Kople til tenar"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Merk tenar som statisk"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Merk tenar som ustatisk"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Merk tenarar som statiske"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Merk tenarar som ustatiske"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Ta bort tenar"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ta bort tenarar"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Fjern alle tenarar"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopier eD2k lenkjer til skrivebordet"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Kople til tenar att"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Er du sikker på at du vil slette alle tenarane?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Er du viss på at du vil slette den valde tenaren."
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Er du viss på at du vil slette dei valde tenarane?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "FEIL: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ÅTVARING: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Ny klientid er %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ÅTVARING: Du har motteke ein Låg-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tTruleg har dette skjedd fordi du er bak ein brannmur eller ruter."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Ukjend tenarinfo motteke! - for kort"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Tok mot %d ny tenar"
 msgstr[1] "Tok mot %d nye tenarar"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Lagring av tenarlista ferdig."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Tenar avviste siste kommando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Falske pakkar mottekne frå tenar: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Urøyvd feil under handsaming av pakke frå tenar: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Kan ikkje skape DNS-løysande tråd for å kople til %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Tenar IP %s·(%s) er filtrert.  Koplar ikkje til."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "brukar protokolltåkelegging."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Koplar til·%s·(%s·-·%s:%i)·%s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Greidde ikkje å løyse dns for tenar %s: Greier ikkje å kople til!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMulelogg"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Tenar ikkje lagd til: Manglar IP eller vertsnamn."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Tenar ikkje lagd til: Ikkje gangbar tenarport."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k status:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Tilkoplingsstatus:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Tilkopla"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia status:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Køyrer på %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Køyrer"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kademlia status"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Tilkoplingsstatus:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Tilkoplingsstatus:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Brannmura status: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Ingen kamerat"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "Tilkopla kamerat"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Tilkopla kamerat"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Funne kjelder :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "Registerfil ikkje funne: "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Gjennomsnitt brukarar:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Gjennomsnitt filer:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Køyrer ikkje"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Fann %i kjend delt fil, %i ukjend"
 msgstr[1] "Fann %i kjende delte filer, %i ukjende"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "FEIL: Freista å dele %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "tenar ikkje funnen: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Brukarnamn"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Nedlastingsfart"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Opplastingsfart"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Tilgjengeleg:"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Opplastingsstatus"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Nedlastingsstatus"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Filnamn"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Delte filer"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Nedlasta delar"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Katalogsti"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Legg til kommentar/Rangering"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Endre kommentar/Rangering"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Endre namn"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Legg filer frå samlinga til overføringslista"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopiér magnet &URI til utklippstavla"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopier eD2k lenka til utklippstavla (&Kjelde)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopier eD2k lenkje til utklippstavle (Kjelde) &Med krypteringsval)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopier eD2k lenkje til utklippstavla (&Vertsnamn)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopier eD2k lenkje til utklippstavla (Vertsnamn) (Med &krypteringsval)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopier eD2k lenkje til utklippstavla (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopier eD2k lenkje til utklippstavla (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Du treng ein HøgID for å lage ei gangbar kjeldelenkje"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Filnamn"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Opplasta data (økt (total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Totalt dataoverskot (pakkar): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Dataoverskot på filetterspurnader (pakkar): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Dataoverskot på kjeldeutveksling (pakkar): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Dataoverskot på tenar (pakkar): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Dataoverskot Kad (pakkar): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Krypteringsdataoverskot (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktive opplastingar: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Ventande opplastingar: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Tal på samtlege vellukka opplastingar: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Tal på samtlege mislukka opplastingar: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Gjennomsnittleg opplastingstid: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Nedlasta data (økt (total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Funne kjelder: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktive nedlastingar (delar): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Økt OL:NL proporsjon (total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Gjennomsnittleg nedlastingsfart (økt): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Gjennomsnittleg opplastingsfart (økt): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Raskaste nedlastingsfart (økt): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Raskaste opplastingsfart (økt): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Attkoplingar: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tid sidan første overføring: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Tilkopla tenar sidan: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktive koplingar (berekna): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Maksimal koplingsgrense nådd: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Gjennomsnittleg tal på koplingar (berekna): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Topp koplingar (berekna): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klientar"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Ukjend storleik"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Filtrert"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Nekta"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total:·%i·Kjend:·%i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Fungerande tenarar: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Mislukka tenarar: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total:·%s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Sletta tenarar: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtrerte tenarar: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Brukarar på fungerande tenarar: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Filer på fungerande tenarar: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Totalt brukertal: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Totalt filtal: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Tenerlast: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Tal på delte filer: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Total storleik på delte filer: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Gjennomsnittleg filstorleik: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operativsystem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Ikkje motteke"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktive koplingar (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Aldri"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Kommandoen·`%s'·med·pid·`%d'·er ferdig med statuskode·`%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Køyr <str> og avslutt."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Ugangbart IP-format. Bruk xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Denne kommandoen krever eit argument. Gangbare argument: 'alle', filnamn, eller eit tal.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Handsamar etter hash"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Handsamar etter filnamn"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Denne kommandoen krever eit argument: Gangbare argument: ein filhash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Ikkje gangbart tal\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Ikkje gangbar hash (lengde må vere nøyaktig 32 teikn)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7269,7 +7180,7 @@ msgstr "Skriv '%s'·for å få meir hjelp.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7278,89 +7189,87 @@ msgstr "Skriv '%s'·for å få meir hjelp.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Skriv '%s'·for å få meir hjelp.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Nedlastingar (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Etterspurnaden mislukka med ukjend feil."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operasjonen var vellukka"
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Etterspurnaden mislukka med følgjande feil: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP-filtréring for klientar er %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "AV"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "PÅ"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP-filtréring for tenarar er %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Novérande IPFilternivå er %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Bandbreiddegrenser: Opp: %u kB/s, Ned: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Tilkopla %s·%s·%s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Koplar til no"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "brannmura"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7369,7 +7278,7 @@ msgstr ""
 "\n"
 "Nedlasting:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7378,7 +7287,7 @@ msgstr ""
 "\n"
 "Opplasting:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7387,7 +7296,7 @@ msgstr ""
 "\n"
 "Klientar i kø:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7396,46 +7305,46 @@ msgstr ""
 "\n"
 "Alle kjelder:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Delfil]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Tal på søkjeresultat: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Tok imot ukjend svar frå tenaren, OpCode·=·%#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Syne kort statusinformasjon."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Syne koplingsstatus, noverande opp- og nedlastingsfart, osb.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Syne fullt statistikktre."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7449,11 +7358,11 @@ msgstr ""
 "\n"
 "Til dømes: 'statistics 5' vil berre syne dei 5 utgåvene på top for kvar klienttype.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Avslutt aMule"
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7462,40 +7371,40 @@ msgstr ""
 "Avslutt den fjerne kjernen (amule/amuled).\n"
 "Dette vil óg avslutte tekstklienten, ettersom den er ubrukeleg utan ei kjerne som køyrer-\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Lastar inn att valt objekt."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Lastar om att ipfiltertabell frå fil."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Vel Ipfilternivå"
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Lastar om att ipfiltertabell frå fil."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Kople til nettverket."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7507,36 +7416,36 @@ msgstr ""
 "den tenaren. IP`en må vere ei punktmerka og desimal IPv4-adresse.\n"
 "eller eit løyseleg DNS-namn."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Kople til berre eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Berre kople til Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Kople frå nettverket."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Dette vil kople frå alle nettverka som no er kopla til.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Kople frå berre eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Berre kople frå Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Legg til ei eD2k eller magnetlenkje  til kjernen"
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7554,52 +7463,52 @@ msgstr ""
 "\n"
 "Magnetlenkja må innehalde eD2k hashen og fillengda.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Set ein brukarvalverdi."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Set brukarval for ipfilter."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Slå IP-filtréring på for både klientar og tenarar."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Slå IP-filtréring av for både klientar og tenarar."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Aktivér/deaktivér IP-filtrering av klientar."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Slå IP-filtréring på for klientar."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Slå IP-filtréring av for klientar."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Aktivér/deaktivér IP-filtrering av tenarar."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Slå IP-filtréring på for tenarar."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Slå IP-filtréring av for tenarar."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Vel Ipfilternivå"
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7607,80 +7516,80 @@ msgstr ""
 "Gangbart filtréringsnivå er mellom 0-255, og den opprinnelege\n"
 "verdien er 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Set bandbreiddegrense."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Verdien i desse kommandoane må vere i kilobytes/sek.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Set bandbreiddegrense for opplastingar."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Verdien i desse kommandoane må vere i kilobytes/sek.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Set bandbreiddegrense for nedlastingar."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Verdien i desse kommandoane må vere i kilobytes/sek.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Hent og syne ein preferanseverdi."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Hent ipfilterinnstillingar"
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hent ipfilterstatus for både klientar og tenarar."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Hent ipfilterstatus for klientar."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Hent ipfilterstatus for tenarar."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Vel Ipfilternivå"
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Hent bandbreiddegrense."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Startar eit kadsøk"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7699,48 +7608,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Startar eit globalt søk"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Startar eit lokalt søk"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Startar eit kadsøk"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Syne resultata av siste søk."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Syner framdrifta i eit søk."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Start nedlasting av ei fil"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7748,82 +7657,82 @@ msgstr ""
 "Talet på ei fil frå siste søk må verte gjeve.\n"
 "Døme: 'download·12' vil starte nedlastinga av fil nummer 12 frå forrige søk.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Set nedlasting på pause."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Hald fram nedlasting."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Avbryt nedlasting"
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Set nedlastingsprioritet."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Gje prioritet Låg, Normal, Høg eller Auto til ei nedlasting.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Set prioritet til låg."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Set prioritet til normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Set prioritet til høg."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Set prioritet til auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Syne køer/lister."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Syner opplastings-/nedlastingskøa, tenarlista eller lista over delte filer.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Syne opplastingskø"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Syne nedlastingskø."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Syne logg."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Syne tenarlister."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Lastar inn att lista over delte filer."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Nullstill logg."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Forelda kommando; bruk '%s' i staden."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7832,262 +7741,259 @@ msgstr ""
 "Dette er ein forelda kommando som ikkje lenger er tilrådd, og kan verte fjerna i framtida.\n"
 "Bruk '%s' i staden\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstklient"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverterer gamle AICH hashsett i '%s'·til·64b·i·'%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ÅTVARING: Filnamnet '%s' er feil og har vorte omdøypt til '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ÅTVARING: Fila '%s' finst allereie; ny fil omdøypt til '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Er du viss på at du vil avbryte og slette alle filene i denne kategorien?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Stadfesting naudsynt"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "For mange koplingar"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Alle andre"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Vel synsfilter"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Legg til kategori"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Redigér kategori"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Ta bort kategori"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashsett etterspurt for ukjend fil: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Held fram opplastingar av fila: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Mellombels stogge opplastingar av fila: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Greidde ikkje å utføre kommendoen `%s'·på·`%s hending."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Nedlasting fullført"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Fullstendig sti til fila"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Namnet til fila utan stikomponent."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "eD2k hash på fila"
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Filstorleiken i bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Samla tid på nedlastingsaktivitet."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Ny lynmeldingsøkt starta"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Meldingssendar."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Tom for plass"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Diskpartisjon,"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Feil ved ferdigstilling"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Handsamar filnummer %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Du har spurt etter delhashar (Berre brukt på filer > 9,5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s·--->·Fila finst ikkje·!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, lenkjeskaparen for aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Velkomen!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Innmatingsparameter"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fil å hashe"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Legg til valfrie URL`ar for denne fila"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Skriv inn fila du vil lage eD2k lenkje til her"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Skriv inn internettadressa du vil leggje til eD2k lenka: Legg til / på slutten for å la aLinkCreator leggje til det noverande filnamnet "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Lag lenkje "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Hjelp til med å spreie nye og sjeldne filer raskare, men med auka lenkjestorleik"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 filhash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k filhash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k lenkje"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Lagre"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopiér til utklippstavle"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Opne ei fil for å rekne ut eD2k lenka hennar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopier utrekna eD2k lenkje til skrivebordet"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Lagre utrekna eD2k lenkje til fil"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Om aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Vel fila du vil rekne ut eD2k lenkje til"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Ikkje noko å kopiére no !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Vel fila til den utrekna eD2k lenka"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Ikkje i stand til å opne "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Vér god å skrive inn eit filnamn som ikkje er tomt"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Ikkje noko å lagre akkurat no !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8107,167 +8013,159 @@ msgstr ""
 "\n"
 "Distribuert under GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hashar..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Avbrote!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Ferdig om %.2f·s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Du har allereie lagt til denne URL`en!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Vér god å skrive inn ein URL som ikkje er tom"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ikkje i stand til å opne %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dag(ar) %i timar %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f·KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "WxCas, aMule nettstatistikk"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Høgaste nedlastingsfart medan wxCas har køyrt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolutt maksimum nedlastingsfart nokon gong medan wxCas har køyrt"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Still attende"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "System"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Stopp. Autooppfrisking"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Lagre nettstatistikkbiletet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Skriv ut nettstatistikkbiletet"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Innstillingsval"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Om wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Start autooppfrisking"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Autooppfrisking stogga"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Autooppfrisking starta"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Lagre statistikkbilete"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule nettstatistikk"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8275,11 +8173,11 @@ msgstr ""
 "Det oppstod eit problem med utskrifta.\n"
 "Kanskje er ikkje skrivaren din innstilt skikkeleg?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Skriv ut"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8297,403 +8195,392 @@ msgstr ""
 "\n"
 "Distribuert·under·GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Å nei, aMule køyrer ikkje..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule køyrer"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule køyrer, men fråkopla"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule koplar til..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Å nei, ukjend status for aMule..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " har køyrt i "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " er stogga !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " er ikkje tilkopla !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " koplar til..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " gjer noko rart, sjekk det !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " er tilkopla "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "av"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " er på "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " med "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Total nedlasting: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr " Opplasting: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Nedlasting denne økta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Nedlasting: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, opplasting: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Deler: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " filer, klientar i kø: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tid: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " på "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Gjennomsnittleg systembelasting (1-5-15·min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Oppetid: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Katalog som inneheld amulesig.dat fila"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Skriv inn kvar katalogen som inneheld amulesig.dat fila er"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Oppfriskingsintervall i sekund"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Lag eit statistikkbilete ved kvar oppfriskingshending"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Skriv inn katalogen du vil lage statistikkbiletet i"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Last regelbunde opp statistikkbilete til ein FTP tenar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP-Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTPsti"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Skriv inn URL til FTP tenar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Skriv inn katalogen du lastar statistikkbiletet til FTPtenaren til"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Brukar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Skriv inn brukarnamnet for å logge inn på FTPtenaren din"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Skriv inn brukarpassordet for å logge inn på FTPtenaren din"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP oppdateringsintervall i minutt"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validere"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Katalog som inneheld signaturfila di"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Katalog der statistikkbiletet vert laga"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Lastar modell <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "HTTP port for vevtenar"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Bruk UPnP portvidarekopling på vevtenarport"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Fulltilgangspassord for vevtenar"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Gjestepassord for vevtenar"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Gje løyve til gjestetilgang"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Nekt gjestetilgang"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Last/lagre vevtenarinnstillingar frå/til fjern aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule konfugurasjonsfilsti. IKKJE NYTT DIREKTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Deaktivér PHP tolk (frårådd)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Omkompilér PHP-sider ved kvar etterspurnad"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule vevtenar"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "vevklientoppkopling godkjend\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Etterspurnaden mislukka med følgjande feil: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Registerfil ikkje funne: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Økt utgått - ber om logginn\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Økt ok, logga inn\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Økt ok, ikkje innlogga\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Inga økt opna - vil be om logginn\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Økt oppretta - ber om logginn\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Handsamar etterspurnad [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Sjekkar passord\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Passord hash feil\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Passord ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Feil passord\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Du skreiv ikkje inn eit passord. Tomt passord er ikkje tillate.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Utlogging etterspurt\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Handsamar etterspurnad [omdirigert]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Oppkopling mislukka "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -23,20 +23,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Pokaż aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "zdalna kontrola aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Zrzut ekranu:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,7 +44,7 @@ msgstr ""
 "\"Ogólnie-Platformy\" klient P2P oparty na eMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -53,79 +53,79 @@ msgstr ""
 "Copyright (c) 2003-2019 Zespół aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Część aMule oparta jest na \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: routing peer-to-peer oparty na metryce XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Strona internetowa:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sprawdź podczas startu czy jest nowa wersja"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Łączę z Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Niedostępny"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Dodaj znajomego"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Musisz wpisać poprawne IP oraz port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informacje"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Wybrany skrót użytkownika jest niepoprawny!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -134,49 +134,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za nazwą aplikacji"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Nieudane połączenie "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -185,103 +184,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Nie udało się otworzyć pliku ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy masz lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Teraz, zakańczam główną aplikację..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Nieudane"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Zakańczam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Zabiłam instancję amuleweb z pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Zakończenie jądra."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Zamykanie aMule zakończone."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Wyniki debugu pamięci dla wyjścia aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Twoje ustawienia lokalne zostały zmienione na domyślne systemowe w związku ze zmianą konfiguracji. Przepraszamy."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informacje"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -289,74 +285,70 @@ msgstr ""
 "\n"
 "Konfiguracja EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "UWAGA"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "BŁĄD"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "serwer sieciowy uruchomiony na pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nie można było powiązać portów z określonym adresem: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u jest niedostępny. Będziesz mieć LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -371,48 +363,48 @@ msgstr ""
 "\n"
 "Sprawdź swoją sieć aby mieć pewność, że port jest otwarty dla wejścia i wyjścia."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Nie udało się utworzyć pliku podpisu online aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Wybrane lokale wydają się być niezainstalowane. (Uwaga: I tak spróbuję je ustawić)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Po raz pierwszy uruchomiłeś aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ta wersja jest aktualizowaną codziennie wersją testową i\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nie dajemy żadnej gwarancji, że nie zniszczy ona niczego, nie spali twojego domu\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "lub zabije twojego psa. *Powinna* ona jednak mimo wszystko działać poprawnie.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Więcej informacji, pomoc i nowe wydania znajdziesz na naszej stronie \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io lub na naszym kanale IRC: #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Nie wahaj się zgłaszać jakichkolwiek błędów na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,224 +412,220 @@ msgstr ""
 "Katalog wybrany na pliki sygnatury online jest nieprawidłowy!\n"
 " Sygnatura online zostanie wyłączona dopóki nie poprawisz tego w preferencjach."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Wstępna alokacja dysku dla pliku '%s' nie powiodła się: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "BŁĄD: nie mogę otworzyć pliku logów"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UWAGA: plik logów jest pusty. Coś jest nie tak."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Logi zostały zresetowane"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Wiadomość z serwera: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pominięto pobranie %s, ponieważ żądany plik nie jest nowszy."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Pobieranie listy węzłów nie powiodło się."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Nie można otworzyć pobranego pliku kontroli wersji"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Uszkodzony plik kontorli wersji"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Używasz przestarzałej wersji aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Twoje wersja eMule to %i.%i.%i, najnowszą wersją jest %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UWAGA: Twoja wersja aMule jest przestarzała: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Twoja kopia aMule jest przestarzała."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Nie udało się pobrać pliku kontroli wersji"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Użytkowników: %s | Plików: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Użytkowników: E: %s K: %s | Plików: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nie wybrano sieci"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "z LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "z HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Połączony z %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Łączenie z %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Rozłączono z eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Włączono Kad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Zatrzymano Kad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Połączono z Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nie można użyć sieci Kad, jeśli port UDP jest wyłączony w preferencjach, nie włączam."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Zablokowano sieć Kad w preferencjach, nie łączę."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "BŁĄD: daemon aMule nie może być użyty, gdy zewnętrzne połączenia są zablokowane. Aby włączyć połączenia zewnętrzne użyj normalnego aMule, włącz amuled z opcją --ec-config lub ustaw klucz \"AcceptExternalConnections\" na 1 w pliku ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "BŁĄD: Potrzebne jest ważne hasło do korzystania z zewnętrznych połączeń, a daemon aMule nie może używany być bez zewnętrznych połączeń. Aby uruchomić deamon aMule, musisz ustawić pole \"ECPassword\" w pliku ~/.aMule/amule.conf~ z odpowiednią wartością. Wykonaj amuled z flagą --ec-config aby ustawić hasło. Więcej informacji można znaleźć na https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - począwszy timer"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Nie można utworzyć pliku Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "BŁĄD: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To jest aMule %s oparty na eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -647,193 +635,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Brak sieci"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Pilot aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Krytyczny Błąd: Nie udało się utworzyć Timera Core"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Podłączony do zdalnego amule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Utracono połączenie"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Pytaj przy wyjściu"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -842,153 +823,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Krytyczny Błąd: Nie udało się utworzyć Timera Poll"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Przechodzę do pętli wydarzenia..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Łączenie..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Zdalne GUI EC obsługi zdarzenia"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Połączenie nie powiodło się. Nie można połączyć się z %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Zamykanie"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Próba połączenia z %s (%s:%i) przedawniła się."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Połącz z siecią."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Połączenie nie powiodło się. Nie można połączyć się z %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Gotowy"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Wszystkie"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Niedostępne"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Nie znaleziono pliku."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nadal katalog '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Szukam kolegi dla połączenia lowid"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fałszywa wersja eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Fałszywy eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Fałszywy eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (oparty na eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Użytkownik: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Zażądano:  %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -996,7 +967,7 @@ msgstr[0] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądania, %s prz
 msgstr[1] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 msgstr[2] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1004,119 +975,119 @@ msgstr[0] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żąda
 msgstr[1] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 msgstr[2] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Zażądano nieznany plik"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Wiadomość przefiltrowana od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nowa wiadomość od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Użytkownik %s (%u) zażądał twojej listy plików udostępnionych w katalogu %s -> Odmówiono"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "UWAGA: %s nie może być otwarty."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "OSTRZEŻENIE: Anulowana lista plików uszkodzona, zawiera nieprawidłowy nagłówek."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Błąd IO podczas odczytu pliku %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Błąd podczas zapisywania pliku %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nowa kategoria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Wybierz folder na pobierane pliki"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Musisz określić nazwę kategorii!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Musisz określić ścieżkę dla kategorii!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Nie udało się utworzyć katalogu przychodzących dla kategorii. Proszę podać właściwą ścieżkę!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Rozpoczęto sesję czata: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Połączony do klienta ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Łączenie z klientem ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Nie udało się połączyć do klienta / Połączenie utracone ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Zdałeś captcha i użytkownik otrzymał twoją wiadomość. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Twoja odpowiedz na captcha była nieprawidłowa i wiadomość ta została zignorowana. Możesz otrzymać kolejną captcha wysyłając nową wiadomość. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Zamknij kartę"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Zamknij wszystkie karty"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Zamknij inne karty"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Dodaj do znajomych"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1124,7 +1095,7 @@ msgstr[0] "Plik kredytów załadowany, %u klient jest znany"
 msgstr[1] "Plik kredytów załadowany, %u klientów jest znanych"
 msgstr[2] "Plik kredytów załadowany, %u klientów jest znanych"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1132,173 +1103,170 @@ msgstr[0] " - Kredyty wygasły dla %u klienta!"
 msgstr[1] " - Kredyty wygasły dla %u klientów!"
 msgstr[2] " - Kredyty wygasły dla %u klientów!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Nie znaleziono pliku cryptkey.dat, tworzenie."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Szczegóły klienta"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Włączony"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Obsługiwany"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nieobsługiwany"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Wyłączony"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Połączony"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Rozłączony"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Niekompletne"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Zły człowiek"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Weryfikacja - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Niedostępne"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Użytkownik %s (%u) zażądał twojej listy udostępnionych plików-> Zaakceptowano"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Użytkownik %s (%u) zażądał twojej listy udostępnionych plików -> Odmówiono"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Użytkownik %s (%u) zażądał twojej listy udostępnionych katalogów -> Zaakceptowano"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Użytkownik %s (%u) żążądał twojej listy udostępnionych katalogów -> Odmówiono"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Użytkownik %s (%u) zażądał twojej listy plików udostępnionych w katalogu %s -> Zaakceptowano"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Użytkownik %s (%u) zażądał twojej listy plików udostępnionych w katalogu %s -> Odmówiono"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Użytkownik %s (%u) udostępnia katalog %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Użytkownik %s (%u) wysłał niechciane katalogi udostępnione."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Użytkownik %s (%u) wysłał listę plików udostępnionych w katalogu %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Użytkownik %s (%u) zakończył wysyłanie listy udostępnionych plików"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Użytkownik %s (%u) wysłał niechcianą listę udostępnionych plików"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Użytkownik %s (%u) odmówił dostępu do listy udostępnionych plików/katalogów"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Komentarze pliku"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nazwa pliku"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocena"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentarz"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Nie można wykonać wyszukiwania Kad, jeśli Kad nie jest włączony"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Szukam kolegi dla połączenia lowid"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Bez komentarza"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1306,268 +1274,258 @@ msgstr[0] "%u komentarz"
 msgstr[1] "%u komentarze"
 msgstr[2] "%u komentarzy"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Zbanowany klient %s za wysyłanie %s uszkodzonych danych z %s dla pliku '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Nie można połączyć się z serwerem pobrania HTTPNie powiodło się pobranie GeoIP.dat z %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Ni]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Wy]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Wysoki"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Bardzo wysoki"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Wydanie"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Pytam"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Połączenie przez serwer"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Pełna kolejka"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "W kolejce"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Pobieranie"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Odbieram zestaw skrótów"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Brak potrzebnych części"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nie można połączyć LowID do LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Zbyt dużo połączeń"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Połączenie przez Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Zbyt dużo połączeń Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Zbanowany"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Błąd połączenia"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Zdalna kolejka pełna"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Stary MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nowy MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Kompatybilny z eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Serwer lokalny"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Wymiana źródeł"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasywny"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Link"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Ziarna źródła"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Wynik wyszukiwania"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zakończono"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "W trakcie"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "BŁĄD: Brak przestrzeni dyskowej"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "BŁĄD: Nie znaleziono partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "BŁĄD: Błąd IO!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "BŁĄD: Niepowodzenie!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "W kolejce"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Aktualnie pobierane"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Nieznany lub błędny format pliku tymczasowego."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Część"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Przesłano"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Prędkość"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Postęp"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Źródła"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorytet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Pozostało czasu"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Ostatnio widziano cały"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Ostatnio widziany"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Jesteś pewien, że chcesz usunąć wybrany plik?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Jesteś pewien, że chcesz usunąć wybrane pliki?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1576,109 +1534,106 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatyczny"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Zatrzymaj"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pauza"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Wznów"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Wyczyść s&kończone"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Przerzuć wszystkie A4AF do tego pliku"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Przerzuć wszystkie A4AF do tego pliku (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Przerzuć wszystkie A4AF do każdego innego pliku"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Zaawansowane opcje"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Podgląd"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Pokaż &szczegóły pliku"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Pokaż wszystkie komentarze"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Skopiuj magnet URI do schowka"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopiuj &link eD2k do schowka"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiuj informację zwrotną do schowka"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "nieprzydzielony"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Przydziel do kategorii"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otwórz plik"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Wprowadź nową nazwę dla tego pliku:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Zmień nazwę"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Pobieranie (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1687,47 +1642,47 @@ msgstr ""
 "Aby zapobiec pojawianiu się tego komunikatu przy każdym podglądzie,\n"
 "ustaw swój odtwarzacz wideo w preferencjach (domyślny jest %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Podgląd pliku"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "BŁĄD: Nie udało się uruchomić zewnętrznego odtwarzacza! Komenda: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Zapisywanie pliku części %u z %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Wszystkie pliki części zapisane."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Ładowanie plików tymczasowych z %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Ładowanie pliku części %u z %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "BŁĄD: Załadowanie pliku kopii zapasowej nieudane. Poszukaj na https://github.com/amule-org/amule/discussions sposobów odzyskiwania .part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Wszystkie pliki części załadowane."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nie znaleziono plików z częściami"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1735,50 +1690,50 @@ msgstr[0] "Znaleziono %u plik części"
 msgstr[1] "Znaleziono %u pliki części"
 msgstr[2] "Znaleziono %u plików części"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "System plików katalogu Temp nie obsługuje dużych plików."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "System plików katalogu Incoming nie obsługuje dużych plików."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Pobieranie %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Starasz się już pobierać plik '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Masz już ten plik '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Masz już ten plik '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Starasz się już pobierać plik %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Nie można skonwertować magnet linka do eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Nieznany protokół linku: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1786,251 +1741,250 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Nieprawidłowy link eD2k! BŁĄD: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Klient wysyła pakiet po nie udanym uwierzytelnieniu."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Zewnętrzne połączenia wyłączone w związku z brakiem hasła!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Zewnętrzne połączenia wyłączone w pliku konfiguracyjnym"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "BŁĄD: nie można zaakceptować nowego połączenia zewnętrznego"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zewnętrzne połączenia odrzucone, ze względu na brak hasła w preferencjach!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Łączę z klientem: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Nieznana wersja"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Niepoprawny ID wersji EC, może występować niezgodność binarna. Użyj rdzenia i zdalnego z tej samej wersji."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nie można połączyć się z wersją finałową z dowolnej wersji SVN! *westchnięcie* prawdopodobnie zapobiegnięto awarii"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Zła wersja protokołu."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Brak znacznika wersji protokołu."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowy skrót podany jako hasło EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Uwierzytelnianie nie powiodło się: nieprawidłowe hasło."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Uwierzytelnianie nie powiodło się: brak hasła."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Nieprawidłowe żądanie, najpierw musisz się uwierzytelnić."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Dostęp udzielony."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Wyślij wiadomość błędu \"%s\" do klienta."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Próba nieautoryzowanego dostępu z %s. Połączenie zakończone."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Zdalna komenda pliku części nieudana: Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Skrót dla pliku nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Błąd przetwarzania OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Nie dodano serwera"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "serwer nieznaleziony: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "trzeba zdefiniować serwer do usunięcia"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Szukanie przez WWW ze zdalnych interfejsów nie ma sensu."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Wyszukiwanie w trakcie. Odświeżenie rezultatów za chwilę!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Brak punktów dla wykresu."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Twój klient nie jest skonfigurowany do tego poziomu szczegółów."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "External Connection: żądanie zamknięcia"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Już w trakcie zamykania."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: dodaję link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Nie znaleziono pliku."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nieprawidłowa nazwa pliku."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nie udało się zmienić nazwy pliku."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad jest wyłączony w preferencjach."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Już podłączony do eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Łączę do eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Już podłączony do Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Łączę z Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Wszystkie sieci są wyłączone."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Rozłącz z eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Rozłączono z Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "External Connection: otrzymano nieprawidłowy opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Nieprawidłowy opcode (zła wersja protokołu?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Nieznane rozszerzenie '%s' dla komendy '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Nieznana komenda '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2038,7 +1992,7 @@ msgstr ""
 "\n"
 "Ta komenda nie może posiadać argumentu.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2046,7 +2000,7 @@ msgstr ""
 "\n"
 "Ta komenda musi posiadać argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2054,7 +2008,7 @@ msgstr ""
 "\n"
 "Ta komenda jest niekompletna, użyj jednego z rozszerzeń podanych niżej.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2062,11 +2016,11 @@ msgstr ""
 "\n"
 "Dostępne rozszerzenia:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Dostępne komendy:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2077,17 +2031,17 @@ msgstr ""
 "Wszystkie komendy są niewrażliwe na wielkość znaków.\n"
 "Wpisz '%s <komenda>', aby uzyskać szczegółowe informacje na temat <komenda>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Wychodzi z programu."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Pokaż pomoc."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2095,7 +2049,7 @@ msgstr ""
 "Aby uzyskać pomoc dotyczącą komendy, wpisz 'help <komenda>'.\n"
 "Aby uzyskać pełną listę komend, wpisz 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2106,46 +2060,46 @@ msgstr ""
 "Użyj '%s' aby otrzymać listę komend\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Błąd składni!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Błąd przetwarzania komendy - to nie powinno się zdarzyć! Proszę zgłosić błąd\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Ta komenda nie powinna posiadać żadnego parametru."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Ta komenda musi posiadać parametr."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Nieprawidłowy argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "To jest niekompletna komenda."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Wpisz '%s' , aby uzyskać więcej pomocy.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "To jest %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "To jest %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2153,7 +2107,7 @@ msgstr ""
 "\n"
 "Tworzenie klienta...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2162,7 +2116,7 @@ msgstr ""
 "\n"
 "OK, wychodzę %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2176,331 +2130,326 @@ msgstr ""
 "\n"
 "Wychodzę...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Pokazuj ten tekst pomocy."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host gdzie jest uruchomiony aMule. (domyślny: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Port zewnętrznych połączeń aMule. (domyślny: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Hasło połączeń zewnętrznych."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Czyta konfiguracje z pliku."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nie wysyłaj żadnego wyjścia na stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Bądź gadatliwy - pokazuj także wiadomości diagnostyczne."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Ustawia locale programu (język)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Zapisuje opcje listy komend do pliku konfiguracyjnego."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Tworzy plik konfiguracyjny oparty na pliku konfiguracyjnym aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Drukuj wersję programu."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Szczegóły pliku"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% skończone"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Witamy!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Łączenie do kolegi"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Stan połączenia:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Sieci"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standardowy port TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Rozszerzony port UDP (KAD / globalne wyszukiwanie)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Włącz UPnP dla przekierowania portów routera"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Starasz się już pobierać plik %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Autoaktualizacja listy serwerów przy starcie"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do odczytu!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do zapisu!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Znajomi"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Pokaż &szczegóły"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Dodaj znajomego"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Usuń znajomego"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Wyślij &wiadomość"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Pokaż pliki"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Ustaw slot dla znajomego"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Jesteś pewien, że chcesz usunąć wybranego przyjaciela?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Jesteś pewien, że chcesz usunąć wybranych przyjaciół?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2508,11 +2457,11 @@ msgstr ""
 "Nie możesz ustanowić więcej niż jeden slot dla znajomego.\n"
 "Przydzielono tylko jeden slot."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Wybór wielu"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2521,183 +2470,182 @@ msgstr ""
 "Nie możesz ustanowić więcej niż jeden slot dla znajomego.\n"
 "Przydzielono tylko jeden slot."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Wyślij wiadomość do użytkownika"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Wiadomość do wysłania:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Usuń ze znajomych"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Wyślij wiadomość"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zamień na ten plik"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Proszę o inny plik"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Oczekiwanie na slot wysyłań"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "W kolejce"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Wysyłanie"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Brak"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nie"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Tak"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Pobieranie..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Pobranie HTTP anulowane"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Adres URL do pobrania nie może być pusty"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Pobrano %d bajtów"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Adres URL %s zwrócił: %i - Błąd (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Pobranie HTTP anulowane"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Pobierz nową GeoIP.dat z %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Nie można pobrąć pliku GeoIP.dat, przerwana aktualizacja."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Nie można usunąć pliku %s, przerwana aktualizacja."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Nie można zmienić nazwy pliku %s, przerwana aktualizacja."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Pomyślnie zaktualizowany %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Błąd aktualizacji GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Nie powiodło się pobranie %s z %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Ładowanie filtrów IP 'ipfilter.dat' i 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Ładowanie pliku ipfilter.dat nieudane '%s', napotkano nieznany format."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Ładowanie pliku ipfilter.dat nieudane '%s', nie można otworzyć pliku."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2705,7 +2653,7 @@ msgstr[0] "Załadowano %u zakres IP z '%s'."
 msgstr[1] "Załadowano %u zakresy IP z '%s'."
 msgstr[2] "Załadowano %u zakresów IP z '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2713,16 +2661,16 @@ msgstr[0] "%u niepoprawna linia została odrzucona."
 msgstr[1] "%u niepoprawne linie zostały odrzucone."
 msgstr[2] "%u niepoprawnych linii zostało odrzuconych."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Nie można załadować danych kraju dla '%s'."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "Filtr IP jest gotowy"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2730,56 +2678,52 @@ msgstr ""
 "Rozruch od \n"
 "znanych klientów"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Węzły (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Nieprawidłowe ip do rozruchu"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Nieprawidłowy port do rozruchu"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Proszę wypełnij wszystkie wymagane pola"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Wiadomość"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Czy jesteś pewien, że chcesz pobrać nowy plik nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Kontynuowanie spowoduje usunięcie obecnych węzłów i restart połączenia Kademlii."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Kontynuować?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: wyszukiwana fraza jest za krótka"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Szukane słowo kluczowe jest już na liście wyszukiwania: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2787,12 +2731,11 @@ msgstr[0] "Wczytaj %u kontakt Kad"
 msgstr[1] "Wczytaj %u kontakty Kad"
 msgstr[2] "Wczytaj %u kontaktów Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Nie znaleziono kontaktów, proszę rozruszyć, lub pobrać plik nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2800,7 +2743,7 @@ msgstr[0] "Tylko %d dostępny kontakt KAD, nodes.dat nie zapisane"
 msgstr[1] "Tylko %d dostępne kontakty KAD, nodes.dat nie zapisane"
 msgstr[2] "Tylko %d dostępnych kontaktów KAD, nodes.dat nie zapisane"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2808,801 +2751,774 @@ msgstr[0] "Zapisano %d kontakt Kad"
 msgstr[1] "Zapisano %d kontakty Kad"
 msgstr[2] "Zapisano %d kontaktów Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Sieć Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nazwa pliku"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Rozmiar pliku"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Ratio wymiany"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Zażądano"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Zaakceptowano"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Pełne źródła"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "OSTRZEŻENIE: Znana lista plików uszkodzona, zawiera nieprawidłowy nagłówek."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Nie można załadować wpisu w znanej liście plików, plik może być uszkodzony"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Nieprawidłowy wpis w znanej liście plików, plik może być uszkodzony: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Nieznana wersja"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Nie można utworzyć docelowego pliku %s do pobrania!"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Tworzenie skrótu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Zakańczanie"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Ukończono"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Błędne"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Czeka"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Musisz określić hasło."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Nieprawidłowe hasło, nie skrót MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Błąd połączenia"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Połączenie EC nieudane. Pusta odpowiedź."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "External Connection: Zła odpowiedź serwera, brak nawiązania. Zakończono połączenie."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Sukces! Nawiązano połączenie z aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Sukces! Nawiązano połączenie."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "External Connection: Brak dostępu z powodu: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "BŁĄD: nie można nasłuchiwać na porcie TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "BŁĄD: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Zamknij"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Wytnij"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Wklej"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Połączony"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Połączony"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Połączono z Kad (za firewallem)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP serwera: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP Serwera:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nie połączony"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Port TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Port TCP: Nie gotowy"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Port UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Port UDP: Nie gotowy"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informacje o kliencie"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limit wysyłania"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limit pobierania"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Pokaż aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Ukryj aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Wyjdź"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Nielimitowane"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menu podajnika aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limity prędkości:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Brak"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Brak"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Prędkość pobierania: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Prędkość wysyłania: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Ksywka: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nie wybrano ksywki!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID klienta: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nazwa serwera: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP serwera: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Nie połączony"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Podpis online: Włączony"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Podpis online: Wyłączony"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Uptime: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Udostępnionych plików: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Klientów w kolejce: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Razem DL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Razem UL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Dodaje link eD2k lub magnet do rdzenia."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Dodaj do znajomych"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Kliknij tutaj, aby dodać link eD2k w linii poleceń do twojej kolejki pobierań."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Zdarzenie są wyświetlane tu. Dla pełnej listy zdarzeń, definiuj logowanie w zakładce serwerów."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Ładuje..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Ilość użytkowników na serwerze do którego jesteś połączony ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Użytkowników: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Użytkowników połączonych do aktualnego serwera i szacunkowa liczba wszystkich użytkowników."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Wysł: 0.0 | Pobr: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Aktualna średnia szybkość wysyłania i pobierania. Jeżeli włączone, liczby w nawiasach wskazują narzut komunikacji z klientem."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Wyświetla status połączonych i aktywnych transferów. Czerwone strzałki wskazują, że nie jesteś aktualnie połączony, żółte, że masz niskie ID (za firewallem) i zielone strzałki wskazują, że masz wysokie ID (optymalny typ połączenia)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Niepołączony ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Aktualnie połączony serwer."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Szukaj"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nazwa:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokalne"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globalne"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parametry dodatkowe"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrowanie"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Typ Pliku"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Dowolny"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Archiwa"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Obrazy CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Obrazki"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programy"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Teksty"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Filmy"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Rozszerzenie"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min rozmiar"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bajtów"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maks. rozmiar"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Dostępność"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtr:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Wyniki filtrowania"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Odwróć wyniki"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Ukryj znane pliki"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Start"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Więcej"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Pobieranie"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Zresetuj pola"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Wyniki"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Wyczyść skończone pobierania"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Źródła pliku:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Brak"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Ogólne"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Pełna nazwa :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "plik met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Skrót :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Rozmiar pliku :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Status pliku części:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Ostatnio widziano całość :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Znaleziono źródeł :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Przesyłam ze źródeł :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Części pliku :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Dostępne :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Aktywny czas pobierania: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Przesłano :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Zakończono :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Inteligentny System Obsługi Błędów"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Utracono z powodu błędów :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Zyskano przez kompresję :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pakietów uratowanych przez I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Udostępnione: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Żądania"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Zaakceptowane żądania"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Przesłane dane"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Ratio wymiany"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Pełne źródła"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Udostępnione pliki"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Wysłanych: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nieoceniony"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Tytuł :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nazwy plików"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Przejmij"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Wyczyść"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Komentuj/Oceń plik (tekst będą widzieli wszyscy użytkownicy)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3610,1271 +3526,1267 @@ msgstr ""
 "Dla filmu można opisać jego długość, historię, język ...\n"
 "i jeśli jest on fałszywy, można powiedzieć to innym użytkownikom aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Jakość pliku"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nieoceniony"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Nieprawidłowy / Uszkodzony / Fałszywy"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Marny"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "W miarę"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Dobry"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Znakomity"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Wybierz ocenę pliku lub skonsultuj z użytkownikiem jeżeli jest nieprawidłowy ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Rozłączono z Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Pobieranie, proszę czekać..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Nieznany rozmiar"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Wymagane informacje"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Adres IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatkowe informacje"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nazwa użytkownika :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Średnia sesji"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Prędkość wysyłania"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Drzewo statystyk"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nazwa użytkownika:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Skrót użytkownika:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Oprogramowanie klienta:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Wersja klienta:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Adres IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID użytkownika:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP Serwera:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nazwa serwera:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Maskowanie:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transfery do klientów"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Aktualnie żądań:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Średnia prędkość wysyłania:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Średnia prędkość pobierania:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Wysłane (sesja):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Pobrane (sesja):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Wysłanych (razem):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Pobranych (razem):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punkty"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modyfikator DL/UL:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Bezpieczny identyfikator:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Pozycja kolejki:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Punkty kolejki:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Ksywa"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - Mule na wielu platformach"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "To jest nazwa jaką inni użytkownicy będą widzieli łącząc się do Ciebie."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Język: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Opóźnienie przed pokazaniem podpowiedzi."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Określa język jaki będzie używany do sterowania."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Sprawdź podczas startu czy jest nowa wersja"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Włączenie tego spowoduje, że aMule będzie sprawdzał, czy jest nowa wersja podczas startu"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Uruchom zminimalizowany"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Włączenie tego spowoduje minimalizowanie aMule podczas startu."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Pytaj przy wyjściu"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Pytaj przed zakończeniem aMule."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Włącz ikonę w zasobniku"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "To włącza/wyłącza ikonę w zasobniku systemowym."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Zminimalizuj do ikony zasobnika"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Włączenie opcji spowoduje, że aMule będzie minimalizował się do paska systemowego zamiast paska stanu."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Opóźnienie tooltipów: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Wybór przeglądarki"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Otwórz w nowej karcie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Otwórz stronę WWW w nowej karcie zamiast w nowym oknie jeśli to możliwe"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Odtwarzacz filmów"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limity przepustowości"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Przydział slotów"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Pporty"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To jest standardowy port eD2k i nie może być wyłączony."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP dla żądań serwera (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ten port UDP jest używany do rozszerzonych żądań ed2k i sieci KAD"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (opcjonalnie):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Automatycznie połącz przy uruchomieniu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Połącz ponownie po rozłączeniu"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Usuń martwe serwery po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "próbach"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Uaktualnij listę serwerów przy połączeniu do serwera"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Uaktualnij listę serwerów przy połączeniu klienta"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Używaj systemu priorytetów"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Używaj inteligentnego sprawdzania LowID przy połączeniu"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Bezpieczne połączenie"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Automatyczne łączenie tylko do serwerów statycznych"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Ustaw priorytet ręcznie dodanych serwerów na Wysoki"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Dodaj pliki do pobrania w trybie wstrzymania"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Dodaj pliki do pobrania z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Próbuj najpierw pobrać pierwszy i ostatni kawałek"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Zacznij następny wstrzymany plik, gdy plik gotowy"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Z tej samej kategorii"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Alokuj wstępnie przestrzeń dyskową dla nowych plików"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Dla nowych plików alokuje wstępnie przestrzeń dyskową dla całego pliku redukując w ten sposób fragmentację"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Zatrzymaj pobieranie gdy zabraknie wolnego miejsca na dysku"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Zaznacz jeśli chcesz, aby aMule sprawdzał Twoją przestrzeń dyskową"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Wpisz tu minimalną ilość miejsca na dysku."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Zapisz 10 źródeł dla rzadkich plików (< 20 źródeł)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Dodaj udostępnione pliki z automatycznym priorytetem"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentna obsługa uszkodzeń (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Włączone"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Zaawansowane I.C.H. ufa każdemu skrótu (nie zalecane)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Kliknij prawym przyciskiem na katalog, aby udostępnić go razem z podkatalogami)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Udostępnij pliki ukryte"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Wykresy"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Odśwież co : 5 sekund"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Czas dla wykresów średnich: 100 minut"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Skala wykresu połączeń: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Skala wykresu pobierania:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Skala wykresu przesyłania:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Kolory: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Tło"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Siatka"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Aktualnie pobierane"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Bieżąca średnia pobierania"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Średnia pobierania sesji"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Aktualnie wysyłane"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Bieżąca średnia wysyłania"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona prędkości w zasobniku systemowym"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Obecne Kad-węzły "
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Działające Kad-węzły"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Wybierz"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Drzewo"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Liczba wyświetlanych wersji klienta (0=nieograniczona)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! UWAGA !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maks. nowych połączeń"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Rozmiar bufora plików: 240000 bajtów"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Rozmiar kolejki wysyłania: 5000 klientów"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Skóra do użycia:"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Pokazuj \"Szybkie wyłapywanie linków eD2K\" w każdym oknie."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Pokaż rozszerzone info w kartach kategorii"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Pokaż prędkość transferu w tytule"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Przed nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Za nazwą aplikacji"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Pokaż narzut przepustowości"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Pionowa orientacja paska narzędzi"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Pobierane pliki w kolejce"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Pokaż procent postępu"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Pokaż pasek postępu"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Płaski"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zabroń dostępu gościom"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Hasło gościa do serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4882,11 +4794,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4896,484 +4808,484 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Wyłączone [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "bajt"
 msgstr[1] "bajty"
 msgstr[2] "bajtów"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "bajt/sek"
 msgstr[1] "bajty/sek"
 msgstr[2] "bajtów/sek"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sek"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "godzin"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dni"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "wszystkie"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "wszystkie inne"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Niekompletne"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Zatrzymany"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Film"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Archiwum"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktywny"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Używanie katalogu konfiguracyjnego: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Oczekiwanie na koniec wątku przemiany pliku części ..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importowanie %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Wczytywanie katalogu temp"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Odbieranie podstawowych informacji z info pobieranego pliku"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Tworzenie pliku docelowego"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Ładowanie danych ze starego pobieranego pliku (%u z %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Zapisywanie bloku w nowym pojedynczym pobieranym pliku (%u z %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Odbieranie informacji o źródłach pobieranego pliku"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Dodawanie pobierania i zapisywanie nowego pliku części"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Import pliku części"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Stan"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Skrót pliku"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Dysk: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Proszę wybraćkatalog w celu poszukiwania tymczasowych pobierań! (Podkatalogi zostaną uwzględnione)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Czy chcesz, aby źródła pomyślnie zaimportowanych pobierań zostały usunięte?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Usunąć źródła?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "BŁĄD: Nie udało się utworzyć pliku części)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Próbuję załadować kopię zapasową pliku met z %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "BŁĄD: Nie udało się otworzyć pliku part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "BŁĄD: plik part.met ma zerowy rozmiar: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "BŁĄD: Nieprawidłowa wersja pliku part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "BŁĄD: %s (%s) jest uszkodzony (zła ilość znaków), nie mogę otworzyć pliku."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "BŁĄD: %s (%s) jest uszkodzony (zła ilość znaków), nie mogę otworzyć pliku."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Próbuję odzyskać informacje o pliku..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Odzyskiwanie nienazwanego pliku - będę próbował odzyskać go jako RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Odzyskano wszystkie możliwe informacje o pliku :D - Próbuję ich użyć..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Nie mogę odzyskać informacji o pliku :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Nie udało się otworzyć: %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "OSTRZEŻENIE: %s może być uszkodzony (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "BŁĄD podczas zapisywania pliku części: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Awaria IO podczas zapisywania pliku części:"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Nie udało się zapisać pliku part.met.seeds dla %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5381,17 +5293,17 @@ msgstr[0] "Zapisano %i zarodek źródeł dla pliku części: %s (%s)"
 msgstr[1] "Zapisano %i zarodki źródeł dla pliku części: %s (%s)"
 msgstr[2] "Zapisano %i zarodków źródeł dla pliku części: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Zapisano %i zarodek źródeł dla pliku części: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Błąd podczas odczytu pliku źródeł plików części  (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5399,335 +5311,335 @@ msgstr[0] "Znaleziono uszkodzoną część (%d) w %d pliku części %s - FileRes
 msgstr[1] "Znaleziono uszkodzoną część (%d) w %d plikach części %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Znaleziono uszkodzoną część (%d) w %d plikach części %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Znaleziono kompletnych części (%i) w %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Skończono ponowne tworzenie skrótu %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Nieoczekiwany błąd podczas zakańczania %s. Plik wstrzymany"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Skończono pobieranie: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Skończono pobieranie: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Usuwanie pliku: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "OSTRZEŻENIE: Nie można utworzyć skrótu pobranej części - zestaw skrótów jest niekompletny dla '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "BŁĄD: Nie można utworzyć skrótu pobranej części - zestaw skrótów niekompletny (%s). Nie powinno do tego dojść"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "UWAGA: Niewystarczająca ilość wolnego miejsca! Wstrzymywanie pliku: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Pobrana część %i jest uszkodzona w pliku: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Odzyskano uszkodzoną część %i dla %s -> Zapisanych bajtów: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Alokuję"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Niewystarczająca ilość przestrzeni dyskowej"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Pobrano"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Połączenie"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Katalogi"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serwery"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Pliki"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfejs"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Zdalna kontrola"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Sygnatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Zawansowane"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Zdarzenia"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debugowanie"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5737,15 +5649,15 @@ msgstr ""
 "    %PARTFILE - pełna ścieżka do pliku\n"
 "    %PARTNAME - tylko nazwa pliku"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5759,35 +5671,35 @@ msgstr ""
 "\n"
 "aMule będzie działał prawidłowo bez zmiany tych ustawień."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Błąd połączenia Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z Cfg do widżetu z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Typ serwera proxy do którego się łączysz"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Błąd przesyłania danych połączenia z widżetu do Cfg z identyfikatorem %d i kluczem %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Sprawdzam hasło\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5795,45 +5707,45 @@ msgstr ""
 "aMule musi zostać zrestartowany przed wprowadzeniem tych zmian:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Zmieniono port TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Zmieniono port UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Nowe zewnętrzne połączenie zaakceptowane"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Zewnętrzne połączenie zamknięte."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Maskowanie protokołu"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5841,7 +5753,7 @@ msgstr ""
 "Twoja lista auto-aktualizacji serwerów jest pusta.\n"
 "'Autoaktualizacja listy serwerów przy starcie' zostanie wyłączona."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5849,33 +5761,33 @@ msgstr ""
 "Połączenia zewnętrzne zostały włączone, ale nie zostało podane hasło.\n"
 "Połączenia zewnętrzne nie mogą być włączone dopóki nie zostanie podane poprawne hasło."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Zmieniono język.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Zmieniono folder tymczasowy.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- sieć ED2K włączona.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Zła wersja protokołu."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5883,7 +5795,7 @@ msgstr ""
 "Zarówno sieć eD2K jak i Kad zostały wyłączone.\n"
 "Nie będzie możliwe połączenie, dopóki nie włączysz przynajmniej jednej z nich."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5891,7 +5803,7 @@ msgstr ""
 "Kad nie uruchomi się, jeśli twój port UDP jest wyłączony.\n"
 "Włącz port UDP lub wyłącz Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5901,69 +5813,69 @@ msgstr ""
 "Musisz zrestartować teraz aMule.\n"
 "Jeśli nie zrestartujesz go teraz, nie narzekaj, jeśli stanie się coś złego.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Folder dla pobranych plików tymczasowych"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Ustawione hasło i włączone połączenia zewnętrzne."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5973,24 +5885,24 @@ msgstr ""
 "Proszę wpisać co najmniej jeden URL wskazujący poprawny plik server.met.\n"
 " Kliknij na przycisku \"Lista\", aby wpisać URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Pliki tymczasowe"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Pliki przychodzące"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Sygnatury Online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Wybierz folder na %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5998,42 +5910,42 @@ msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Szukaj odtwarzacza filmów"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Wybierz przeglądarkę"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Program%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Edytuj listę serwerów"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6041,42 +5953,42 @@ msgstr ""
 "Dodaj jeden URL w każdej linii.\n"
 "Tylko jeden URL w każdej linii."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Pełne źródła"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6084,7 +5996,7 @@ msgstr[0] "Opóźnienie odświeżania: %d sekunda"
 msgstr[1] "Opóźnienie odświeżania: %d sekundy"
 msgstr[2] "Opóźnienie odświeżania: %d sekund"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6092,12 +6004,12 @@ msgstr[0] "Czas dla przeciętnego wykresu: %d minuta"
 msgstr[1] "Czas dla przeciętnego wykresu: %d minuty"
 msgstr[2] "Czas dla przeciętnego wykresu: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Skala wykresu połączeń: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6105,7 +6017,7 @@ msgstr[0] "Rozmiar bufora pliku: %d bajt"
 msgstr[1] "Rozmiar bufora pliku: %d bajty"
 msgstr[2] "Rozmiar bufora pliku: %d bajtów"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6113,7 +6025,7 @@ msgstr[0] "Rozmiar kolejki wysyłania: %d klient"
 msgstr[1] "Rozmiar kolejki wysyłania: %d klientów"
 msgstr[2] "Rozmiar kolejki wysyłania: %d klientów"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6121,236 +6033,236 @@ msgstr[0] "Odświeżanie połączeń do serwera co: %d minutę"
 msgstr[1] "Odświeżanie połączeń do serwera co: %d minuty"
 msgstr[2] "Odświeżanie połączeń do serwera co: %d minut"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Odświeżanie połączeń do serwera co: Wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "wyłączone"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Wykonaj komendę przy wydarzeniu `%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Włącz wykonanie komendy w rdzeniu"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Komenda rdzenia:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Włącz wykonanie komendy w GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Komenda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Następujące zmienne zostaną zastąpione:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Udostępnione foldery"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Ostrzeżenie wyszukiwania"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Główne"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Nie można wykonać wyszukiwania eD2K, jeśli eD2K nie jest połączony"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Słowa kluczowe dla wyszukiwania: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nieoczekiwany błąd podczas próby wyszukiwania Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID pliku"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nieoceniony"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Pobieranie w kategorii"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Dodaj opcjonalny URL dla tego pliku"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Szukaj powiązanych plików (eD2k, serwer lokalny)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Oznacz jako znany plik"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiuj link eD2k do schowka"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jesteś połączony do serwera który chcesz usunąć. Proszę rozłącz się najpierw."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Anulowane"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nowy"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Nie udało się połączyć do wszystkich zamaskowanych serwerów na liście. Próbuję ponownie bez maskowania."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Nie udało się połączyć do wszystkich zamaskowanych serwerów na liście. Próbuję ponownie bez maskowania."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Nie udało się połączyć do serwerów z listy. Kolejne podejście."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Nie udało się połączyć do serwerów z listy. Kolejne podejście."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Sieć eD2K wyłączona w preferencjach, nie łączę."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Nie ma poprawnych serwerów do połączenia na liście"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Połączony z %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Nawiązano połączenie z: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Błąd krytyczny podczas próby łączenia. Może nie ma połączenia do internetu"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Utracono połączenie z %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) wygląda na wyłączony."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) wygląda na pełny."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6358,48 +6270,48 @@ msgstr[0] "Automatyczne łączenie do serwera nastąpi za %d sekundę"
 msgstr[1] "Automatyczne łączenie do serwera nastąpi za %d sekundy"
 msgstr[2] "Automatyczne łączenie do serwera nastąpi za %d sekund"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Łączenie z %s (%s:%i) nieudane."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "BŁĄD: nieprawidłowe gniazdo przy sprawdzaniu timeouta"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Próba połączenia z %s (%s:%i) przedawniła się."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Otrzymano późny wynik wyszukiwania DNS, odrzucanie."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Otwieram plik server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Nieznaleziono pliku server.met!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Nie udało się załadować pliku server.met '%s', napotkano nieznany format."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Nie udało się otworzyć server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Uszkodzony plik server.met, znaleziono nieprawidłowy versiontag: 0x%x, rozmiar %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6407,7 +6319,7 @@ msgstr[0] "%i serwer znaleziono w server.met"
 msgstr[1] "%i serwery znaleziono w server.met"
 msgstr[2] "%i serwery znaleziono w server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6415,237 +6327,236 @@ msgstr[0] "%d serwer dodany"
 msgstr[1] "%d serwery dodane"
 msgstr[2] "%d serwerów dodanych"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Błąd IO podczas odczytu pliku %s: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serwer nie dodany: [%s:%d] nie określa prawidłowego portu."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serwer nie dodany: Ten IP [%s:%d] jest filtrowany lub niepoprawny."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serwer nie dodany: Serwer z takim IP:Portem [%s:%d] znaleziony na liście."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Serwer dodany: Serwer na [%s:%d] używający nazwy '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Jesteś połączony do serwera który chcesz usunąć. Proszę rozłącz się najpierw."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Nie udało się otworzyć '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Nie udało się zapisać server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Nieprawidłowy URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Zakończono pobieranie listy serwerów z %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Brak wpisu listy adresów serwerów w 'addresses.dat'. Wklej prawidłową listę adresów do tego pliku, aby automatycznie zaktualizować listę twoich serwerów"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Rozpocznij pobieranie listy serwerów z %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "UWAGA: określono nieprawidłowo adres URL dla autoaktualizacji serwerów: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Niepoprawny url do auto-pobierania serwer.met w adresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Nie udało się pobrać listy serwerów z %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Serwer lokalny jest filtrowany przez IPFilters, podłączam ponownie do innego serwera!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nazwa serwera"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adres"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Opis"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Użytkowników"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Stałe"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Wersja"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Próbujesz usunąć serwer z którym jesteś połączony. Proszę się najpierw rozłączyć. Serwer NIE został usunięty."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nieznana nazwa)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Na pewno chcesz usunąć serwer statyczny %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serwery (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Serwer"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Połącz z serwerem"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Oznacz serwer jako statyczny"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Oznacz serwer jako nie statyczny"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Oznacz serwery jako statyczne"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Oznacz serwery jako nie statyczne"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Usuń serwer"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Usuń serwery"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Usuń wszystkie serwery"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Skopiuj linki eD2k do schowka"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Połącz ponownie z serwerem"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Na pewno chcesz usunąć wszystkie serwery?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Jesteś pewien, że chcesz usunąć wybrany serwer?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Jesteś pewien, że chcesz usunąć wybrane serwery?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "BŁĄD: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "OSTRZEŻENIE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Twoje nowe id to %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "OSTRZEŻENIE: Otrzymałeś Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tNajprawdopodobniej jest to spowodowane tym, że jesteś za firewallem lub routerem."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPo więcej informacji udaj się na https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Otrzymane info nieznanego serwera! - za krótkie"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6653,178 +6564,178 @@ msgstr[0] "Otrzymano %d nowy serwer"
 msgstr[1] "Otrzymano %d nowe serwerów"
 msgstr[2] "Otrzymano %d nowych serwerów"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Zapisywanie listy serwerów zakończone."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Serwer odrzucił ostatnią komendę"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Otrzymano podrobiony pakiet z serwera: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Nieobsługiwany błąd w trakcie przetwarzania pakietu z serwera: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Nie mogę utworzyć wątku rozwiązywania dns dla połączenia do %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP serwera %s (%s) jest filtrowane. Nie łącze."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "używa maskowania protokołu."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Łączę z  %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Nie mogę rozwiązać dns dla serwera %s: Nie mogę połączyć!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Logi aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serwer nie dodany: Nie podano IP lub nazwy hosta."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serwer nie dodany: Podano nieprawidłowy port serwera."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Status eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Stan połączenia:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Połączony"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Status Kademlii:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Uruchomiony na %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Uruchomiony"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Status Kademlii:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Stan połączenia:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Za firewallem - otwórz port %d TCP w routerze lub firewallu"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Stan połączenia UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Za firewallem - otwórz port %d UDP w routerze lub firewallu"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Stan firewalla: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Bez wymagania kolegi - otwarty port TCP"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Bez wymagania kolegi - otwarty port UDP"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Brak kolegów"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Łączenie do kolegi"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Łączenie do kolegi przy %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indeksowane źródła:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indeksowane słowa kluczowe:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indeksowane uwagi:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Załadowane indeksowania:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Średnio użytkowników:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Średnio plików:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Nie uruchomiony"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Dodawanie pliku %s do udostępnień"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6832,7 +6743,7 @@ msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6840,7 +6751,7 @@ msgstr[0] "Znaleziono %i znany udostępniony plik, %i nieznanych"
 msgstr[1] "Znaleziono %i znane udostępnionych plików, %i nieznanych"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików, %i nieznanych"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6848,420 +6759,420 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "BŁĄD: Próba udostępnienia %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Nie znaleziono katalogu udostępnionego, pomijam: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nazwa uzytkownika"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Prędkość pobierania"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Prędkość wysyłania"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Dostępne części"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Status wysyłania"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Status pobierania"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Źródło"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nazwa pliku lokalnego"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Udostępnione pliki"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Otrzymane części"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Ścieżka katalogu"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Dodaj komentarz/ocenę"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Edytuj komentarz/ocenę"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Dodaj pliki kolekcji do listy pobierania"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopiuj magnet &URI do schowka"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopiuj link eD2k do schowka (Ź&ródło)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopiuj link eD2k do schowka (Źródło) (&Z opcjami Crypt)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopiuj link eD2k do schowka (Nazwa &hosta)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopiuj link eD2k do schowka (Nazwa hosta) (Z opcjami &Crypt)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopiuj link eD2k do schowka (Informacje &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopiuj link eD2k do schowka (Informacje &AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Potrzebujesz HighID, aby stworzyć poprawny link źródłowy"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Nazwa pliku"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Wysłane dane (Sesja (Razem)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Łączny narzut  (Pakiety): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Narzut żądań pliku (Pakiety): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Narzut wymiany źródeł (Pakiety): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Narzut serwera (Pakiety): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Narzut Kad (Pakiety): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Narzut Crypt (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktywne wysyłanie: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Oczekujące wysyłanie: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Całkowita ilość udanych sesji wysyłania: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Całkowita ilość nieudanych sesji wysyłania: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Średni czas wysyłania: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Pobrane dane (Sesja (Razem)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Znaleziono źródła: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktywne pobieranie (części): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Stosunek UL:DL sesji (Razem): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Średnie tempo pobierania (sesja): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Średnie tempo wysyłania (sesja): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Maksymalne tempo pobierania (sesja): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Maksymalne tempo wysyłania (sesja): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Ponowne łączenia: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Czas od pierwszego transferu: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Podłączony do serwera od: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktywne połączenia (szacunkowo): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Osiągnięto maks. limit połączeń: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Średnio połączeń (szacunkowo): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Szczytowe połączenia (szacunkowo): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienci"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Nieznane: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrowane: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Zbanowane: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Razem: %i Znanych: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Działające serwery:  %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Niedziałające serwery: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "W sumie: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Usunięte serwery: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Przefiltrowane serwery: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Użytkowników na działających serwerach: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Plików na działających serwerach:  %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "W sumie użytkowników: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "W sumie plików: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zajętość serwera: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Liczba udostępnianych plików: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Łączny rozmiar udostępnianych plików: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Średni rozmiar pliku: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "System operacyjny"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Nie otrzymano"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktywnych połączeń (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Niedostępny"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nigdy"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Komenda `%s' z pid `%d' zakończyła działanie ze statusem `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Wykonaj <str> i wyjdź."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Niepoprawny format IP. Użyj xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Komenda ta wymaga argumentu. Prawidłowe argumenty: 'all', nazwa pliku lub liczba.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Przetwarzanie przez skrót: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Przetwarzanie przez nazwę pliku: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Komenda ta wymaga argumentu. Prawidłowe arguentu: skrót pliku.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Niepoprawny numer\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Nieprawidłowy skrót (długość powinna wynosić dokładnie 32 znaki)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7270,7 +7181,7 @@ msgstr "Wpisz '%s' , aby uzyskać więcej pomocy.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7279,89 +7190,87 @@ msgstr "Wpisz '%s' , aby uzyskać więcej pomocy.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Wpisz '%s' , aby uzyskać więcej pomocy.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Rozmiar pobierania: %i"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Żądanie nie powiodło się z powodu nieznanego błędu."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operacja zakończona pomyślnie."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Żądanie nieudane z powodu błędu: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtrowanie IP klientów jest %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "WYŁĄCZONE"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "WŁĄCZONE"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtrowanie IP serwerów jest %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Aktualny poziom filtra IP to %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limity przepustowości: Up: %u kB/s, Down: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Połączony z %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Łącze"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "za firewallem"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7370,7 +7279,7 @@ msgstr ""
 "\n"
 "Pobieranie:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7379,7 +7288,7 @@ msgstr ""
 "\n"
 "Wysyłanie:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7388,7 +7297,7 @@ msgstr ""
 "\n"
 "Klientów w kolejce:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7397,47 +7306,47 @@ msgstr ""
 "\n"
 "Razem źródeł:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Plik części]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Liczba wyników wyszukiwania: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "Pokaż procent postępu"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Otrzymano nieznaną odpowiedź z serwera, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Pokaż krótką informację o statusie."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Pokaż stan połączenia, obecne prędkości wysyłania/pobierania itd.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Pokaż pełne drzewo statystyk."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7451,11 +7360,11 @@ msgstr ""
 "\n"
 "Przykład: 'statistics 5' wyświetli tylko 5 pierwszych wersji dla każdego typu klienta.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Wyłącz aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7465,35 +7374,35 @@ msgstr ""
 "Spowoduje to również wyłączenie klienta tekstowego, ponieważ jest on bezużyteczny\n"
 "bez działającego rdzenia.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Przeładowuje podany obiekt."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Przeładowuje tabelę filtrowania IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Przeładowuje bieżącą tabelę filtrowania IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Aktualizuje tabelę filtrowania IP z adresu URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Jeśli adres URL zostanie pominięty to używany będzie adres URL z listy preferencji."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Połącz z siecią."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7505,35 +7414,35 @@ msgstr ""
 "tylko z tym serwerem. IP musi być adresem IPv4\n"
 "lub odczytywalną nazwą DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Połącz tylko z eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Połącz tylko z Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Rozłącz z siecią."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Spowoduje to rozłączenie z wszystkich sieci, które są obecnie włączone.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Rozłącz tylko z eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Rozłącz tylko z Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Dodaje link eD2k lub magnet do rdzenia."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7551,51 +7460,51 @@ msgstr ""
 "\n"
 "Magnet link musi zawierać skrót eD2k i długość pliku.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Ustaw wartość opcji."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Ustaw preferencje filtrowania IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Włącz filtrowanie IP klientów i serwerów."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Wyłącz filtrowanie IP klientów i serwerów."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Włącz/wyłącz filtrowanie IP klientów."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Włącz filtrowanie IP klientów."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Wyłącz filtrowanie IP klientów."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Włącz/Wyłącz filtrowanie IP serwerów."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Włącz filtrowanie IP serwerów."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Wyłącz filtrowanie IP serwerów."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Wybierz poziom filtrowania IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7603,74 +7512,74 @@ msgstr ""
 "Prawidłowe poziomy filtrowania mieszczą się w zakresie 0-255, a wartością\n"
 "domyślną (początkową) jest 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Ustaw limity przepustowości."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Wartości podane w tych komendach muszą być w kilobajtach/sekundę.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Ustaw limit przepustowości wysyłania."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Wartości podane w tych komendach muszą być w kilobajtach/sekundę.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Ustaw limit przepustowości pobierania."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Wartości podane w tych komendach muszą być w kilobajtach/sekundę.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Pobierz i wyświetl wartość preferencji."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Pobierz preferencje filtrowania IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Pobierz stan filtrowania IP zarówno dla klientów i serwerów."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Pobierz stan filtrowania IP tylko dla klientów."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Pobierz stan filtrowania IP tylko dla serwerów."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Pobierz poziom filtrowania IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Pobierz limity przepustowości."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Wykonuje wyszukiwanie."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7689,44 +7598,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Wykonuje globalne wyszukiwanie."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Wykonuje lokalne wyszukiwanie"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Wykonuje wyszukiwanie kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Pokazuje wyniki ostatniego wyszukiwania."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Pokazuje postęp wyszukiwania."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Rozpocznij pobieranie pliku"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7734,81 +7643,81 @@ msgstr ""
 "Musi zostać podany numer pliku z ostatniego wyszukiwania.\n"
 "Przykład: 'download 12' rozpocznie pobieranie pliku o numerze 12 z poprzedniego wyszukiwania.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Wstrzymaj pobieranie."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Wznów pobieranie."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Anuluj pobieranie."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Ustaw priorytet pobierania."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Ustaw priorytet pobierania na Niski, Normalny, Wysoki lub Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Ustaw priorytet na niski."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Ustaw priorytet na normalny."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Ustaw priorytet na wysoki."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Ustaw priorytet na auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Pokaż kolejki/listy."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Pokazuje kolejkę wysyłania/pobierania, listę serwerów lub listę udostępnionych plików.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Pokaż kolejkę wysyłania."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Pokaż kolejkę pobierania."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Pokaż log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Pokaż listę serwerów."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Przeładowuje listę udostępnionych plików."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Zresetuj log."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Wycofywana komenda, użyj '%s' zamiast niej."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7817,262 +7726,259 @@ msgstr ""
 "Komenda ta jest wycofywana i może zostać usunięta w przyszłości.\n"
 "Użyj zamiast niej '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Tekstowy klient aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konwertuję stare zestawy skrótów AICH w '%s' do 64b w '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "UWAGA: Nazwa pliku '%s' jest nieprawidłowa i została zmieniona na '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "UWAGA: Plik '%s' już istnieje, zmieniono nazwę na '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Jesteś pewien, że chcesz anulować i usunąć wszystkie pliki z tej kategorii?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Wymagane potwierdzenie"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Zbyt dużo połączeń"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Wszystkie inne"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Dodaj kategorię"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Edytuj kategorię"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Usuń kategorię"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Żądanie skrótu dla nieznanego pliku: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Wznawianie wysyłania pliku: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Wstrzymywanie wysyłania pliku: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Nie powiodło się wykonanie komendy `%s' przy zdarzeniu `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Pobieranie zakończone"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Pełna ścieżka do pliku."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Nazwa pliku bez jego ścieżki."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Skrót eD2k pliku."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Rozmiar pliku w bajtach."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Łączny czas aktywności w pobieraniu."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Rozpoczęto nową sesję czatu"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Nadawca wiadomości."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Brak miejsca"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partycja dysku."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Błąd podczas ukończenia"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Przetwarzanie pliku numer %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Pytałeś o skróty części (Używane tylko dla plików > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Nie istniejący plik !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, kreator linków eD2k aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Witamy!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parametry wejściowe"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Plik do skracania"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Dodaj opcjonalny URL dla tego pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Wprowadź tutaj plik, którego link eD2k chcesz obliczyć"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Wprowadź tutaj adres URL, który chcesz dodać do linku eD2k: Dodaj / na końcu, aby pozwolić aLinkCreator dodać nazwę obecnego pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Utwórz link ze skrótami części"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Pomóż rozpowszechniać nowe i rzadkie pliki szybciej, kosztem zwiększenia rozmiaru linku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Skrót typu MD4 pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Skrót eD2k pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Skopiuj do schowka"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Otwórz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Otwórz plik, by obliczyć jego link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopiuj obliczony link ED2k do schowka"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Zapisz jako"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Zapisz obliczony link ED2k do pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Informacje o aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Zaznacz plik, którego link eD2k chcesz obliczyć"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Nie można otworzyć schowka"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "W tej chwili nie ma nic do skopiowania !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Wybierz plik do twojego obliczonego linku eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Nie mogę otworzyć "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Proszę wpisać nazwę pliku"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "W tej chwili nie ma nic do zapisania !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8092,167 +7998,159 @@ msgstr ""
 "\n"
 "Dystrybucja na zasadach GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Tworzę skrót..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator pracuje dla ciebie"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Obliczenie Hashu MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Obliczenie Hashów eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Anulowano !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Gotowe w %.2f ach"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Masz już dodany ten URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Proszę wpisać adres URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Nie mogę otworzyć %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dni %i godzin %i minut %i "
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, statystyki aMule online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Maksymalna szybkość DL od czasu uruchomienia wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolutne maksimum szybkości DL podczas poprzedniego uruchomienia wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Resetuj"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "System"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Zatrzymaj automatyczne odświeżanie"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Zapisz obrazek statystyk online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Wydrukuj obrazek statystyk online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Ustawienia preferencji"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Informacje o wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Rozpocznij automatyczne odświeżanie"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Automatyczne odświeżanie zatrzymane"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "automatyczne odświeżanie rozpoczęte"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Zapisz obrazek statystyk"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Statystyki aMule online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8260,11 +8158,11 @@ msgstr ""
 "Wystąpił problem podczas drukowania.\n"
 "Może nie masz prawidłowo ustawionej drukarki ?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Drukuję"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8282,403 +8180,392 @@ msgstr ""
 "\n"
 "Dystrybucja na zasadach GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Och och, aMule nie jest uruchomiony..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule jest uruchomiony"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule jest uruchomiony, ale nie połączony"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule łączy się..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Och och, status aMule jest nieznany..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " jest uruchomiony od "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " jest zatrzymany !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " jest nie połączony!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " łączy się..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " robi coś dziwnego, sprawdź to !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " jest połączony z "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "wyłączony"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " jest włączony "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " z "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Razem pobranych: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Wysłanych: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Pobranych w sesji: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Pobranych: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Wysłanych: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Udostępnione: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " plik(ów), Klientów w kolejce: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Czas: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " na "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Średnie obciążenie systemu (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Uptime systemu: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Katalog zawierający plik amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Podaj katalog z twoim plikiem amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Czas pomiędzy odświeżeniami w sekundach"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Generuj obrazek statystyk przy każdym odświeżeniu"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Wpisz katalog, w którym chcesz generować obrazki statystyk"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Wysyłaj cyklicznie twój obrazek statystyk na serwer FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Url FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Ścieżka FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Wpisz URL twojego serwera FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Wpisz katalog do składowania twoich obrazków statystyk na serwerze FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Użytkownik"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Wpisz nazwę użytkownika. aby zalogować się do twojego serwera FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Wpisz hasło użytkownika. aby zalogować się do twojego serwera FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Czas pomiędzy odświeżeniami FTP w minutach"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Sprawdź"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Katalog zawierający twój plik sygnatury"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Katalog gdzie będzie wygenerowany statyczny obrazek"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Ładuje szablon <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Port HTTP serwera sieciowego"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Użyj forwardowania portu UPnP na porcie serwera sieciowego"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Port UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Hasło pełnego dostępu do serwera sieciowego"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Hasło gościa do serwera sieciowego"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Pozwól na dostęp gości"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Zabroń dostępu gościom"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Wczytaj/zapisz ustawienia serwera sieciowego z/do zdalnego aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Ścieżka do pliku konfiguracyjnego aMule. NIE UŻYWAJ BEZPOŚREDNIO!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Zablokuj interpreter PHP (wycofywany)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Przekompiluj strony PHP przy każdym żądaniu"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Serwer WWW aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "zaakceptowano połączenie klienta sieciowego\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "BŁĄD: nie można zaakceptować połączenia klienta internetowego\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Żądanie nie powiodło się z powodu błędu: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Nie znaleziono pliku indeksu: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesja wygasła - żądanie loginu\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesja ok, zalogowano\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesja ok, nie zalogowano\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nie otwarto sesji - zażądam loginu\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Utworzono sesję - żądam loginu\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Przetwarzam żądanie (oryginalne): "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nie podano hasła, logowania nie będą akceptowane."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Sprawdzam hasło\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Nieprawidłowy skrót hasła\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Hasło ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Złe hasło\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Nie wprowadziłeś hasła. Puste hasło nie jest dozwolone.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Zażądano wylogowania\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Przetwarzam żądanie (przekierowane): "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Nieudane połączenie "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -27,19 +27,19 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "Sobre o aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Controle Remoto do aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,7 +47,7 @@ msgstr ""
 "Cliente p2p 'multi-plataforma' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -55,76 +55,76 @@ msgstr ""
 "Direitos Reservados (c) 2003-2026 Equipe do aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado no \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: roteamento peer-to-peer baseado em métrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Direitos autorais reservados (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Página Web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Documentação:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Problemas:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Clique para conferir se existe uma versão nova ao iniciar."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Conferir existência de atualizações"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "Conferindo a existência de atualizações..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "Você está rodando a última versão do aMule."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Uma versão nova (%s) está disponível:"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "Não foi possível conferir a existência de atualizações. Tente novamente mais tarde."
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Adicionar um amigo"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Você deve digitar um IP e porta válidos!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informação"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "A Hash do usuário especificado é inválida!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -138,47 +138,46 @@ msgstr ""
 "\n"
 "Deseja instalar agora a integração com o desktop?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "Adicionar o aMule ao seu menu de aplicativos?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Instalar"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Agora não"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Não perguntar novamente"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Não foi possível instalar a integração com o desktop: a variável de ambienteAPPDIR não está setada. Normalmente isto significa que a AppImage foi lançada de uma forma não padrão."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "A integração do aMule falhou"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Não foi possível instalar a integração com o desktop: falha ao criar %s. Confira se seu diretório de usuário tem permissão de escrita."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Não foi possível instalar a integração com o desktop: falha escrevendo %s. Confira se seu diretório de usuário tem permissão de escrita."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "Integração do AppImage: aMule foi adicionado ao seu menu de aplicativos (%d atalhos do shell em ~/.local/bin)."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -192,103 +191,100 @@ msgstr ""
 "\n"
 "Reiniciar agora o aMule?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule instalado"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Reiniciar agora"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Mais tarde"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Falha ao abrir arquivo de Ligações ED2K."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma ligação eD2k quando tem um lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Agora, deixando a aplicação principal..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Matando a instância do amuleweb com o pid '%d'... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Falha"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Terminando a instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Matando a instância do amuleapi com o pid '%d'... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Finalizando o núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Encerramento do aMule completo."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração da memória para a saída do aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "Conectando o tráfego par-a-par do aMule para a interface: %s (atualizações via HTTP usam a rota padrão)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Canectando todo o tráfego de rede à interface: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "AVISO: a interface de rede configurada '%s' não foi encontrada - o tráfego não está conectado a ela e pode sair pela rota padrão. Confira o nome da interface em Preferências."
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "AVISO: para conectar-se à interface de rede '%s' são necessários privilégios elevados e NÃO FOI aplicado - o tráfego pode sair pela rota padrão. Condeda a capacidade (e.g. 'sudo setcap cap_net_raw+ep') ao binário do aMule ou rode-o com privilégios suficientes."
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "AVISO: não foi possível conectar-se à interface de rede '%s' - o tráfego pode sair pela rota padrão."
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Seu locale foi alterado para o padrão do Sistema devido a mudança na configuração. Desculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -296,20 +292,19 @@ msgstr ""
 "\n"
 "Configuração EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Senha definida e conexões externas habilitadas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "CUIDADO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -317,51 +312,48 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web server rodando no pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi rodando com pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Você pediu para rodar o amuleapi na início, mas o binário do amuleapi não pode ser rodado. Por favor instale o pacote contendo o servidor REST API do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível conectar às portas desse endereço: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u não disponível. Você ficará com LOWID (id baixa)\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,49 +368,49 @@ msgstr ""
 "\n"
 "Verifique sua rede para ver se essa porta está aberta para entrada e saída."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Falha ao criar o arquivo OnlineSig do aMule"
 
 # src/amuled.cpp:1246:
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Parece que o idioma selecionado não está instalado no seu computador. (Nota: eu irei defini-lo mesmo assim)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Essa é a primeira vez que você executa o aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Essa é uma versão de testes, atualizada diariamente, e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não daremos garantia se ela quebrar algo, queimar sua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar seu cachorro. Mas ela *deve* ser segura para uso mesmo assim.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Maiores informações, suporte e novas versões podem ser encontradas em nossa\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "homepage https://amule-org.github.io ou em nosso canal de irc #aMule na irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja a vontade para notificar qualquer bug em https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -426,222 +418,218 @@ msgstr ""
 "A pasta especificada para os arquivos da Online Signature é INVÁLIDA!\n"
 "OnlineSignature ficará DESATIVADA até você atualizar as preferências."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Pré-alocação de espaço em disco para arquivo '%s' falhou: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não foi possível abrir arquivo de log"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o arquivo de log está vazio. Algo está errado."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Arquivo de log resetado"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "MensagemDoServidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Pulando o download de %s, pois o arquivo requerido não é o mais novo."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Falha ao obter a lista de nodes."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir arquivo de versão baixado"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Arquivo de versão corrompido"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Você está utilizando uma versão anterior do aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A mais recente versão pode ser obtida em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "CUIDADO: Sua versão do aMuled esta ultrapassada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Sua cópia do aMule está em dia."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Falha ao baixar arquivo de controle de versão"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Usuários:%s | Arquivos: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Usuários: E: %s K: %s | Arquivos: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nenhuma rede selecionada"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "com HighID (Id alta)"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectando a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desconectado de eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad iniciado."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad parado."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Conectado a rede Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectado a rede Kad (sob firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desconectado da rede Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se a porta UDP está desabilitada em preferências, não iniciará."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "A rede Kad está desabilitada em preferências, não iniciará."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERRO: O daemon aMule não pode ser usado quando conexões externas estão desabilitadas. Para habilitar Conexões Externas, use também um aMule normal, inicie o amuled com a opção --ec-config ou mude o comando\"AcceptExternalConnections\" para 1 no arquivo ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERRO: Uma senha válida é requirida para conexões externas, e o daemon aMule não pode ser usado sem conexões externas. Pra rodar o daemon aMule, você deve definir a campo \"ECPassword\" no arquio ~/.aMule/amule.conf com o valor apropriado. Execute o amuled com a opção --ec-config para definir a senha. Mais informações podem ser encontradas em https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - iniciando temporizador"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Incapaz Criar Arquivo Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esse é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Uma versão mais nova está disponível"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -656,191 +644,184 @@ msgstr ""
 "\n"
 "Você gostaria de abrir a página de download?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Sem redes"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Controle remoto do aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Erro Fatal: Falha ao criar Core Timer"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Conectar a aMule remoto"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Conexão perdida"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "Abortar a edição e sair"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "Reconectando... (tentativa %d)"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "Próxima tentativa em %d s..."
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -853,40 +834,40 @@ msgstr ""
 "\n"
 "A interface foi pausada até que a conexão seja reestabelecida."
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Erro Fatal: Falha ao criar Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Repetição de evento..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Conectando..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "A conexão falhou. Por favor, confira o anfitrião, porta e senha."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Manipulador de evento GUI EC remoto"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Falha na conexão. Incapaz de conectar em %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Desligando"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "O tempo para a tentativa de reconectar foi expirado; tentando novamente."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -895,681 +876,658 @@ msgstr ""
 "Tempo expirado na conexão. Incapaz de atingir %s:%d dentro do tempo alocado.\n"
 "Por favor, confira o host, porta e que aMule esteja rodando com a opção de Conexões Externas habilitada."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "A conexão com o núcleo remoto foi perdida. Tentando reconectar..."
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "Reconectado ao núcleo remoto."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentativa de reconexão %d: conectando-se a %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "A reconexão não pode ser iniciada; tentando novamente em breve."
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Pronto"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Tudo"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "não é possivel ler"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "não encontrado"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "O núcleo rejeitou as seguintes pastas compartilhadas: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Link inválido ou já está na lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretório '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Procurando amigo para conexão lowid"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (versão de eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule Falso)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule Falso)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitado: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas dessa sessão: Aceito %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas dessa sessão: Aceitos %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas de todas as sessões: Aceito %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas de todas as sessões: Aceitos %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Solicitado um arquivo desconhecido"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensagem filtrada de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensagem de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuário %s (%u) solicitou sua lista de compartilhados para pasta não existente '%s' -> Negado"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "CUIDADO: %s não pode ser aberto."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "CUIDADO: Cancela lista de arquivos corrompida, contém cabeçalho inválido."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Erro de I/O ao ler arquivo %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Erro ao salvar arquivo %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nova Categoria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Escolha um diretório para os arquivos"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Você precisa dar um nome para a categoria!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Você precisa definir um caminho para a categoria!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Falha ao definir pasta para a categoria. Favor informar um caminho válido!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sessão de Chat iniciada: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Conectado ao Cliente ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Conectando ao Cliente ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Falha ao conectar ao Cliente / Conexão perdida ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Você tem que inserir a checagem captcha e o usuário terá recebido sua mensagem. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Sua resposta para o captcha esta errada e sua mensagem foi ignorada. Você pode requerer um novo captcha enviando uma nova mensagem. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Bate-papo"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Fechar aba"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Fechar todas as abas"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Fechar outras abas"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Adicionar aos Amigos"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Arquivo de créditos carregado, %u cliente reconhecido"
 msgstr[1] "Arquivo de créditos carregado, %u clientes reconhecidos"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Créditos expirados para %u cliente!"
 msgstr[1] " - Créditos expirados para %u clientes!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Arquivo 'cryptkey.dat' não foi encontrado, criando."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Suportado"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Incompleto"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Cara Mau"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Não Disponível"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Usuário %s (%u) pediu sua lista de shares -> Aceito"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Usuário %s (%u) pediu sua lista de shares -> Negado"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "O usuário %s (%u) solicitou sua lista de pastas compartilhadas -> Aceito"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "O usuário %s (%u) solicitou sua lista de pastas compartilhadas -> Negado"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Usuário %s (%u) solicitou sua lista de compartilhados para pasta '%s' -> aceito"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Usuário %s (%u) solicitou sua lista de compartilhados para pasta '%s' -> negado"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Usuário %s (%u) compartilha diretório '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Usuário %s (%u) enviou pastas não solicitadas."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Usuário %s (%u) enviou lista de compartilhamentos para pasta '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Usuário %s (%u) terminou de enviar seus compartilhamentos"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Usuário %s (%u) enviou compartilhamentos não solicitados"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Usuário %s (%u) negou o acesso a lista de arquivos compartilhados"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentários do arquivo"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nome do usuário"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do arquivo"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Avaliação"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentário"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "Não foi possível começar uma busca Kad"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "A busca do Kad não pode ser feita se o Kad não estiver rodando"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "Procurando por comentários em Kad..."
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Sem comentários"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentário"
 msgstr[1] "%u comentários"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "O cliente %s foi banido por enviar %s dados corrompidos de um total de %s para o arquio '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Falha ao obter a dados de país para '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Baixo]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [Normal]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Alto]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alto"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Muito Alto"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Lançamento"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Perguntando"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Conectando via servidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Fila de espera cheia"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na fila de espera"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Baixando"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Recebendo hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nenhuma parte necessária"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Não se pode conectar LowID com LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Excesso de conexões"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Conectando via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Muitas conexões Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Banido"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Erro ao conectar"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Fila de espera remota cheia"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "MlDonkey velho"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Novo MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatível com eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Servidor Local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Troca de Fontes"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passivo"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Link"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Fontes de arquivo"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultado da Busca"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Em progresso"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "ERRO: falta de espaço em disco"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "Erro: Partmet não encontrado"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERRO: erro de E/S!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Na fila de espera"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Já baixando"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Arquivo temp desconhecido ou danificado."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tempo Restante"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Última vez concluído"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Último recebimento"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Deseja remover os arquivo selecionado?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Deseja remover os arquivos selecionados?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1578,109 +1536,106 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Parar"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "Pau&se"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Continuar"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Limpar Down&loads concluídos"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Trocar cada entrada A4AF para este arquivo agora"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Trocar cada entrada A4AF para este arquivo (auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Trocar cada entrada A4AF para outro arquivo"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opções Extras"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Exibir &detalhes do arquivo"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Exibir todos os comentários"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiar URL Magnet para Área de Transferência"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copiar &link eD2k para área de transferência"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar retorno para a Área de Transferência"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "não definido"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Adicionar na Categoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Abrir &o arquivo"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Informe o novo nome para o arquivo:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Renomear"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "O manipulador de shell default do Windows"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1689,346 +1644,345 @@ msgstr ""
 "Para impedir que este aviso apareça em toda pré-visualização,\n"
 "defina seu tocador de vídeo preferido nas preferências (%s é o padrão)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Pré-visualização"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Falha ao executar o player de mídia externo! Comando: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Salvando PartFile %u de %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Todas PartFiles Salvas."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Carregando arquivos temp de %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Carregando PartFile %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERRO: Falha ao carregar arquivo de cópia. Procure em https://github.com/amule-org/amule/discussions para o .part.met recuperar soluções."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Todas PartFiles Carregadas."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nenhum arquivo parcial (.part) encontrado"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Encontrado %u arquivo parcial"
 msgstr[1] "Encontrados %u arquivos parciais"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "O sistema de arquivos para o diretório Temp não pode manusear grandes arquivos."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "O sistema de arquivos para o diretório Recebido não pode manusear grandes arquivos."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Baixando %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Ops! Você já está tentando baixar o arquivo '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Você já tem o arquivo '%s' (pedido como '%s')"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Você já tem o arquivo '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ops! Você já está tentando baixar o arquivo %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Não pode converter ligação magnética para eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocolo de link desconhecido: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "Não foi possível adicionar %u link (veja o log para detalhes)."
 msgstr[1] "Não foi possível adicionar %u links (veja o log para detalhes)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Pacote enviado por cliente após falha na autenticação."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Conexão externa encerrada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Conexões externas desativadas por não ter sido definida uma senha!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Conexões externas desativadas no arquivo de configuração"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Novas conexões externas aceitas"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: Não pôde aceitar uma nova conexão externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexão externa recusada por não ter sido definida uma senha nas preferências!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Cliente conectando: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Id de versão do EC incorreta, deve ser incompatibilidade binária. Use o core e o remote da mesma versão."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Você não pode conectar a uma versão oficial a partir de um cliente de desenvolvimento! *ufa* Possível travamento evitado"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versão do protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Falta tag de versão do protocolo."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autenticação falhou: hash inválido especificado como senha EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Falha na autenticação: senha errada."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Falha na autenticação: senha desconhecida."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Requisição inválida, por favor autentique primeiro."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Acesso liberado."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviar mensagem de erro \"%s\" para cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentativa de acesso de %s não autorizado. Conexão encerrada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Comando de PartFile remoto falhou: Filehash não encontrada: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Hash do arquivo não encontrada: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Processando erro OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "precisa definir o servidor a ser removido"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k foi desabilitado nas preferências."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Amigo não encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "Cliente não encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED requer EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa web pela interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Pesquisa em andamento, aguarde!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Sem dados para gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Seu cliente não está configurado para esse nível de detalhes."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Conexão Externa: requerido desligar"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Já estou desligando."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: adicionar link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d de %d links falharam (inválidos ou já estava na lista)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "A checagem de versão foi desacelerada; tente novamente em breve."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "A checagem de versão não está disponível neste daemon."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Arquivo não encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nome de arquivo inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Não foi possível renomear o arquivo."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad está desativado nas preferências."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Já conectado em eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Conectando em eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Já conectado a rede Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Conectando a rede Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desabilitadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desconectado de eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desconectado da rede Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexão Externa:opcode recebido inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "O opcode é inválido (versão errada do protocolo?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensão '%s' desconhecida para o comando '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comando desconhecido '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2036,7 +1990,7 @@ msgstr ""
 "\n"
 "Esse comando não precisa de argumentos.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Esse comando precisa de um argumento.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2052,7 +2006,7 @@ msgstr ""
 "\n"
 "Esse comando está incompleto, você precisa de uma das extensões abaixo.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2060,11 +2014,11 @@ msgstr ""
 "\n"
 "Extensões disponíveis:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comandos disponíveis:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2075,17 +2029,17 @@ msgstr ""
 "Todos os comandos não diferenciam letras maiúsculas de minúsculas.\n"
 "Digite '%s <comando>' para obter ajuda sobre o <comando>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Sair do programa."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Exibe a ajuda."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2093,7 +2047,7 @@ msgstr ""
 "Para obter ajuda sobre um comando, digite 'help <comando>'.\n"
 "Para obter a lista completa de comandos, digite 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2104,46 +2058,46 @@ msgstr ""
 "Use '%s' para lista de comandos\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Erro na sintaxe!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Erro processando comando - isso jamais deveria acontecer! Reporte o bug, por favor\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Este comando não precisa de parâmetros."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Este comando precisa de um parâmetro."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argumento inválido."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Este comando está incompleto."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Digite '%s' para maiores informações.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Este é %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Este é %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2151,7 +2105,7 @@ msgstr ""
 "\n"
 "Criando cliente..\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2160,7 +2114,7 @@ msgstr ""
 "\n"
 "Ok, abandonando %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2174,331 +2128,326 @@ msgstr ""
 "\n"
 "Finalizando...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Exibir esse texto de ajuda."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host onde o aMule está rodando. (padrão: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta em que o aMule está esperando Conexões Externas (padrão: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Senha para Conexão Externa."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Ler configuração de arquivo."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Não imprima mensagens em stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Seja verborrágico - mostre até as mensagens de debug."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Defina o locale (idioma)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Gravar opções de linha de comando."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Criar arquivo de configuração baseado no do aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Exibir versão do programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Força a compressão ZLIB independente da localidade IP discado (útil quando o servidor for alcançável por um túnel VPN que resolve para um IP de LAN)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "Acrescenta uma cópia de toda saída do console a este arquivo de log (padrão: <config-dir>/amuleapi.log)."
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "Não escrever um arquivo de log; imprimir apenas no console."
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalhes do Arquivo"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% concluído"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Bem-vindo!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Conectando ao amigo"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Tipo de Conexão:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Redes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Porta TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porta UDP estendida (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Habilitar UPnP para redirecionamento de porta do roteador"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Inicialização"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ops! Você já está tentando baixar o arquivo %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Lista de servidores auto-atualizáveis na iniciação"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar o aMule automaticamente quando eu logar no sistema"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para links ed2k://"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra o aMule para links \"magnet:\""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Pasta para arquivos temporários baixados"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para leitura!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amigos"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Exibir &Detalhes"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Adicionar amigo"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Remover amigo"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Enviar &Mensagem"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Exibir Arquivos"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Abrir slot para amigos"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Deseja eliminar o amigo selecionado de sua lista?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Deseja eliminar os amigos selecionados de sua lista?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2506,11 +2455,11 @@ msgstr ""
 "Você não pode definir mais de um slot para amigos.\n"
 " Apenas um foi definido."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Seleção múltipla"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2518,206 +2467,205 @@ msgstr ""
 "Você não pode definir mais de um slot para amigos.\n"
 " Apenas um foi definido."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Enviar mensagem ao usuário"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensagem a Enviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Remover dos amigos"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Enviar mensagem"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Trocar para esse arquivo"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Em Fila: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Pediu por outro arquivo"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Esperando por slot de upload"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Na fila: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nenhum"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sim"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Baixando..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "A URL para baixar não pode estar vazia"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Falha ao criar requisição HTTP para %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP download: corpo da resposta vazio para %s"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Não foi possível mover arquivo baixado para %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Baixados %s (%llu bytes)"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "A URL %s retornou: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Baixa HTTP falhou para %s: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 Não autorizado para %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Arquivo GeoLite2-Country.mmdb existente migrado para %s"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country: MaxMind foi selecionado como a fonte de GeoIP, mas não existe chave de licensa configurada. Abra Preferências -> IP2Country, e cole sua chave de licensa grátis da MaxMind e clique 'Atualizar agora'."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country: Uma URL Customizada foi selecionada como fonte de GeoIP, mas não existe URL configurada. Abra Preferências -> IP2Country, e forneça uma URL que aponte para um arquivo .nmdb (ou .gz / .tar.gz contendo um)."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country: falhou em resolver uma URL de download de GeoIP."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Baixando novo %s de %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Download de %s falhou, a atualização foi interrompida."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Falha ao remover o arquivo %s, a atualização foi interrompida."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Falha ao renomear arquivo %s, a atualização foi interrompida."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Atualização concluída %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "Erro ao atualizar %s"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "Falha no download de DB-IP para o mês corrente - tentando novamente com a URL do mês anterior."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Falha ao baixar %s de %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Carregando Filtros de IP 'ipfilter.dat' e 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Falha ao carregar arquivo ipfilter.dat '%s', formato desconhecido."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Falha ao carregar arquivo ipfilter.dat '%s', impossível abrir arquivo."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Carregada %u Faixa de IP de '%s'."
 msgstr[1] "Carregadas %u Faixas de IP de '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u linha malformada foi ignorada."
 msgstr[1] "%u linhas malformadas foram ignoradas."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Falha ao renomear novo arquivo %s, abortando atualização."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "Filtro IP está pronto"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2725,860 +2673,828 @@ msgstr ""
 "Inicializando com \n"
 "clientes conhecidos"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nós (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP Inválido para inicialização"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Porta inválida para inicialização"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Preencha todos os campos necessários"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Deseja baixar uma nova versão do arquivo nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Fazendo isso, seus nodes atuais serão removidos e a conexão Kademlia será reiniciada."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Continuar?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: chave de pesquisa muito curta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Termo para busca já está na lista de busca: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Falha ao ler o arquivo nodes.dat - muito velho. Essa versão (0) não é mais suportada."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Lendo %u contato Kad"
 msgstr[1] "Lendo %u contatos Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Nenhum contato encontrado, por favor reinicie, ou baixe um arquivo nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Somente %d de contato Kad disponível, nodes.dat não escrito"
 msgstr[1] "Somente %d de contatos Kad disponíveis, nodes.dat não escrito"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Gravado %d contato Kad"
 msgstr[1] "Gravados %d contatos Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Usuário Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "A busca de nota em Kad por '%s' não foi iniciada: Kad não está conectada"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "A busca de nota em Kad por '%s' não foi iniciada: uma busca de nota já está rodando para este arquivo"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "A busca de nota por '%s' não foi iniciada: o arquivo não está na lista de compartilhamento, na fila de downloads ou nos resultados da busca"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "A busca por nota em Kad por '%s' não foi iniciada: outra busca Kad (e.g. uma busca por fontes) já está usando o hash deste arquivo - tente novamente em breve"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "A busca por nota em Kad por '%s' não foi iniciada: falha na preparação de busca (PrepareLookup)"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nome do Arquivo"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tamanho do arquivo"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Taxa de compartilhamento"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Requisitado"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aceito"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fontes completas"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ATENÇÃO: Arquivo de lista known corrompido, contém cabeçalho inválido."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Falha ao carregar entrada em lista de arquivo known, arquivo pode estar corrompido"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida na lista de arquivo known, arquivo pode estar corrompido: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Erro desconhecido %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Incapaz obter descrição do erro para o erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Calculando hash"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Finalizando"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Com Erro"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Você deve informar uma senha não-vazia."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Senha inválida, não é um hash MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Falha ao conectar"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "Conexão externa perdida - saindo."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Conexão EC falhou. Resposta vazia."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Conexão Externa: Má resposta, handshake falhou. Conexão fechada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Sucesso! Conexão estabelecida ao aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Sucesso! Conexão estabelecida."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Conexão Externa: Acesso negado porque: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Conexão Externa: Handshake falhou."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Soquete de escuta: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERRO: Não pôde ouvir a porta TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERRO: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "CUIDADO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Fechar"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Recortar"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Selecionar Tudo"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Conectado (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Conectado (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Conectado (sob firewall)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Servidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "IP do servidor: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Não conectado"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Porta TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Porta TCP: Não está pronta"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Porta UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Porta UDP: Não está pronta"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informação do Cliente"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limite de envio"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limite de download"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostrar aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Ocultar aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sair"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menu do Tray aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limites de Velocidade:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Nenhum"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Nenhum"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocidade de Download: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocidade de Upload: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Apelido: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nenhum Nickname definido!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ClienteID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nome do Servidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP do Servidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Não conectado"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Signature: Ativado"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Signature: Desativado"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Tempo ligado: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Arquivos compartilhados: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Cliente na fila: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "DL Total: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "UL Total: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "Cole links eD2k ou magnet aqui"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "Adicionar links"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Clique aqui para adicionar a ligação eD2k no controle de texto para sua fila de download."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Os eventos são exibidos aqui. Para uma lista completa, veja o log na aba Servidores."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Carregando..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Número de usuários conectados neste servidor..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Usuários: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Usuários conectados a esse servidor e número estimado do total de usuários."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Média atual de Download e Upload. Se há número entre os parêntesis, significa que atingiu o número máximo de conexões com o cliente."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Exibe o status atual da conexão e transferências ativas. Seta VERMELHA significa que você não está conectado, AMARELA significa que você está com low ID (sob firewall) e VERDE significa que você está com uma Id Alta (High ID, o melhor tipo de conexão)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Não Conectado..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Servidor atualmente conectado."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parâmetros Estendidos"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrando"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipo de Arquivo"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arquivos"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Áudio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imagem-CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Figuras"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programas"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Textos"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vídeos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensão"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Tamanho Mínimo"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Tamanho Máximo"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponível"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Resultados do Filtro"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverter resultado"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Ocultar arquivos conhecidos"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Iniciar"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Mais"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Pedir para pares Kad que já responderam para alargar a busca. Cada clique interroga o próximo par mais próximo por mais contatos (KADEMLIA_FIND_VALUE_MORE), fazendo emergir casamentos de arquivos adicionais que a fronteira alfa inicial da busca perdeu."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Pare"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Reiniciar Campos"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Limpar downloads completados"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de arquivos:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Geral"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nome Completo:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "arquivo-met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tamanho :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferência"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Status parcial :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Última vez completo:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fontes encontradas:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Transferindo de (fontes):"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Contador de partes:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponíveis:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Taxa de transf.:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Tempo ativo de download: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferido :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamanho completo:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Manipulador Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdido ao corromper:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Ganho com compressão:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pacotes recuperados pelo I.C.H.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "Compartilhando"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Pedidos"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Pedidos aceitos"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Dados transferidos"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Taxa Compartilhada"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fontes Completas"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "Compartilhado desde"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "Ultimo upload"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "Informação da Mídia"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Comprimento:"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Taxa de Bits:"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Codec:"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Artista:"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Título:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nomes do arquivo"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Assumir"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Limpar"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comente/Avalie o arquivo (o texto será exibido para todos)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3586,570 +3502,568 @@ msgstr ""
 "Para um filme você pode dizer seu tamanho, sua história, idioma ...\n"
 "e se ele é falso, você pode dizer isso a outros usuários do aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Qualidade do arquivo"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Não avaliado"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Inválido / Corrompido / Falso"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Ruim"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Regular"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bom"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excelente"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Escolha uma classe ou avise os demais usuários se o arquivo é inválido..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "Pegar da rede Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Baixando, aguarde..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Tamanho desconhecido"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informação necessária"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Endereço IP:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informações adicionais"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Usuário :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Média da sessão"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload (velocidade)"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Árvore de Estatísticas"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Nome do Usuário:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Hash do Usuário:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software Cliente:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versão do Cliente:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Endereço IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID do Usuário:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP do servidor:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nome do Servidor:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Obfuscação:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferir para o cliente"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Solicitação atual:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Taxa upload (média):"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Taxa download (média):"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Upload (Sessão):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Download (sessão):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Upload (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Download (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pontuação"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador Down/Up:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificação segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Ranking de espera:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Pontuação de fila:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nick (identificação)"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - A Mula multi-plataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Esse é o nome que os usuários verão quando se conectarem à você."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Tempo de espera antes de mostrar as dicas."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Especifica o idioma que será usado no aMule."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Conferir a existência de uma versão nova periodicamente"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ativar isto faz com que o aMule verifique por nova versão ao iniciar e uma vez por dia enquanto roda"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra no sistema operacional uma entrada de início automático por usuário com de modo a iniciar o aMule no login. Se você mover o arquivo binário, rode o aMule uma vez manualmente depois para atualizar a entrada."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Torna o aMule o padrão para lidar com links ed2k:// de modo que ao clicar em um em seu navegador ou gerenciador de arquivos o fará abrir aqui."
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "O aMule lida apenas com links magnet compatíveis com eD2k (contendo xt=urn:ed2k:). Magnets de BitTorrent NÃO SÃO suportados e clicá-los irá falhar silenciosamente. Se você usar um cliente BitTorrent (Transmission, qBittorrent, etc.), deixe isso desligado."
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Iniciar minimizado"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Ativando isto deixará o aMule minimizado na inicialização."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Perguntar ao sair"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Fazer o aMule prompt antes de sair."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Ativar ícone no Systray"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Essa opção ativa/desativa o ícone no system tray (ou taskbar)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Fechar aplicação quando o botão fechar for pressionado"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizar para a bandeja"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Ativando isso, o aMule vai minimizar para o ícone de bandeja, ao invés da barra de tarefas."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Mostrar as notificações quando terminar de baixar"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Habilitar isto vai fazer com que o aMule mostre notificações quando terminar de baixar."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Tempo de atraso da janela de dica: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Browser Padrão"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Abrir em nova aba se possível"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a webpage em nova aba quando possível, ao invés de uma nova janela"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Player de Video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limites de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Alocação de Slots"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portas"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Essa é a porta eD2k padrão e não pode ser desabilitada."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porta UDP para requisições do servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Essa porta UDP é usada para requisições eD2k estendidas e rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porta TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Apenas para usuários avançados: concentra todo tráfedo do aMule em uma interface de rede, escolhida da lista ou digitada por nome (e.g. tun0, eth0, en0) ou indice. Diferentemente da ligação por IP, isto impede que o tráfego vaze pela rota default - útil com uma VPN. Requer elevação de privilégios."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes para arquivos baixando:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Auto-conectar ao iniciar"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconectar ao ser desconectado"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Remover servidores inativos após"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Servidores estáticos nunca são removidos, mesmo que inalcançáveis."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Atualizar lista de servidores quando conectar em um servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Atualizar lista de servidores quando um cliente conectar"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usar sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao conectar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Conexão segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Auto-conectar somente em servidores da lista estática"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Definir servidores adicionados manualmente com prioridade Alta"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Adicionar novos downloads em pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Adicionar novos downloads com prioridade automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Tentar baixar o primeiro e o último pedaço do arquivo primeiro"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "Modo \"Endgame\": roda para fontes mais rápidas nos blocos finais"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Começar o próximo arquivo pausado quando o arquivo completar"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Pré-alocar espaço em disco para novos arquivos"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos arquivos pré-alocar espaço em disco para todo o arquivo, isso reduz fragmentação"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar download quando espaço livre em disco acabar "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selecione isso se você quer uqe o aMule cheque seu espaço em disco"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Digite aqui o espaço min. de disco desejado."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvar 10 fontes em arquivos raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos compartilhamentos com prioridade automática"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manuseamento Inteligente de Corrupção (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Habilitado"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avançado confia em todo hash (não recomendado)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "Extração de metadados da mídia"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Extrair compeimento / taxa de bits / codec de arquivos compartilhados de audio e vídeo"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Quando habilitado, o aMule roda ffprobe em cada arquivo de mídia compartilhado para preencher as colunas de Comprimento / Taxa de Bits / Codec que os outros clientes veem quando acham o arquivo em uma procura. Requer que o ffmpeg (o binário ffprobe) esteja instalado."
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "Caminho para ffprobe:"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "Caminho completo para o binário ffprobe. Deixe vazio para que o aMule detecte automaticamente quando iniciar."
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "Detectar"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4157,684 +4071,682 @@ msgstr ""
 "Downloads finalizados são guardados aqui. Todos os arquivos nesta pasta são automaticamente compartilhados com outros pares.\n"
 "Se esta pasta também guarda arquivos que você não quer compartilhar, aponte para uma sub-pasta só para o aMule."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Pastas compartilhadas pelo núcleo. Digite um caminho para adicionar uma.)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Caminho absoluto de uma pasta no núcleo da máquina, e.g. /home/user/shared"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "Recursivo"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Compartilhar todas as sub-pastas dentro desta, incluindo as criadas posteriormente."
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Botão direito na pasta para compartilhar recursivamente)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Compartilhar arquivos ocultos"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Vasculha novamente automaticamente arquivos compartilhados que mudaram"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Segue links simbólicos em pastas compartilhadas"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "Exclui arquivos correspondendo a:"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "Caracteres curinga separados por '|', e.g. .DS_Store|Thumbs.db|*.tmp. Arquivos cujos nomes corresponderem não serão compartilhados. A correspondência é sensível à letra maiúscula/minúscula."
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "Padrões são expressões regulares"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Quando ligado, o campo inteiro é uma expressão regular ('|' é alternativa). Quando desligado, é uma lista de caracteres curinga separados por '|'."
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Tempo de atualização: 5s"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100min"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala dos gráficos das conexões: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Escala gráfica de download:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala gráfica de upload:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Grade"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Download atual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Média dos Downloads ativos"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Média dos Downloads da sessão"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Upload Atual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Média dos Uploads ativos"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Conexões ativas"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Ícone de barra de velocidade"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-nodes atuais"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-nodes rodando"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Selecione"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de versões a exibir (0=sem limite)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! CUIDADO !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "No. Max. de conexões / 5s"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "Procura concorrente de fontes Kad"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo entre novas buscas de fontes Kad (minutos)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo entre novos pedidos de fonte (minutos)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho do arquivo buffer: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "Usar MMAP: acesso de arquivo mapeado em memória (menor uso de memória)"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Mapeia arquivos part em memória ao invés de buferizá-los na heap, diminuindo a pegada de memória do processo. Pode reduzir a velocidade de download em alguns discos; melhor para hopedeiros com memória restrita ou que façam upload intensivamente."
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Atualizar conexão com servidor: desativado"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Desabilitar modo timed standby do computador"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Pele a usar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar \"Manipulador Veloz de Ligações eD2k\" em cada janela."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar info. extras nas abas de categoria"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Exibir versão do aplicativo no título"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Exibir taxa de transferência no título"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Mostrar banda sobressalente"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientação Vertical da Barra de Ferramentas"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Ordenação de coluna ao vivo (reordenamento automático das colunas conforme seus valores mudam)"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Fila de arquivos baixando"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Mostrar porcentagem do progresso"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Negar acesso restrito"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Senha de visitante para servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rodar webserver ao iniciar (deprecado)"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4846,11 +4758,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4866,11 +4778,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4880,504 +4792,504 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Desativado [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/s"
 msgstr[1] "bytes/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "s"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "horas"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dias"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "todos"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "todos os outros"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Parado"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeo"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arquivo"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Texto"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Ativos"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Usando diretório de configuração: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando pela linha de conversão do partfile para morrer..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importando %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Lendo pasta temp"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Recebendo informações básicas do arquivo info de download"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Criando arquivo de destino"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Carregando dados do download antigo (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Salvando bloco de dados em novo arquivo de download (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Recebendo informações sobre fontes do arquivo a baixar"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Adicionando download e salvando novo arquivo .part"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importar arquivos .part"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estado"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Hash do arquivo"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disco: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Escolha uma pasta para procurar por downloads temporários! (subdiretórios serão incluídos)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Deseja excluir os temporários dos que foram importados com sucesso?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Remover temporários?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERRO: falha na criação de partfile"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Tentando carregar backup do met-file de %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERRO:Falha ao abrir arquivo part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERRO: arquivo part.met é de tamanho 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERRO: Versão do arquivo part.met inválida: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Erro: %s (%s) está corrompido (bad tags: %s), impossível carregar arquivo."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERRO: %s (%s) está corrompido (tagcount errado), incapaz de carregar arquivo."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Tentando recuperar info do arquivo..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Recuperando arquivo sem nome - tentarei recuperá-lo como RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperada todas as informações do arquivo :D - Tente usá-lo..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Não foi possível recuperar o arquivo :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Falha ao abrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "CUIDADO: %s pode estar corrompido (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "Erro ao salvar arquivo .part: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Erro de IO enquanto salvava partfile: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "Escritos 0/desconhecidos bytes para '%s' -- preservando os arquivos .part.met. existentes."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Falha ao salvar part.met.seeds para %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Salvo %i fonte do .part: %s (%s)"
 msgstr[1] "Salvos %i fontes do .part: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Não é possível ler as sementes para Partfile %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erro lendo arquivo .seeds do arquivo (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Encontrada parte corrompida (%d) em %d arquivo .part %s - Resultado |%s| Hash |%s|"
 msgstr[1] "Encontradas partes corrompidas (%d) em %d arquivo .part %s - Resultado |%s| Hash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Achado parte completa (%i) em %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Terminado o rehash %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erro inesperado quando completado %s. Arquivo parado"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Download concluído: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5386,306 +5298,306 @@ msgstr ""
 "Download concluído:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Apagando arquivo: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "CUIDADO: Incapaz de fazer hash em part baixado - hashset incompleto para '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Incapaz de fazer hash de part baixado - hashset incompleto (%s). Isto nunca deveria acontecer"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "Parte %u de '%s' marcada como completa, porém o arquivo parte é menor que o esperado (tem %llu bytes, precisa %llu); reabrindo o gap para re-download."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF enquanto fazia hash de parte %u baixada com tamanho %u (max %u) de parte '%s' com tamanho %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Não há espaço em disco suficiente! Colocando arquivo %s em pausa"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte baixada %i do arquivo %s está corrompida"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte corrompida %i para %s -> Bytes salvos: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Alocando"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixado"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "Letão"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Conexão"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Diretórios"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controles remotos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debugando"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5695,15 +5607,15 @@ msgstr ""
 "    %PARTFILE - caminhos completo para o arquivo\n"
 "    %PARTNAME - somente nome do arquivo"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "O suporte para ícone da bandeja do sistema requer libayatana-appindicator3 em tempo de compilação."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Não disponível no Wayland: o protocolo não avisa quando uma janela foi minimizada, portanto esta opção não pode interceptar o botão de minimização do sistema. Alternativa: lance o aMule com `GDK_BACKEND=x11` para usar XWayland."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5719,35 +5631,35 @@ msgstr ""
 "O aMule funciona corretamente sem qualquer tipo de\n"
 "alteração nessas opções."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falha ao conectar Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Cfg para Widget com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Tipo de proxy ao qual você está conectado"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falha ao transferir dado do Widget para Cfg com o ID %d e senha %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Senha de administração"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5755,39 +5667,39 @@ msgstr ""
 "O aMule deve ser reiniciado para habilitar estas mudanças:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "-Porta TCP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "-Porta UDP alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- Interface de conexão de rede modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Porta de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Aceitação da conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Interface de conexão externa modificada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suporte de protocolo de ofuscamento mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- A configuração do amuleapi mudou.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5795,7 +5707,7 @@ msgstr ""
 "Sua lista de Auto-atualização de servidor está vazia.\n"
 "'Auto-atualização de servidor na iniciação' será desativada."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5803,32 +5715,32 @@ msgstr ""
 "Você ativou as conexões externas mas não definiu uma senha.\n"
 "Conexões Externas só podem ser feitas se for especificada uma senha válida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "-Idioma alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "-Diretório temporário alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K conectada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Este padrão de exclusão de arquivos compartilhados não é uma expressão regular válida. O filtro ficou desabilitado."
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5836,7 +5748,7 @@ msgstr ""
 "Ambas rede eD2k e Kad estão desativadas.\n"
 "Você não será capaz de conectar senão habilitar pelo menos um deles."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5844,7 +5756,7 @@ msgstr ""
 "Kad não iniciará se sua porta UDP estiver desabilitada.\n"
 "Habilite a porta UDP ou desative a rede Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5854,68 +5766,68 @@ msgstr ""
 "Você DEVE reiniciar o aMule agora.\n"
 "Se você não reiniciá-lo agora, não reclame se algo de ruim acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Não foi possível registrar o aMule para início automático no login. A lista de autostart pode estar como apenas leitura."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Não foi possível remover a entrada de início automático no login."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Início automático"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "Registrar manipulador de URL"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "O aMule lida apenas com links magnet compatíveis com eD2k. Se você trocar o manipulador atual (%s), links magnet deBitTorrent irão parar de funcionar - o aMule não pode baixar conteúdo BitTorrent. Continuar?"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Atualmente um outro aplicativo é o manipulador padrão para estes links (%s). Troco ele pelo aMule?"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "Não foi possível registrar o aMule como manipulador de URL. O armazenamento deve estar como \"apenas leitura\"."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "Não foi possível remover o registro de manipulação de URL."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "O servidor web e o aMule API necessitam que as conexões externas estejam habilitadas."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "O servidor web do aMules está deprecado. Ao invés disso, considere rodar sob a API do aMule."
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5925,64 +5837,64 @@ msgstr ""
 "Coloque pelo menos uma linha que aponte para um server.met válido.\n"
 "Clique no botão \"Lista\" para abrir a caixa para digitar uma URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Arquivos Temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Arquivos Recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Escolha uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Iria excluir %u de %u arquivo compartilhado"
 msgstr[1] "Iria excluir %u de %u arquivos compartilhados"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Defina seu Player de Vídeo preferido"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Selecione o Browser"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "Selecione o binário ffprobe"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "O ffprobe não foi encontrado no PATH ou nos locais padronizados de instalação. Instale o ffmpeg (que traz junto o ffprobe) ou use Browse para escolher um binário manualmente."
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "Resetar as configurações nesta página para seus valores padrão?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "Resetar para os valores padrão"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editar lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5990,114 +5902,114 @@ msgstr ""
 "Adicione aqui URL's para baixar arquivo 'server.met'\n"
 "Somente uma URL por Linha."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "Falha ao atualizar IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "Dados por MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "Fonte customizada"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "Dados por DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Status: %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status: %s - %s carregados"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Estado: Falha ao carregar - clique 'Atualizar agora' para refrescar."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Estado: Não encontrado - clique 'Atualizar agora' para baixar."
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Delay na atualização: %d segundo"
 msgstr[1] "Delay na atualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo do gráfico de média: %d minuto"
 msgstr[1] "Tempo do gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do gráfico de conexões: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho do Buffer de Arquivo: %d byte"
 msgstr[1] "Tamanho do Buffer de Arquivo: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho de Espera de Upload: %d cliente"
 msgstr[1] "Tamanho de Espera de Upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Atualizar conexão com servidor: %d minuto"
 msgstr[1] "Atualizar conexão com servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo para atualizar conexão no servidor: Desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "desativado"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar comando em evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Habilitar execução de comando no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comando do Núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Habilitar execução de comando na GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comando da GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "As seguinte variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6105,1082 +6017,1081 @@ msgstr ""
 "As seguintes pastas parecem ser de sistema ou locais sensíveis:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as redes eD2k/Kad. Você realmente quer isto?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Procurando por subdiretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Atualizando pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Varridos %u diretórios..."
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erro na busca"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Alerta da busca"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Procura eD2k não pode ser concluída se o eD2k não está conectado"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Sem palavra-chave para busca Kad - interrompendo"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erro inesperado quando tentava fazer a busca do Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Busca Kad: pediu resultados mais amplos de mais um par."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Busca Kad: nenhum par sobrou para pedir mais resultados novamente (capacidade atingida ou ainda sem respostas)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do arquivo"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Comprimento"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Taxa de Bits"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Baixar na categoria"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtendo %s para este arquivo"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurando arquivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marcar como arquivo conhecido"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para área de transferência"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Você não está atualmente conectado a um servidor que suporta a função \"Arquivos Relacionados\""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Novo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Falha ao conectar em todos servidores estáticos ofuscados listados. Tentando de novo sem ofuscação."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Falha ao conectar em todos servidores obscurecidos listados. Tentando de novo sem ofuscação."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Falha ao conectar em todos os servidores estáticos listados. Tentando novamente."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Falha ao conectar em todos os servidores listados. Tentando novamente."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rede eD2k desabilitada nas preferências, não conectado."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Nenhum servidor válido para o qual conectar na lista de servidor"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Conectado a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Conexão estabelecida em: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Erro Fatal durante tentativa de conexão. Talvez seu link Internet tenha caído"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Conexão perdida com %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) parece estar desativado."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheio."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Conexão automática com o servidor irá se repetir em %d segundo"
 msgstr[1] "Conexão automática com o servidor irá se repetir em %d segundos"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Conexão a %s (%s:%i) falhou."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERRO: Socket inválido no tempo de checagem"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Expirado tempo de espera para conectar a %s (%s:%i)."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Recebido último resultado da consulta DNS, descartando."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Carregando arquivo server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Arquivo server.met não encontrado!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Falha ao carregar arquivo server.met '%s', formato desconhecido."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Falha ao abrir arquivo server.met !"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Arquivo server.met corrompido, encontrada tag de versão inválida: 0x%x, tamanho %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "Encontrado %i servidor no server.met"
 msgstr[1] "Encontrados %i servidores no server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "Adicionado %d servidor"
 msgstr[1] "Adicionados %d servidores"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Erro: o arquivo 'server.met' está corrompido: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Erro de I/O ao ler arquivo 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Servidor não adicionado: [%s:%d] não possui uma porta válida."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Servidor não adicionado: o IP de [%s:%d] está filtrado ou é inválido."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Servidor não adicionado: Servidor com esse IP:Porta [%s:%d] já na lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Servidor adicionado: Servidor em [%s:%d] usando o nome '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Você está conectado a um servidor que está tentando apagar. Desconecte primeiro."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Falha ao abrir '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Falha ao salvar server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL inválida"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Download da lista de servidores de %s concluída"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Nenhuma entrada lista de endereço de servidores encontrada em addresses.dat. Por favor cole uma lista de endereços válida de servidores dentro deste arquivo em ordem para auto-atualizar sua lista de servidores"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Iniciando download da lista de servidores de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "CUIDADO: URL especificada inválida para auto-atualização dos servidores: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Nenhuma URL com server.met da lista addresses.dat é válida"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Falha ao obter a lista de servidores de %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Servidor local é filtrado pelo IPFilters, reconectando em um servidor diferente!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Endereço"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Porta"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descrição"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Usuários"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Fixo"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "Flags TCP"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "Flags UDP"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Você está conectado a um servidor que está tentando apagar. Desconecte antes. O servidor NÃO foi apagado."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nome Desconhecido)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Deseja remover o servidor estático %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Servidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectar ao servidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marcar servidor como fixo"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marcar servidor como não-fixo"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar servidores como fixos"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar servidores como não-fixos"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Apagar servidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Apagar servidores"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Remover todos os servidores"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copiar ligações eD2k para área de transferência"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconectar ao servidor"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Deseja remover todos os servidores?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Deseja remover o servidor selecionado?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Deseja remover o servidores selecionados?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERRO %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "CUIDADO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "O servidor %s (%s) rejeitou nosso login (nenhum ID de cliente atribuído). Desconectando."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Novo ID do cliente é %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVISO: você recebeu uma ID baixa (LowID)!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tGeralmente isso acontece quando você está atrás de um firewall/router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPara maiores informações, vá até https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Info desconhecida recebida do servidor - muito curta"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Recebido %d servidor novo"
 msgstr[1] "Recebidos %d servidores novos"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Salvamento da lista de servidores concluído."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "O servidor rejeitou o último comando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Pacote falso recebido do servidor: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Ocorreu um erro imprevisto ao processar os pacotes do servidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Não foi possível ativar resolução DNS para conectar a %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP do servidor %s (%s) está filtrado. Não conectando."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "usando obscurecimento de protocolo."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Conectando para %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Não foi possível resolver o DNS para %s: Impossível conectar!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "Log do aMuleGUI"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Servidor não adicionado: sem IP ou hostname."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor não adicionado: porta informada inválida."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Status de eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Tipo de Conexão:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Conectado"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Status Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Rodando em modo LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Rodando"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "ID do cliente Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estado da Conexão:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Atrás de Firewall - abra a porta TCP %d em seu roteador ou firewall"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estado da Conexão UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Atrás de Firewall - abra a porta UDP %d em seu roteador ou firewall"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estado do Firewall: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nenhum amigo requirido - porta TCP aberta"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nenhum amigo requirido - porta UDP aberta"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Sem amigos"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Conectando ao amigo"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectado ao amigo em %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fontes indexadas::"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Palavras chaves indexadas:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notas indexadas:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Index carregado:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Média de Usuários:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Média de Arquivos:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Parado"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Adicionando arquivo %s ao compartilhamento"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i arquivo conhecido compartilhado"
 msgstr[1] "Encontrados %i arquivos conhecidos compartilhados"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Encontrado %i arquivo conhecido, %i desconhecido"
 msgstr[1] "Encontrados %i arquivos conhecidos, %i desconhecidos"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "%i arquivo excluído do compartilhamento pelo filtro"
 msgstr[1] "%i arquivos excluídos do compartilhamento pelo filtro"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERRO: Tentando compartilhar %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Diretório compartilhado não encontrado, pulando: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nome de Usuário"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Partes Disponíveis"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Status de Upload"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Status de Download"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nome do arquivo Local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Lista de Arquivos Compartilhados"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Partes já baixadas"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Caminho completo"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Adicionar Comentário/Avaliação"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editar Comentário/Avaliação"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Renomear"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "Verificar Dados Locais"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adicionar arquivo na coleção para lista de transgênica"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiar &URL Magnet para Área de Transferência"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiar &link eD2k para área de transferência (&Fonte)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiar &link eD2k para área de transferência (Fonte) (&Com opções de criptografia)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiar &link eD2k para área de transferência (&Nome da máquina)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiar &link eD2k para área de transferência (Nome da máquina) (Com &Opções de criptografia)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiar &link eD2k para área de transferência (&Info AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiar &link eD2k para área de transferência (&Info AICH + Fonte)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Verificar Dados Locais em PartFile não é atualmente suportado: %s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Você precisa ter HighID para criar uma fonte ED2K válida"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do arquivo remoto"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Dados enviados (Sessão (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Overhead Total (pacotes): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Solicitações de Arquivo (pacotes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Troca de fontes (Pacotes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Overhead de servidor (Pacotes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Overhead Kad (pacotes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Criptografia elevada (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Uploads ativos: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Uploads em espera: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total de sessões de upload com sucesso: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de sessões de upload que falharam: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tempo médio de upload: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Dados baixados (Sessão (Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fontes encontradas: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Downloads ativos (pedaços): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Média de UL:DL da Sessão (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Taxa média de download (Sessão): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Taxa média de envio (Sessão): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Taxa máxima de download (Sessão): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Taxa máxima de envio (Sessão): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconectados: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tempo desde a primeira transferência: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Conectado ao servidor desde: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Conexões ativas (estimada): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Máximo de conexões que atingiram tempo limite: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Média de conexões (estimativa): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexões (estimada): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clientes"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Desconhecido: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrado: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Banido: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i Conhecidos: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servidores ativos: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servidores que falharam: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servidores eliminados: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servidores Filtrados: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Usuários em servidores ativos: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Arquivos nos servidores ativos: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Total de usuários: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Total de arquivos: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupação do Servidor: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de arquivos compartilhados: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Tamanho total de compartilhados: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Média de tamanho de arquivo: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema Operacional"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Não recebido"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Conexões ativas (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Não disponível"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nunca"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Comando '%s' com pid '%d' foi finalizado com o código de status '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executar <str> e sair."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formato do IP inválido. Use xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Esse comando requer um parâmetro. Válidos: 'all', NomeDeArquivo, ou um número.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Processando pela hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Processando por nome de arquivo: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Esse comando requer um parâmetro. Válido: hash de um arquivo.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Não é um número válido\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Não é uma hash válida (precisa ter exatamente 32 caracteres)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7190,7 +7101,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7200,7 +7111,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7208,82 +7119,80 @@ msgstr ""
 "Nenhum tipo de busca definido.\n"
 "Tecle 'help search' para obter mais ajuda.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Arquivo de Download: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Solicitação falhou com erro desconhecido."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operação executada com sucesso."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Solicitação falhou com os seguintes erros: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtragem IP para clientes é %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Desligado"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Ligado"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtragem IP para servidores é %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Nível atual do IPFilter é %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limites de banda: Enviar: %u kB/s, Baixar: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "Rotação de fontes \"Endgame\" é %s.\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Busca iniciada (id %u).\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Conectado a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Conectando"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "sob firewall"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7292,7 +7201,7 @@ msgstr ""
 "\n"
 "Download:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7301,7 +7210,7 @@ msgstr ""
 "\n"
 "Upload:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7310,7 +7219,7 @@ msgstr ""
 "\n"
 "Clientes na fila:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7319,46 +7228,46 @@ msgstr ""
 "\n"
 "Fontes totais:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartFile]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "Busca expirada ou ID desconhecido. Comece uma nova busca.\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados da busca: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progresso da busca: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progresso da busca não disponível"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Resposta recebida do servidor desconhecida, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Exibir informações de status resumidas."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Exibir informações de conexão, taxa de Down/Up, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Exibir árvore de estatísticas completas."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7372,11 +7281,11 @@ msgstr ""
 "\n"
 "Exemplo: 'statistics 5' vai mostrar apenas as 5 maiores versões de cada tipo de cliente.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Fechar aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7386,35 +7295,35 @@ msgstr ""
 "Isso irá também desligar o cliente texto, por causa disso é inútil sem um\n"
 "núcleo rodando.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recarregar objeto selecionado."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recarregar a lista de arquivos compartilhados."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recarregar a tabela IPFilter."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Carregar a atual tabela de IP filtering."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Atualizar a tabela de IP filtering de URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Se a URL é omitida a URL das preferências é usado."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Conectar à rede."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7426,35 +7335,35 @@ msgstr ""
 "a esse servidor apenas. O IP deve ter notação decimal IPv4,\n"
 "ou um nome DNS que possa ser resolvido."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Conectar somente em eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Conectar a rede Kad apenas."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desconectar da rede."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Isso irá desconectar você de todas as redes conectadas atualmente.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desconectar somente de eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desconectar apenas da rede Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Adicionar uma ligação eD2k ou magnet ao núcleo."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7472,51 +7381,51 @@ msgstr ""
 "\n"
 "A ligação magnética deve conter o hash eD2k e tamanho do arquivo.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Defina as preferências."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Definir preferências de IP filtering."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Ligar filtragem IP para ambos clientes e servidores."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Desligar filtragem IP para ambos clientes e servidores."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Habilitar/Desabilitar filtragem IP para clientes."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Ligar filtragem IP para clientes."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Desligar filtragem IP para clientes."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Habilitar/Desabilitar filtragem IP para servidores."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Ligar filtragem IP para servidores."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Desligar filtragem IP para servidores."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Definir no nível do IP Filter."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7524,71 +7433,71 @@ msgstr ""
 "Qualquer valor entre 0 e 255 é válido, e o valor padrão (inicial)\n"
 "é 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Ajusta a limitação de largura de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "O Valor informado nesses comandos deve ser em kilobytes/s.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Definir limite de Upload."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "O Valor informado deve ser em kilobytes/seg.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Definir limite de Download."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "Ativa ou desativa rotação de fontes \"fim de jogo\"."
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "O Valor informado deve ser 1/ON (ligado) ou 0/OFF (desligado).\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obter e mostrar o valor da preferência selecionada."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obter preferências de IP filtering."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obter estado de IP filtering para ambos clientes e servidores."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obter estado do IP filtering somente para clientes."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obter estado do IP filtering somente para servidores."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Definir no nível de IP filtering."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obter limites de largura de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "Acessa o estado de rotação de fim de jogo."
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Faça uma pesquisa."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7622,23 +7531,23 @@ msgstr ""
 "Exemplo: 'search global linux iso --type Iso --min-size 100M' retorna\n"
 "resultados para \"linux iso\" de arquivos tipo Iso de no mínimo 100 MiB.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Faça uma pesquisa global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Faça uma pesquisa local"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Faça uma pesquisa no kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "Mostra resultados de uma busca."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7646,11 +7555,11 @@ msgstr ""
 "Retorna os resultados de uma busca.\n"
 "Opcionalmente recebe uma id (de 'search ...'); sem o id, retorna os resultados da busca mais recentemente começada.\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Exibe progresso de uma pesquisa."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7658,11 +7567,11 @@ msgstr ""
 "Mostra o progresso de uma busca.\n"
 "Opcionalmente recebe uma id de busca; sem a id, mostra o progresso da busca mais recentemente começada.\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Iniciar download de um arquivo"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7670,80 +7579,80 @@ msgstr ""
 "O número de um arquivo de uma última busca poderá ser obtido.\n"
 "Exemplo: 'download 12' começará a baixar o arquivo com o número 12 da busca anterior.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Parar Download."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Continuar Download."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Cancelar Download."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Definir prioridade de download."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Mudar prioridade de um download para Baixo, Normal, Alto ou Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Definir prioridade baixa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Definir prioridade normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Definir prioridade alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Definir prioridade auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Exibir as listas de Up/Down."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Exibe listas de upload/download, lista de servidores ou lista de compartilhados.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostrar fila de upload."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostrar fila de download."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostrar o log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostrar a lista de servidores."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Mostrar a lista de arquivos compartilhados."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Reiniciar log."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comando ultrapassado, use '%s' no lugar."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7752,261 +7661,258 @@ msgstr ""
 "Esse comando foi depreciado e será removido no futuro.\n"
 "Ao invés desse, use '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente em modo texto do aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convertendo hashsets AICH antigos de '%s' para 64b em '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "Verificar Dados Locais (%s): Resultado OK para %s"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "Verificar Dados Locais (%s): ERROS ENCONTRADOS! %s Blocos falhos: MD4: %s. %s %s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVISO: O nome de arquivo '%s' é inválido e foi renomeado para '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVISO: O arquivo '%s' já existe, novo arquivo renomeado para '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Deseja cancelar e apagar todos os arquivos desta categoria?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Confirmação requerida"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Somente 99 categorias são suportadas."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Excesso de conexões!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Todos os outros"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Selecione o filtro de exibição"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Adicionar categoria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editar categoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Remover categoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Hashset solicitado para arquivo desconhecido: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Continuando uploads para o arquivo: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Suspendendo uploads para o arquivo: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Falha ao executar comando `%s' no evento `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Download concluído"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Caminho completo do arquivo."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Nome do arquivo sem seu caminho completo."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "O hash eD2k do arquivo."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Tamanho do arquivo em bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tempo acumulado de download ativo."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nova sessão de chat iniciada"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remetente da mensagem."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Sem espaço"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partição do disco."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Erro ao concluir"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Processando arquivo número %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Você pediu por hash de partes (só é usado para arquivos > 9,5MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Arquivo não existe !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, o criador de ligações do aMule eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Bem-vindo!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parâmetros de Entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Arquivo a gerar hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "URL para esse arquivo (opcional)"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Escreva aqui o arquivo que você quer computar a ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Escreva aqui a URL que você quer adicionar na ligação eD2k: Adicione / no fim para deixar o aLinkCreator anexar o atual nome do arquivo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Criar link com hash de partes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ajuda a espalhar arquivos novos e raros mais rápido, mas aumenta o tamanho do link"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hash MD4 do arquivo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Hash de arquivo eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Salvar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiar para a Área de Transferência"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Abra o arquivo para computar esta ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiar ligação eD2k computada para a área de transferência"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Salvar como"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Salvar ligação eD2k computada no arquivo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Sobre o aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Selecione o arquivo que você quer computar a ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Não pode abrir o clipboard"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Nada a ser copiado!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Selecione o arquivo para sua ligação eD2k computada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Impossível abrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Por favor, informe um nome não-vazio"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Nada a ser salvo!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8026,167 +7932,159 @@ msgstr ""
 "\n"
 "Distribuído sobre GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Criando Hash..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator está trabalhando por você"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Computando Hash MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Computando Hashes eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Cancelado !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Pronto em %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Você já adicionou essa URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Informe uma URL não-vazia"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Impossível abrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Faltou memória enquanto calculava o hash ed2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dias %i horas %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Estatísticas Online do aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Taxa máxima de DL enquanto roda o wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Taxa máxima absoluta de DL enquanto rodava o wxCas (anterior)"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Limpar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Parar atualização automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Salvar imagem de estatística Online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimir imagem de estatística Online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Preferências"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Sobre wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Iniciar atualização automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Atualização automática parada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Atualização automática iniciada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Salvar imagem estatísticas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estatísticas Online do aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8194,11 +8092,11 @@ msgstr ""
 "Encontrei um problema na hora de imprimir.\n"
 "A sua impressora está configurada corretamente?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8216,375 +8114,364 @@ msgstr ""
 "\n"
 "Distribuído sob licença GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule não está rodando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule está rodando"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule está rodando, mas desconectado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule está conectando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, o status do aMule é desconhecido..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " está rodando há "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " esta parado !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " não esta conectado !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " está conectando..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " está fazendo algo de estranho, verifique!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " conectado em "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "desligado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " está ativo "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " com "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Download Total: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Download da Sessão: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Compartilhando: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " arquivos, Clientes na fila: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tempo: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " em "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Média de carga do Sistema (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Uptime do Sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Pasta contendo arquivo amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Informe aqui a pasta onde está o arquivo amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Taxa de atualização (em segundos)"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Gerar imagem de estatística a cada atualização"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Informe aqui a pasta onde gravar a imagem de estatística gerada"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Fazer upload periódico da imagem para servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL do FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Caminho no FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Informe a URL do seu servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Informe a pasta onde colocar a sua imagem estatística no servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Usuário"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Informe o nome do usuário de login, para o servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Informe a senha para o usuário do servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalo entre atualizações do servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Pasta contendo seu arquivo de assinatura"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Pasta para colocar imagem estatística gerada"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carregar modelo <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Porta HTTP do web server"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Usar redirecionamento de porta UPnP na porta do cliente web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Porta UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Utilizar compressão gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Senha de total acesso para servidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Senha de visitante para servidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permitir acesso restrito"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Negar acesso restrito"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Carregar/salvar configurações do servidor web de/para aMule remoto"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Caminho para arquivo amule.conf - NÃO USE DIRETAMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Desabilitar o interpretador PHP (obsoleto)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompilar páginas PHP a cada solicitação"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Servidor Web do aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "conexão de cliente web aceita\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERRO: não pode aceitar conexões de clientes web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Solicitação falhou com o seguinte erro: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Arquivo index não encontrado: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sessão expirada - solicitando login\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessão Ok, logado\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessão Ok, ainda não logado\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nenhuma sessão aberta - solicitando login\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessão criada - solicitando login\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Processando pedido [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "Recusando-se a ler `além` de uma URL query string\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nenhuma senha especificada, login não será permitido."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Verificando senha\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash de senha inválido\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Senha Ok\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Senha inválida\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Você não digitou nenhuma senha. Senha em branco não é permitido.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Solicitado logout\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Processando solicitação [redirecionado]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (obrigatório)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Atalho de desktop"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "Iniciar o aMule quando eu logar no sistema"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Remover dados do usuário (configuração, servidores eD2k, nós Kad, partfiles)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "Arquivos do aplicativo aMule (obrigatório)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Coloca um atalho do aMule no desktop."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Inicia o aMule automaticamente quando o usuário atual faz login no sistema (configuração por usuário)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "Remove arquivos de aplicação do aMule, Menu Iniciar / atalhos de desktop, chaves de início automático, registros de esquemas de URL e entradas de Adiciona/Remove Programas (obrigatório)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Apaga permanentemente %APPDATA%\\aMule para o usuário atual (aMule.conf, lista de servidores eD2k, nós Kad, partfiles, Filtros de IP, lista de amigos). Deixe não-marcado para manter suas configurações."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8592,7 +8479,7 @@ msgstr ""
 "aMule parece estar rodando de $INSTDIR.\r\n"
 "Por favor, feche o aMule (e o aMuleD / aMuleGUI) e tente novamente."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8600,11 +8487,11 @@ msgstr ""
 "O daemon aMule (amuled.exe) parece estar rodando de $INSTDIR.\r\n"
 "Por favor, pare-o e tente novamente."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "Removendo a instalação anterior do aMule em $0..."
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8612,11 +8499,11 @@ msgstr ""
 "Não foi possível remover a instalação anterior do aMule em $0.\r\n"
 "Por favor, feche todos os processos aMule rodando e tente novamente, ou desinstale as versões anteriores manualmente primeiro."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador novamente."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -28,20 +28,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Mostrar"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Controlo remoto do aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -49,7 +49,7 @@ msgstr ""
 "Cliente p2p 'para todas as plataformas' baseado no eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -58,79 +58,79 @@ msgstr ""
 "Copyright (C) 2003-2019 Equipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Parte do aMule é baseado em \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Encaminhamento peer-to-peer baseado na métrica XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (C) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Website:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Fórum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verificar nova versão no arranque"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "A ligar à Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Indisponível"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Adicionar um Amigo"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Deve indicar um endereço IP e porto válidos!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informação"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "A chave de utilizador especificada não é válida!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -139,49 +139,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Depois do nome da aplicação"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "A ligação falhou "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -190,103 +189,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Falha ao abrir ficheiro de ligações eD2k."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k enquanto tiver lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "A fechar a aplicação..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Falhas"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "A terminar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "A matar instância do amuleweb com o pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: A terminar núcleo."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule terminado."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Resultados da depuração de memória para a saída do aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "O seu idioma foi alterado para a predefinição do sistema devido a uma mudança de configuração. Desculpe."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informação"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -294,74 +290,70 @@ msgstr ""
 "\n"
 "Configuração das LE"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "AVISO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "servidor web a executar no pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Não foi possível associar os portos ao endereço especificado: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "O porto %u não está disponível. Ficará com LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -376,48 +368,48 @@ msgstr ""
 "\n"
 "Verifique a sua rede para se certificar de que o porto está aberto para leitura e escrita."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Erro ao criar o ficheiro da Assinatura Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Erro a criar o ficheiro da Assinatura Online do aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "O idioma seleccionado parece não estar instalado no seu computador. (Nota: de qualquer das formas, irei tentar activá-lo)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Esta é a primeira vez que executa o aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Esta é uma versão de testes actualizada diariamente e\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "não há qualquer garantia de que não irá partir nada, pegar fogo à sua casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ou matar o seu cão. Mas, *em princípio*, deverá ser seguro usá-lo.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mais informação, suporte e novos lançamentos na nossa página,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "em amule-org.github.io ou no canal de IRC #aMule em irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Esteja à vontade para comunicar erros para https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -425,224 +417,220 @@ msgstr ""
 "A pasta para os ficheiros da Assinatura Online é INVÁLIDA!\n"
 " A Assinatura Online será DESACTIVADA até que resolva a situação nas preferências."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Reserva de espaço em disco para o ficheiro '%s' falhou: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ERRO: não é possível abrir o ficheiro de relatório"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "AVISO: o ficheiro de relatório está vazio. Algo está mal."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "O relatório foi limpo"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mensagem do servidor: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "O download de %s não foi feito porque o ficheiro requisitado não é mais recente."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Falha ao transferir a lista de nós."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Falha ao abrir o ficheiro de verificação de versão transferido"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Ficheiro de verificação de versão corrompido"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Está a usar uma versão antiga do aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "A sua versão do aMule é %i.%i.%i e a última versão é %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "AVISO: A sua versão do aMuled está desactualizada: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "A sua cópia do aMule está actualizada."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Falha ao transferir o ficheiro de verificação de versão"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizadores: %s | Ficheiros: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizadores: E: %s K: %s | Ficheiros: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Não foram seleccionadas redes"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "com LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "com HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ligado a %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "A ligar a %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Desligado da eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad iniciada."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad parada."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Ligado à Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Desligado da Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "A rede Kad não pode ser usada se o porto UDP estiver desactivado nas preferências, inicialização não efectuada."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rede Kad desligada nas preferências, a ligação não será efectuada."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ERRO: Não é possível usar o daemon do aMule quando as ligações externas estão desactivadas. Para activar as Ligações Externas use um aMule normal, inicie o amuled com a opção --ec-config ou mude a chave \"AcceptExternalConnections\" para 1 no ficheiro ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ERRO: É necessária uma palavra-passe para utilizar as ligações externas e o daemon do aMule não pode ser utilizado sem ligações externas. Para executar o daemon do aMule deve definir o campo \"ECPassword\" no ficheiro ~/.aMule/amule.conf com um valor adequado. Execute o amuled com o parâmetro --ec-config para definir a palavra-passe. Para mais informações consulte https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - a iniciar temporizador"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Não foi Possível Criar o Ficheiro de Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,193 +640,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Sem rede"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Controlo remoto do aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Erro Fatal: Falha ao criar o Temporizador Central"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Ligar ao amule remoto"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Ligação perdida"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Confirmar fecho do programa"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -847,727 +828,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Erro Fatal: Falha ao criar o 'Poll Timer'"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "A ir para o ciclo de eventos..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "A Ligar..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Gestor de eventos da interface gráfica remota"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "A ligação falhou. Não é possível ligar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "A fechar"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "A tentativa de ligação a %s (%s:%i) expirou."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Religar à rede."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "A ligação falhou. Não é possível ligar a %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Pronto"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Todos"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Indisponível"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Ficheiro não encontrado."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ligação inválida ou já na lista."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Não é possível criar o directório '%s' para a categoria '%s', a manter directório '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "A procurar parceiro para ligação com lowid"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versão do eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule falso)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule falso)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcunha: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pedido: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas para esta sessão: Aceite %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas para esta sessão: Aceites %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas para todas as sessões: Aceite %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas para todas as sessões: Aceites %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Pedido um ficheiro desconhecido"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensagem filtrada de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensagem de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados para a pasta '%s' -> Ignorado"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "AVISO: %s não pode ser aberto."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "AVISO: Lista de ficheiros cancelados corrompida, contém cabeçalho inválido."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Erro de entrada/saída ao ler ficheiro %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Erro ao gravar ficheiro %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nova Categoria"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Seleccione uma pasta de ficheiros completos"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Deve especificar um nome para a categoria!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Deve especificar um caminho para a categoria!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Erro ao criar pasta de entrada para categoria. Por favor, especifique um caminho válido!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sessão de Conversa Iniciada: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Ligado ao Cliente ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** A Ligar ao Cliente ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Erro na ligação ao cliente / Ligação perdida ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Passou o teste do 'captcha' e o utilizador recebeu a sua mensagem. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** A sua resposta ao 'captcha' estava errada e a sua mensagem foi ignorada. Pode solicitar um novo 'captcha' enviando uma nova mensagem. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Fechar o separador"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Fechar todos os separadores"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Fechar os outros separadores"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Adicionar à lista de Amigos"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Ficheiro de créditos carregado, %u cliente conhecido"
 msgstr[1] "Ficheiro de créditos carregado, %u clientes conhecidos"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Os créditos expiraram para %u cliente!"
 msgstr[1] " - Os créditos expiraram para %u clientes!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Ficheiro 'cryptkey.dat' não encontrado, a criar."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Activado"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Suportado"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Desactivado"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ligado"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Desligado"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Incompleto"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Pessoa Maldosa"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Indisponível"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados -> Aceite"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados -> Negado"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "O utilizador %s (%u) pediu a sua lista de pastas partilhadas -> Aceite"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "O utilizador %s (%u) pediu a sua lista de pastas partilhadas -> Negado"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados para a pasta '%s' -> aceite"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados para a pasta '%s' -> negado"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "O utilizador %s (%u) partilha a pasta '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "O utilizador %s (%u) enviou pastas partilhadas não requisitadas."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "O utilizador %s (%u) enviou a lista de ficheiros partilhados para a pasta '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "O utilizador %s (%u) terminou o envio da lista de ficheiros partilhados"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "O utilizador %s (%u) enviou lista de ficheiros partilhados não desejada"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "O utilizador %s (%u) negou acesso à lista de pastas/ficheiros partilhados"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentários do ficheiro"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Nome de Utilizador"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do Ficheiro"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Classificação"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentário"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Não é possível pesquisar na Kad se não estiver ligado à rede Kad"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "A procurar parceiro para ligação com lowid"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Sem comentários"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u comentário"
 msgstr[1] "%u comentários"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Cliente %s banido por ter enviado %s dados corrompidos de um total de %s para o ficheiro '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Falha ao carregar dados de país para '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Automática [Baixa]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Automática [Normal]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Automática [Alta]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Muito Alta"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Lançamento"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "A Pedir"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "A ligar via servidor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Fila de Espera Cheia"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Em Fila de Espera"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "A Receber"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "A receber o conjunto de chaves"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Não há partes necessárias"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Não é possível ligar dois clientes com LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Demasiadas ligações"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "A ligar via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Demasiadas ligações Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Banidos"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Erro de Ligação"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Fila de Espera Remota Cheia"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "MLDonkey antigo"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "MLDonkey Novo"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatível com eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Servidor Local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Troca de Fontes"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passivo"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Ligação"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Sementes de Fontes"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Resultados de Pesquisas"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Concluído"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Em progresso"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERRO: Sem espaço em disco"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ERRO: Partmet não encontrado"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ERRO: erro de entrada/saída!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Em Fila"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Já a transferir"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formato de ficheiro temporário desconhecido ou danificado."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Estado"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Tempo Restante"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Última Vez Visto Completo"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Última recepção"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Tem a certeza que deseja eliminar o ficheiro seleccionado?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Tem a certeza que deseja eliminar os ficheiros seleccionados?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1576,109 +1534,106 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "P&arar"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Continuar"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Limpar terminados"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Trocar cada A4AF para este ficheiro"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Trocar cada A4AF para este ficheiro (Automático)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Trocar cada A4AF para outro ficheiro"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opções Estendidas"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Mostrar &detalhes do ficheiro"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Mostrar todos os comentários"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiar URI magnet para a área de transferência"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Copiar &ligação eD2k para a área de transferência"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar comentários para a área de transferência"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "destituir"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Atribuir à categoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir o ficheiro"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Insira o novo nome para este ficheiro:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Renomear ficheiro"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1687,348 +1642,347 @@ msgstr ""
 "Para evitar que este aviso apareça em cada pré-visualização,\n"
 "defina o seu leitor de vídeo nas preferências (por omissão é o %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Pré-visualização do ficheiro"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Erro na execução do leitor multimédia externo! Comando: '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "A gravar Ficheiro Parcial %u de %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Todos os Ficheiros Parciais Gravados."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "A carregar ficheiros temporários de %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "A carregar Ficheiro Parcial %u de %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ERRO: Falha ao carregar ficheiro de backup. Procure em https://github.com/amule-org/amule/discussions por soluções para recuperação de .part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Carregados Todos os Ficheiros Parciais."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nenhum ficheiro de partes (.part) encontrado"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Encontrado %u ficheiro de partes"
 msgstr[1] "Encontrados %u ficheiros de partes"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "O sistema de ficheiros da pasta de ficheiros temporários não suporta ficheiros grandes."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "O sistema de ficheiros da pasta de ficheiros completos não suporta ficheiros grandes"
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "A transferir %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Já está a tentar obter o ficheiro '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Já possui o ficheiro '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Já possui o ficheiro '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Já está a tentar transferir o ficheiro %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Conversão de ligação magnet para eD2k não pode ser feita: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocolo do link desconhecido: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Ligação eD2k inválida! ERRO: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "O cliente enviou um pacote depois de a autenticação ter falhado."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Ligação externa fechada."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Ligações externas desactivadas devido a palavra-passe vazia!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Ligações externas desactivadas no ficheiro de configuração"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nova ligação externa aceite"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ERRO: não foi possível aceitar uma nova ligação externa"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ligação externa recusada devido a palavra-passe não preenchida nas preferências!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "A ligar cliente: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versão desconhecida"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Versão de LE incorrecta, pode haver incompatibilidade binária. Utilize núcleo e remoto da mesma versão."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Não pode ligar-se a uma versão oficial a partir de uma versão de desenvolvimento arbitrária! *suspiro*... Prevenido potencial erro futuro"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versão de protocolo inválida."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Elemento de versão de protocolo em falta."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Falha de autenticação: chave inválida indicada como palavra-passe para LE"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "A autenticação falhou: palavra-passe errada."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "A autenticação falhou: palavra-passe em falta."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Pedido inválido, deve autenticar-se primeiro."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Acesso concedido."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Enviada mensagem de erro \"%s\" ao cliente."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Acesso não-autorizado de %s. Ligação fechada."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Falha no comando de ficheiro de partes remoto: Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Chave não encontrada: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS! Erro de processamento de código de operação!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Servidor não adicionado"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "servidor não encontrado: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "é necessário definir o servidor a remover"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2K desactivada nas preferências."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa na web a partir da interface remota não faz sentido."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "A pesquisar. Resultados dentro de momentos!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Sem pontos para gráfico."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "O cliente não está configurado para este nível de detalhe."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Ligação Externa: finalização pedida"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Já a desligar."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "LigaçãoExterna: a adicionar o link '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ligação inválida ou já na lista."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Ficheiro não encontrado."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nome de ficheiro inválido."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Não é possível renomear o ficheiro."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "A Kad está desactivada nas preferências."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Já ligado à eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "A ligar à eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Já ligado à Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "A ligar à Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Todas as redes estão desactivadas."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Desligado da eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Desligado da Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Ligação Externa: recebido código de operação inválido: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Código de operação inválido (versão de protocolo errada?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensão '%s' desconhecida para o comando '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comando '%s' desconhecido.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2036,7 +1990,7 @@ msgstr ""
 "\n"
 "Este comando não pode ter um argumento.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Este comando deve ter um argumento.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2052,7 +2006,7 @@ msgstr ""
 "\n"
 "Este comando está incompleto, deve usar uma das extensões abaixo.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2060,11 +2014,11 @@ msgstr ""
 "\n"
 "Extensões disponíveis:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comandos disponíveis:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2075,17 +2029,17 @@ msgstr ""
 "Todos os comandos não consideram a capitalização das letras.\n"
 "Escreva '%s <comando>' para obter mais detalhes sobre <comando>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Sai do programa."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Mostrar ajuda."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2093,7 +2047,7 @@ msgstr ""
 "Para obter ajuda num comando, escreva 'help <comando>'.\n"
 "Para obter a lista completa de comandos escreva 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2104,46 +2058,46 @@ msgstr ""
 "Use '%s' para a lista de comandos\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Erro de sintaxe!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Erro ao processar o comando - nunca deveria acontecer! Por favor, comunique o erro\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Este comando não deveria ter quaisquer parâmetros."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Este comando deve ter um parâmetro."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argumento inválido."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Este comando está incompleto."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Escreva '%s' para obter mais ajuda.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Isto é %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Isto é %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2151,7 +2105,7 @@ msgstr ""
 "\n"
 "A criar o cliente...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2160,7 +2114,7 @@ msgstr ""
 "\n"
 "OK, a sair %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2174,331 +2128,326 @@ msgstr ""
 "\n"
 "A sair...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Mostra esta ajuda."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Máquina onde o aMule está a ser executado. (predefinida: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porto do aMule para Ligação Externa. (predefinido: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Palavra-passe de Ligação Externa."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Ler a configuração a partir do ficheiro."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Não mostrar qualquer mensagem para a saída padrão."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Detalhado - mostrar também mensagens de depuração."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Define a localização do programa (idioma)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Escrever as opções da linha de comandos para o ficheiro de configuração."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Cria ficheiro de configuração baseado no ficheiro de configuração do aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Mostrar a versão do programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalhes do ficheiro"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% terminado"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Bem-vindo!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "A ligar a um parceiro"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Estado da Ligação:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Redes"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Porto TCP Padrão "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Porto UDP estendido (Kad / pesquisa global) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activar UPnP para encaminhamento de portos no router"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Inicialização"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Já está a tentar transferir o ficheiro %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Auto-actualizar lista de servidores no arranque"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Pasta para ficheiros temporários"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para leitura!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Amigos"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Mostrar &Detalhes"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Adicionar um amigo"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Remover Amigo"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Enviar &Mensagem"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Ver Ficheiros"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Estabelecer Ligação de Amigo"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Tem a certeza que deseja remover o amigo seleccionado?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Tem a certeza que deseja remover os amigos seleccionados?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2506,11 +2455,11 @@ msgstr ""
 "Não lhe é permitido definir mais do que uma ligação de amigo.\n"
 " Apenas uma ligação foi atribuída."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selecção múltipla"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2519,206 +2468,205 @@ msgstr ""
 "Não lhe é permitido definir mais do que uma ligação de amigo.\n"
 " Apenas uma ligação foi atribuída."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Enviar uma mensagem ao utilizador"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensagem a enviar:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Tirar da lista dos amigos"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Enviar mensagem"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Mudar para este ficheiro"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Na Fila: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "A pedir outro ficheiro"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "À espera de upload"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Em Fila de Espera: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "A Enviar"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nenhum"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Sim"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "A Receber..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "O URL para download não pode estar vazio"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Pasta para ficheiros temporários"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%d bytes transferidos"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "O URL %s devolveu: %i - Erro (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Download HTTP cancelado"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Transferir novo GeoIP.dat a partir de %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Transferência do ficheiro GeoIP.dat falhou, a abortar actualização."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Falhou ao remover ficheiro %s, a cancelar actualização."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Falhou ao mudar o nome do ficheiro %s, a cancelar actualização."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s actualizado com sucesso"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Erro ao actualizar o GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Falhou a transferência do %s de %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "A carregar os filtros de IPs 'ipfilter.dat' e 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Erro ao carregar o ficheiro ipfilter.dat '%s', formato desconhecido encontrado."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Erro ao carregar o ficheiro ipfilter.dat '%s', não foi possível abrir o ficheiro."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u intervalo IP carregado de '%s'."
 msgstr[1] "%u intervalos IP carregados de '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u linha defeituosa foi ignorada."
 msgstr[1] "%u linhas defeituosas foram ignoradas."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Falhou ao mudar o nome ao novo ficheiro %s, a cancelar actualização."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "O filtro de IPs está pronto"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2726,876 +2674,844 @@ msgstr ""
 "Arrancar a partir de \n"
 "clientes conhecidos"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nós (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Endereço IP inválido para arranque"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Porto inválido para arranque"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Por favor, preencha todos os campos pedidos"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Tem a certeza que deseja transferir um novo ficheiro nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Ao fazê-lo, irá remover os seus nós actuais e reiniciar a ligação à Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Continuar?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: palavra-chave de pesquisa demasiado curta"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: A palavra-chave de pesquisa já está na lista de pesquisa: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Falha ao ler o ficheiro nodes.dat - demasiado antigo. Esta versão (0) já não é suportada."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Lido %u contacto Kad"
 msgstr[1] "Lidos %u contactos Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Não foram encontrados contactos. Por favor inicialize ou transfira um ficheiro nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Apenas %d contacto Kad disponível, nodes.dat não escrito"
 msgstr[1] "Apenas %d contactos Kad disponíveis, nodes.dat não escrito"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Escrito %d contacto Kad"
 msgstr[1] "Escritos %d contactos Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Rede Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Nome de ficheiro"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Tamanho do Ficheiro"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Razão de partilha"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Pedido"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Aceite"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Fontes completas"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "AVISO: Lista de ficheiros conhecidos corrompida, contém cabeçalho inválido."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Falhou ao carregar entrada na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Erro desconhecido %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Impossível obter descrição para o erro %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "A gerar chave"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "A completar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Em Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Em Espera"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Deve especificar uma palavra-passe não vazia."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Palavra-passe inválida, não é uma chave MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Falha de ligação"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Ligação externa fechada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Ligação LE falhou. Resposta vazia."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Ligação Externa: Má resposta, negociação inicial falhou. Ligação fechada."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Sucesso! Ligação estabelecida com o aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Sucesso! Ligação estabelecida."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Ligação Externa: Acesso negado porque: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ERRO: Não é possível escutar o porto TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ERRO: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "AVISO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Fechar"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Seleccionar tudo"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Ligado"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Ligado"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Ligado à Kad (atrás de firewall)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP do servidor: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP do servidor:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Não ligado"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Porto TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Porto TCP: Não preparado"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Porto UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Porto UDP: Não preparado"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informação do cliente"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limite de Upload"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limite de Download"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Mostrar"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Esconder"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sair"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menu de Área de Notificação do aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limites de velocidade:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Nenhum"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Nenhum"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Velocidade de Download: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Velocidade de Upload: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Alcunha: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nenhuma Alcunha seleccionada!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID do cliente: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nome do servidor: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP do servidor: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Não Ligado"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Assinatura Online: Activada"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Assinatura Online: Desactivada"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Tempo de funcionamento: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Ficheiros partilhados: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clientes em espera: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total DL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total UL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Adiciona uma ligação eD2k ou ligação magnet ao núcleo."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Adicionar à lista de Amigos"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Clique aqui para adicionar a ligação eD2k (na caixa de texto) à sua lista de downloads."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Os eventos são mostrados aqui. Para uma lista completa de eventos, consulte o relatório no separador Servidores."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "A carregar..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Número de utilizadores ligados a este servidor..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Utilizadores: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Utilizadores ligados ao servidor actual e um estimativa do número total de utilizadores."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Up: 0.0 | Down: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Médias de entrada e saída actuais. Se activado, os números entre parêntesis representam a sobrecarga da comunicação do cliente."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Mostra o estado da ligação e as transferências activas. Setas vermelhas significam que actualmente não está ligado, setas amarelas significam que tem LowID (atrás de firewall) e setas verdes significam que tem HighID (o tipo de ligação óptimo)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Desligado..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Servidor a que está ligado."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parâmetros estendidos"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtragem"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipo de Ficheiro"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Qualquer"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arquivos"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Áudio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imagens de CDs"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Fotografias"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programas"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Textos"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Vídeos"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensão"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Tamanho Mínimo"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "kB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Tamanho Máximo"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilidade"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrar Resultados"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inverter Resultados"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Esconder Ficheiros Conhecidos"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Iniciar"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Mais"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Limpar campos"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Limpa os downloads concluídos"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de ficheiros:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/D"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Geral"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nome completo :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Ficheiro de servidores conhecidos :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Chave :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Tamanho do ficheiro :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferência"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Estado do ficheiro de partes :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Última vez visto completo :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Fontes encontradas :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Fontes em transferência :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Contagem de partes :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponíveis :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Tempo de Download Activo: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferido :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamanho Completo :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Perdido por corrupção :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Ganho por compressão :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pacotes recuperados por M.I.C. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "A partilhar: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Pedidos"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Pedidos Aceites"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Dados Transferidos"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Grau de Partilha"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Fontes Completas"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Upload: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Não avaliado"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Título :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Nomes de ficheiros"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Assumir"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Limpar"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comentar/Avaliar ficheiro (Texto será visível a todos os utilizadores)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3603,1270 +3519,1266 @@ msgstr ""
 "Para um filme pode dizer a sua duração, enredo, idioma ...\n"
 "e se for um ficheiro falso, pode transmiti-lo aos outros utilizadores."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Qualidade do Ficheiro"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Não avaliado"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Inválido / Corrompido / Falso"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Mau"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Razoável"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bom"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excelente"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Escolha a classificação ou avise os utilizadores se o ficheiro for inválido..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Desligado da Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "A transferir, por favor aguarde ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Tamanho desconhecido"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informação Necessária"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Endereço IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Porto :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informações adicionais"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Utilizador :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Média da sessão"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidade de Upload"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Downloads activos"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Uploads activos"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Árvore de Estatísticas"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Utilizador:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Chave de utilizador:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Programa cliente:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versão do cliente:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Endereço IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID do utilizador:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP do servidor:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nome do servidor:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Ofuscação:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "A transferir"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Pedidos actuais:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Taxa média de upload:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Taxa média de download:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Enviado (sessão):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Recebido (sessão) :"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Enviado (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Recebido (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pontuações"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificador DL/UL:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificação segura:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Pontuação na fila de espera:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Pontuação na fila de espera:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Alcunha"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - a Mula multi-plataforma"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Este é o nome que os outros utilizadores verão ao ligar-se a si."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Idioma: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "O tempo que decorre até serem mostradas as dicas."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Especifica o idioma usado nos controlos."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Verificar nova versão no arranque"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ao activar, fará o aMule procurar por uma nova versão no arranque"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Iniciar minimizado"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Quando activado, o aMule minimiza automaticamente no arranque."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Confirmar fecho do programa"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Faz com que o aMule peça uma confirmação ao sair."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Activar o ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Activa/desactiva o ícone da área de notificação (ou barra de tarefas)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizar para a área de notificação"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Se activar isto o aMule vai minimizar para a área de notificação em vez de para a barra de tarefas."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Atraso de exibição de dicas: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "segundos"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selecção de Navegador"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Abrir num novo separador se possível"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Abrir a página num novo separador em vez de uma nova janela, quando possível"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Leitor de vídeo"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limites de largura de banda"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Upload"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Atribuição de Ligações"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto da eD2k por omissão e não pode ser desactivado."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Porto UDP para pedidos ao servidor (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP é usado para pedidos eD2k estendidos e para a rede Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Porto TCP UPnP (Opcional):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Máximo de fontes por ficheiro:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Ligar automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Voltar a ligar se perder ligação"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Remover servidores inactivos após"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "tentativas"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualizar a lista de servidores quando se liga a um servidor"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualizar a lista de servidores quando um cliente se liga"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Usar o sistema de prioridades"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Usar verificação inteligente de LowID ao ligar"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Ligação segura"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Apenas ligar automaticamente a servidores estáticos"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Atribuir alta prioridade a servidores adicionados manualmente"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Adicionar ficheiros para transferir em modo de pausa"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Adicionar ficheiros para transferir com prioridade automática"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Tentar receber primeiro o início e o final dos ficheiros"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Iniciar o próximo ficheiro em pausa quando um ficheiro completa"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Da mesma categoria"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Em ordem alfabética"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Reservar previamente espaço em disco para novos ficheiros"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Para novos ficheiros, reserva o espaço em disco para o ficheiro completo, reduzindo assim a fragmentação"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Parar os downloads quando o espaço livre em disco atinge "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Seleccione se quiser que o aMule verifique o espaço em disco"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Insira o espaço mínimo no disco desejado."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Guardar 10 fontes para ficheiros raros (< 20 fontes)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uploads"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Adicionar novos ficheiros partilhados com prioridade automática"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Activar"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "M.I.C. Avançada confia em todas as chaves (não recomendado)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Remover"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Clique com o botão do lado direito no ícone da pasta para partilha recursiva)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Partilhar ficheiros ocultos"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Atraso de actualização: 5 segundos"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tempo para gráfico de média: 100 minutos"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Escala do Gráfico de Ligações: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Escala do gráfico de download:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Escala do gráfico de upload"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Cores: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fundo"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Grelha"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Download actual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Média actual de download"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Média de download da sessão"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Upload actual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Média actual de upload"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Ligações activas"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidade no ícone da área de notificação"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nós Kad actuais"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nós Kad a executar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Árvore"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Número de Versões de Cliente mostradas (0=ilimitado)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! AVISO !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Máximo de novas ligações / 5 segundos"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Tamanho da memória temporária de ficheiro: 240000 Byte"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Tamanho da Lista de Espera de Upload: 5000 clientes"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Intervalo de actualização da ligação ao servidor: Desactivado"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Desactivar o modo de espera temporizado do computador"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Tema a utilizar: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Mostrar a barra de adição rápida de ligações eD2k em todas as janelas."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Mostrar informação extra nos separadores de categorias"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Mostrar velocidades de transferência na barra de título"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Antes do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Depois do nome da aplicação"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Mostrar sobrecarga na largura de banda"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientação vertical da barra de ferramentas"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Ficheiros na Fila de Espera dos Downloads"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Mostrar percentagem de progresso"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plana"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Negar acesso de convidado"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Palavra-passe de convidado para o servidor web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4874,11 +4786,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4888,828 +4800,828 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Desactivado [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "segundos"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minutos"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "horas"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dias"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "todos"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "todos os outros"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Incompleto"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Parado"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Vídeo"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arquivo"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Texto"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Activo"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "A utilizar pasta de configuração: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "À espera que o programa de conversão do ficheiro de partes termine..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "A importar %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "A ler pasta de temporários"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "A obter informação básica do ficheiro de informação de download"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "A criar ficheiro de destino"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "A carregar dados a partir do ficheiro de download antigo (%u de %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "A gravar bloco de dados no novo ficheiro único (%u de %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "A obter informação de ficheiro de fontes"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "A adicionar download e a gravar novo ficheiro de partes"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importar ficheiros de partes"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Estado"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Chave de ficheiro"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disco: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Por favor escolha uma pasta para localizar downloads incompletos! (subpastas serão incluídas)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Deseja que os ficheiros de origem dos downloads importados com sucesso sejam removidos?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Remover fontes?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ERRO: falha na criação do ficheiro de partes"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "A tentar carregar a cópia de segurança do ficheiro met de %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ERRO: Falha ao abrir o ficheiro part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ERRO: O ficheiro part.met está vazio: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ERRO: Versão inválida no ficheiro part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Erro: %s (%s) está corrompido (elementos incorrectos: %s), não é possível carregar o ficheiro."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ERRO: %s (%s) está corrompido (contagem de elementos errada), não é possível carregar o ficheiro."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "A tentar recuperar a informação do ficheiro..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "A recuperar ficheiro sem nome - tentar-se-á recuperá-lo como 'RecoveredFile.dat'"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Recuperada toda a informação disponível do ficheiro :D - A tentar usá-la..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Não é possível recuperar a informação do ficheiro :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Falha ao abrir %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "AVISO: %s parece estar corrompido (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ERRO ao gravar ficheiro parcial: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Falha ao gravar ficheiro parcial: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Erro ao gravar o ficheiro 'part.met.seeds' para %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Gravada %i semente de fontes para o ficheiro de partes: %s (%s)"
 msgstr[1] "Gravadas %i sementes de fontes para o ficheiro de partes: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Gravada %i semente de fontes para o ficheiro de partes: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Erro ao ler o ficheiro de sementes de ficheiro de partes (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Encontrada parte corrompida (%d) no ficheiro de %d parte %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Encontrada parte corrompida (%d) no ficheiro de %d partes %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Encontrada parte completa (%i) em %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Terminado a regeneração da chave de %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Erro inesperado ao completar %s. ficheiro em pausa"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Transferência concluída: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Transferência concluída: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "A eliminar o ficheiro: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "AVISO: Não é possível calcular a chave de uma parte recebida - conjunto de chaves incompleto para '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ERRO: Impossível calcular a chave de uma parte recebida - conjunto de chaves incompleto (%s). Isto nunca deveria acontecer"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF ao gerar a chave da parte transferida %u de comprimento %u (máximo %u) do ficheiro de partes '%s' com comprimento %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "AVISO: Espaço livre em disco insuficiente! A pausar o ficheiro: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Parte recebida %i está corrompida no ficheiro: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Recuperada parte corrompida %i para %s -> bytes guardados: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "A atribuir"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Transferido"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Ligação"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directórios"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Segurança"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interface"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Controlos remotos"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Assinatura Online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Eventos"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Depuração"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5719,15 +5631,15 @@ msgstr ""
 "    %PARTFILE - caminho completo do ficheiro\n"
 "    %PARTNAME - apenas o nome do ficheiro"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5743,35 +5655,35 @@ msgstr ""
 "O aMule correrá perfeitamente sem ajustar qualquer\n"
 "uma destas opções."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Falhou ao ligar Cfg ao widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Cfg para o Widget com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "O tipo de proxy ao qual está a ligar-se"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Falhou ao transferir dados do Widget para o Cfg com o ID %d e chave %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "A verificar a palavra-passe\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5779,42 +5691,42 @@ msgstr ""
 "O aMule tem de ser reiniciado para activar estas alterações:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Porto TCP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Porto UDP alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Porta para ligações externas alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Alterada a aceitação de ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Alterada interface para ligações externas.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Ofuscação do Protocolo"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5822,7 +5734,7 @@ msgstr ""
 "A sua lista de actualização automática de servidores está vazia.\n"
 "A 'actualização automática no arranque' será desactivada."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5830,33 +5742,33 @@ msgstr ""
 "Activou as ligações externas mas não especificou uma palavra-passe.\n"
 "As ligações externas não podem ser activadas a menos que seja especificada uma palavra-passe válida."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- O idioma foi alterado.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- A pasta Temp foi alterada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rede ED2K activada.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versão de protocolo inválida."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5864,7 +5776,7 @@ msgstr ""
 "As redes eD2K e Kad estão desactivados.\n"
 "Não vai conseguir uma ligação até activar pelo menos uma deles."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5872,7 +5784,7 @@ msgstr ""
 "A Kad não vai funcionar se o porto UDP estiver desactivado.\n"
 "Active o porto UDP ou desactive a Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5882,69 +5794,69 @@ msgstr ""
 "DEVE reiniciar o aMule agora.\n"
 "Se não o fizer, não se queixe se algo grave acontecer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Actualização automática iniciada"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Pasta para ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Palavra-passe definida e permitidas as ligações externas."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5954,66 +5866,66 @@ msgstr ""
 "Por favor, indique pelo menos uma localização que aponte para um ficheiro server.met válido.\n"
 "Clique no botão \"Lista\" para inserir uma localização."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Ficheiros temporários"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Ficheiros recebidos"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Assinaturas Online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Seleccione uma pasta para %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Procurar leitor de vídeo"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Seleccionar navegador"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executável%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editar a lista de servidores"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6021,1210 +5933,1209 @@ msgstr ""
 "Adicione localizações para obter ficheiros server.met\n"
 "Apenas uma localização por linha."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Fontes completas"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Estado:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervalo de actualização: %d segundo"
 msgstr[1] "Intervalo de actualização: %d segundos"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tempo para o gráfico de média: %d minuto"
 msgstr[1] "Tempo para o gráfico de média: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Escala do Gráfico de Ligações: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Tamanho de memória temporária de ficheiros: %d byte"
 msgstr[1] "Tamanho de memória temporária de ficheiros: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Tamanho da fila de espera de upload: %d cliente"
 msgstr[1] "Tamanho da fila de espera de upload: %d clientes"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervalo de actualização de ligação ao servidor: %d minuto"
 msgstr[1] "Intervalo de actualização de ligação ao servidor: %d minutos"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervalo de actualização de ligação ao servidor: Desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "desactivado"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Executar o comando quando ocorrer o evento '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Activar execução de comandos no núcleo"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comando de núcleo:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Activar execução de comando na interface gráfica"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comando da interface gráfica:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "As seguintes variáveis serão substituídas:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Pastas partilhadas"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máximo ignorado."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Aviso de pesquisa"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Não é possível pesquisar na eD2k se não estiver ligado à rede eD2k"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Palavra-chave para pesquisa: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erro inesperado enquanto tentava pesquisar na Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do Ficheiro"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Não avaliado"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Transferir para a categoria"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marcar como ficheiro conhecido"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para a área de transferência"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está ligado ao servidor que está a tentar remover. Por favor, desligue-se primeiro."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Novo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Ligação a servidores ofuscados falhou. A tentar de novo, sem ofuscação."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Ligação a servidores ofuscados falhou. A tentar de novo, sem ofuscação."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Falha ao ligar a todos os servidores listados. A tentar novamente."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Falha ao ligar a todos os servidores listados. A tentar novamente."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rede eD2K desactivada nas preferências, a ligação não vai ser feita."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Não há servidores válidos para ligar na lista de servidores"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Ligado a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Ligação estabelecida a: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Erro Fatal durante tentativa de ligação. A ligação à Internet pode ter caído"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Perdida a ligação a %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) parece estar morto."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheio."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Ligação automática ao servidor irá repetir-se em %d segundo"
 msgstr[1] "Ligação automática ao servidor irá repetir-se em %d segundos"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "A Ligação a %s (%s:%i) falhou."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ERRO: Socket inválido durante a verificação"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "A tentativa de ligação a %s (%s:%i) expirou."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Recebido resultado tardio para pedido DNS, a descartar."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "A carregar o ficheiro server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Ficheiro server.met não encontrado!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Falha ao carregar o ficheiro server.met '%s', formato desconhecido encontrado."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Falha ao abrir server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Ficheiro server.met corrompido, versão inválida encontrada: 0x%x, tamanho %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "Foi encontrado %i servidor no server.met"
 msgstr[1] "Foram encontrados %i servidores no server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d servidor adicionado"
 msgstr[1] "%d servidores adicionados"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Erro: o ficheiro 'server.met' está corrompido: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Erro de entrada/saída ao ler o ficheiro 'known.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Servidor não adicionado: [%s:%d] não especifica um porto válido."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Servidor não adicionado: O IP de [%s:%d] está filtrado ou é inválido."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Servidor não adicionado: Servidor com IP:Porto correspondente [%s:%d] encontrado na lista."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Servidor adicionado: Servidor em [%s:%d] a usar o nome '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Está ligado ao servidor que está a tentar remover. Por favor, desligue-se primeiro."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Erro ao abrir '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Falha ao gravar server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL inválido"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Terminou a transferência da lista de servidores de %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Não foi encontrada nenhuma lista de servidores no 'addresses.dat'. Por favor indique um endereço correcto neste ficheiro para a auto-actualização da lista de servidores"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Iniciar transferência de lista de servidores de %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "AVISO: URL especificado inválido para a actualização automática de servidores: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Não há nenhuma localização válida para download automático do server.met em addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Erro ao obter a lista de servidores a partir de %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Servidor local filtrado pelo Filtro de IPs, a ligar a um servidor diferente!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Endereço"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Porto"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descrição"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Utilizadores"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Estático"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Encontra-se ligado a um servidor que está a tentar remover. Por favor, desligue-se primeiro. O servidor NÃO foi removido."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nome desconhecido)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Tem a certeza que deseja eliminar o servidor estático %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Servidor"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Ligar ao servidor"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marcar o servidor como estático"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marcar o servidor como não estático"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar os servidores como estáticos"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar os servidores como não estáticos"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Remover o servidor"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Remover os servidores"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Remover todos os servidores"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copiar ligações eD2k para a área de transferência"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Voltar a ligar ao servidor"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Tem a certeza que deseja eliminar todos os servidores?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Tem a certeza que deseja eliminar o servidor seleccionado?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Tem a certeza que deseja eliminar os servidores seleccionados?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ERRO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "AVISO: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "O novo identificador de cliente é %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "AVISO: Recebeu LowID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tMuito provavelmente, isto deve-se ao facto de estar por detrás de uma firewall ou router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPara mais informação, por favor consulte https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Recebida informação do servidor desconhecida! - demasiado curta"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Recebido %d novo servidor"
 msgstr[1] "Recebidos %d novos servidores"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Gravação da lista de servidores completa."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "O servidor rejeitou o último comando"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Pacote mal formado recebido do servidor: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Erro não tratado ao processar pacote do servidor: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Não é possível criar o processo leve de resolução de nomes para ligar a %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "O endereço IP do servidor %s (%s) está filtrado. Não irá ligar."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "a utilizar ofuscação do protocolo."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "A ligar a %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Não é possível resolver o nome do servidor %s: Incapaz de ligar!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Relatório"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Servidor não adicionado: IP ou nome de máquina não especificado."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor não adicionado: Porto de servidor especificado inválido."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Estado da eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Estado da Ligação:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Ligado"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Estado da Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "A correr no modo LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "A Executar"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Estado da Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Estado:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Estado da Ligação:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Atrás de firewall - abra o porto TCP %d no seu router ou firewall"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Estado da Ligação UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Atrás de firewall - abra o porto UDP %d no seu router ou firewall"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Estado da firewall: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Não é necessário um parceiro - porto TCP aberto"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Não é necessário um parceiro - porto UDP aberto"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Sem parceiro"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "A ligar a um parceiro"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ligado a parceiro em %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fontes indexadas:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Palavras-chave indexadas:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Notas indexadas:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Carga indexada:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Média de Utilizadores:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Média de Ficheiros:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Parado"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "A adicionar ficheiro %s à partilha"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido, %i desconhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos, %i desconhecidos"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ERRO: Tentado partilhar %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Pasta partilhada não encontrada, a ignorar: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nome de Utilizador"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Partes Disponíveis"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Estado do Upload"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Estado do Download"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nome do Ficheiro Local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Partilha a Lista de Ficheiros"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Partes Obtidas"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Caminho da Pasta"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Adicionar Comentário/Avaliação"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editar Comentário/Avaliação"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Renomear"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adicionar ficheiros na colecção à lista de transferências"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiar &URI magnet para a área de transferência"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiar ligação eD2k para a área de transferência (&Fonte)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiar ligação eD2k para a área de transferência (Fonte) (Com opções C&rypt)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiar ligação eD2k para a área de transferência (&Hostname)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiar ligação eD2k para a área de transferência (Hostname) (Com opções Cr&ypt)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiar ligação eD2k para a área de transferência (informação &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiar ligação eD2k para a área de transferência (informação &AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Necessita de HighID para criar uma ligação de fonte válida"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do Ficheiro Remoto"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Dados Enviados (Sessão (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Sobrecarga Total (Pacotes): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Sobrecarga de Pedidos de Ficheiro (Pacotes): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Sobrecarga de Trocas de Fontes (Pacotes): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Sobrecarga do Servidor (Pacotes): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Sobrecarga na Kad (Pacotes): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Sobrecarga criptográfica (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Uploads Activos: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Uploads Em Espera: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total de sessões de upload com sucesso: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total de sessões de upload falhadas: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Tempo médio de envio: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Dados recebidos (Sessão (Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Fontes Encontradas: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Downloads activos (blocos): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Razão UL:DL da sessão (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Taxa média de download (Sessão): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Taxa média de upload (Sessão): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Taxa máxima de download (Sessão): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Taxa máxima de upload (Sessão): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Religações: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tempo Desde a Primeira Transferência: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Ligado Ao Servidor Desde: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Ligações Activas (estimativa): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Limite Máximo de Ligações Alcançado: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Média de Ligações (estimativa): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de Ligações (estimativa): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clientes"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Desconhecido: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrados: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Banidos: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i Conhecidos: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servidores Activos: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servidores Falhados: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servidores Removidos: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servidores Filtrados: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Utilizadores em Servidores Activos: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Ficheiros em Servidores Activos: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Total de Utilizadores: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Total de Ficheiros: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupação dos Servidores: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de Ficheiros Partilhados: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Tamanho médio dos ficheiros: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistema Operativo"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Não recebido"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Ligações activas (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Indisponível"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nunca"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Comando '%s' com pid '%d' terminou com o código '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executar <exp> e sair."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Formato de IP inválido. Use xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Este comando requer um argumento. Argumentos válidos: 'all', nome de ficheiro, ou um número.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "A processar por chave: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "A processar por ficheiro: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Este comando requer um argumento. Argumentos válidos: uma chave de ficheiro.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Número inválido\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Não é uma chave válida (o comprimento deveria ser de 32 caracteres)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7233,7 +7144,7 @@ msgstr "Escreva '%s' para obter mais ajuda.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7242,89 +7153,87 @@ msgstr "Escreva '%s' para obter mais ajuda.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Escreva '%s' para obter mais ajuda.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "A transferir %s"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "O pedido falhou com um erro desconhecido."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operação com sucesso."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Falha no pedido com o seguinte erro: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtro de IP para clientes está %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Desactivado"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Activado"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtro para servidores está %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "O nível actual do filtro de IPs é %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limites de banda: Up: %u kB/s, Down: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Ligado a %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "A ligar"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "atrás de uma firewall"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7333,7 +7242,7 @@ msgstr ""
 "\n"
 "Download:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7342,7 +7251,7 @@ msgstr ""
 "\n"
 "Upload:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7351,7 +7260,7 @@ msgstr ""
 "\n"
 "Clientes em espera:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7360,46 +7269,46 @@ msgstr ""
 "\n"
 "Total de fontes:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[FicheiroPart]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progresso da pesquisa: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progresso da pesquisa indisponível"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Recebida resposta desconhecida do servidor, instrução %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Mostrar informação curta de estado."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Mostrar estado da ligação, velocidade de transferência actual, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Mostrar a árvore de estatísticas completa."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7413,11 +7322,11 @@ msgstr ""
 "\n"
 "Exemplo: 'statistics 5' exibirá apenas as 5 versões de topo para cada tipo de cliente.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Terminar o aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7427,35 +7336,35 @@ msgstr ""
 "O cliente de texto também será desligado, uma vez que é inútil sem um\n"
 "núcleo em execução.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Recarrega o objecto."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Recarrega a tabela de filtros de IP a partir do ficheiro."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Recarrega a tabela de filtros de IPs actual."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Actualiza a tabela de filtros de IPs a partir do URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Se o URL for omitido, será utilizado o URL nas preferências."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Religar à rede."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7467,35 +7376,35 @@ msgstr ""
 "ligar apenas a esse servidor. O endereço IP deve ser na forma IPv4 ou um\n"
 "nome resolúvel por DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Ligar apenas à eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Ligar apenas à Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Desligar da rede."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Isto desligará de todas as redes actualmente ligadas.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Desligar apenas da eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Desligar apenas da Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Adiciona uma ligação eD2k ou ligação magnet ao núcleo."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7514,51 +7423,51 @@ msgstr ""
 "serão adicionados à lista dos servidores \n"
 "A ligação magnet tem de conter a chave eD2k e o tamanho do ficheiro.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Definir um valor de preferência."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Definir preferências do filtro de IPs."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Activar o filtro de IPs para servidores e clientes."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Desactivar o filtro de IPs para clientes e servidores."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activar/Desactivar filtro de IPs para clientes."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Activar filtro de IPs para clientes."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Desactivar filtro de IPs para clientes."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activar/Desactivar filtro de IPs para servidores."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Activar filtro de IPs para servidores."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Desactivar filtro de IPs para servidores."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Seleccionar nível de filtragem de IPs."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7566,74 +7475,74 @@ msgstr ""
 "Níveis de filtragem válidos pertencem ao intervalo 0-255 e\n"
 "o valor padrão (inicial) é 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Definir limites de largura de banda."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "O valor dado nestes comandos deve ser em kilobytes/s.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Definir limite de largura de banda de upload."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "O valor dado nestes comandos deve ser em kilobytes/s.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Definir limite de largura de banda de download."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "O valor dado nestes comandos deve ser em kilobytes/s.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Obter e exibir um valor de preferência."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obter preferências do filtro de IPs."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obter estado do filtro de IPs para clientes e servidores."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obter estado do filtro de IPs para clientes."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obter estado do filtro de IPs para servidores."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Obter nível de filtragem de IPs."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obter limites de largura de banda."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Faz uma pesquisa."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7652,44 +7561,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Faz uma pesquisa global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Faz uma pesquisa local"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Faz uma pesquisa na Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Mostra os resultados da última pesquisa."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Apresenta o progresso da pesquisa."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Começar a transferir um ficheiro"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7697,81 +7606,81 @@ msgstr ""
 "O número do ficheiro da última pesquisa tem de ser especificado.\n"
 "Exemplo: 'download 12' iniciará o download do ficheiro com o número 12 da última pesquisa.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pausar download."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Continuar download."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Cancelar download."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Estabelecer a prioridade."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Estabelecer a prioridade como Baixa, Normal, Alta ou Automática.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Estabelecer a prioridade como Baixa."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Estabelecer a prioridade como Normal."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Estabelecer a prioridade como Alta."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Estabelecer a prioridade como Automática."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Mostrar filas/listas."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Mostra as filas de upload/download, listas de servidores ou ficheiros partilhados.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Mostrar fila de saída."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Mostrar fila de entrada."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Mostrar o relatório."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Mostrar lista de servidores."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Recarrega a lista de ficheiros partilhados."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Apagar o relatório."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comando obsoleto, passe a usar '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7780,261 +7689,258 @@ msgstr ""
 "Este é um comando obsoleto, e poderá ser retirado no futuro.\n"
 "Passe a usar '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente de texto do aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversão de grupos de chaves AICH antigas em '%s' para 64b em '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "AVISO: O nome do ficheiro '%s' é invalido e foi mudado para '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "AVISO: O ficheiro '%s' já existe, o novo ficheiro tem agora o nome '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Tem a certeza que deseja cancelar e apagar todos os ficheiros desta categoria?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Confirmação Necessária"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Só são suportadas 99 categorias"
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Demasiadas categorias!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Todos os outros"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Seleccione o filtro de exibição"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Adicionar categoria"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editar categoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Remover categoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Conjunto de chaves pedido para ficheiro desconhecido: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "A continuar uploads do ficheiro: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "A suspender upload do ficheiro: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "A execução do comando `%s' no evento `%s' falhou."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Download concluído"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "O caminho completo para o ficheiro."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "O nome do ficheiro sem a parte do caminho."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "A chave eD2k do ficheiro."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "O tamanho do ficheiro em bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Tempo cumulativo de download."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Nova sessão de conversa iniciada"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Remetente de mensagem."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Falta de espaço"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partição de disco."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Erro ao completar"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "A processar o ficheiro número %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Requisitou chaves parciais (Usado apenas para ficheiros > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Ficheiro inexistente!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, o criador de ligações eD2k do aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Bem-vindo!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parâmetros de entrada"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Ficheiro para gerar chave"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Adicionar URLs Opcionais para este ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Indique aqui o ficheiro para o qual deseja obter o link eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Indique aqui o URL onde pretende adicionar a ligação eD2k: Adicione / ao fim para permitir que o aLinkCreator acrescente o nome de ficheiro actual"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Criar a ligação com chaves de partes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ajudar a espalhar ficheiros novos e raros mais rapidamente, com o custo de um maior tamanho da ligação"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Chave MD4 do ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Chave eD2k do ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Gravar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Abrir"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Abrir um ficheiro para calcular a sua ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiar ligação eD2k calculada para a área de transferência"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Gravar como"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Gravar a ligação eD2k calculada para um ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Acerca do aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Seleccione o ficheiro para o qual pretende criar a ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Não é possível abrir a área de transferência"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Nada a copiar por agora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seleccione o ficheiro para guardar a sua ligação eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Não é possível abrir "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Por favor, insira um nome de ficheiro"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Nada a gravar por agora!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8054,167 +7960,159 @@ msgstr ""
 "\n"
 "Distribuído sob a licença GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "A gerar chaves..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "O aLinkCreator está a trabalhar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "A calcular chave MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "A calcular chave eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Cancelado !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Concluído em %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Já adicionou este URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Por favor, insira um URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Não é possível abrir %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dia(s) %i hora(s) %i minuto(s) %i segundo(s)"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02um %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f kB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Estatísticas Online do aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Taxa máxima de download desde que o wxCas está em execução"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Taxa absoluta de download máxima durante as execuções anteriores do wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Limpar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistema"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Parar Actualização Automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Gravar imagem das Estatísticas Online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Imprimir a imagem de Estatísticas Online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Definição de preferências"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Acerca do wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Iniciar a Actualização Automática"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Actualização Automática parada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Actualização automática iniciada"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Gravar a Imagem de Estatísticas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Estatísticas Online do aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8222,11 +8120,11 @@ msgstr ""
 "Ocorreu um erro ao imprimir.\n"
 "Talvez a sua impressora actual não esteja bem configurada."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "A imprimir"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8244,403 +8142,392 @@ msgstr ""
 "\n"
 "Distribuído sob a licença GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, o aMule não esta em execução..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "O aMule está em execução"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "O aMule está a funcionar mas está desligado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "O aMule está a ligar..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, o estado do aMule é desconhecido..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " está em execução há "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " está parado !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " não está ligado !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " está a ligar..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " está a fazer algo estranho, verifique!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " está ligado a "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "parado"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " está em "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " com "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Download Total: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Download na Sessão: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Download: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upload: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "A partilhar: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " ficheiro(s). Clientes na fila de espera: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Hora: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " no "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Média de carga do sistema (1-5-15 minutos): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Tempo de funcionamento do sistema: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Pasta que contém o ficheiro amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Insira a pasta onde se encontra o seu ficheiro amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervalo de actualização em segundos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Gerar uma imagem das estatísticas a cada evento de actualização"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Insira aqui a pasta onde deseja gerar a imagem das estatísticas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Transferir periodicamente a imagem das estatísticas para o servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL do FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Caminho do FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Insira aqui o URL do seu servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Insira aqui a pasta do servidor FTP onde deseja colocar a sua imagem das estatísticas"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Utilizador"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Insira aqui o nome de utilizador para entrar no seu servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Insira aqui a palavra-passe para entrar no seu servidor FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervalo de actualização do FTP em minutos"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validar"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Pasta que contém o seu ficheiro de assinatura"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Pasta onde se gera a imagem das estatísticas"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Carrega o modelo <exp>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Porto HTTP do servidor web"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Utilizar UPnP para configurar encaminhamento no porto do servidor web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Porto UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Usar compressão gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Palavra-passe de acesso total para o servidor web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Palavra-passe de convidado para o servidor web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permitir acesso de convidado"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Negar acesso de convidado"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Carregar/guardar as preferências do servidor web de/para aMule remoto"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Caminho do ficheiro de configuração do aMule. NÃO USE DIRECTAMENTE!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Desactivar o interpretador PHP (obsoleto)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompilar as páginas PHP em cada pedido"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Servidor Web do aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "Ligação de cliente web aceite\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ERRO: não é possível aceitar ligação de cliente web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "O pedido falhou com o seguinte erro: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Ficheiro de índice não encontrado: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "A sessão expirou - a pedir entrada no sistema\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sessão ok, dentro do sistema\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sessão ok, fora do sistema\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Sessão não aberta - ir-se-á pedir entrada no sistema\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sessão criada - a pedir entrada no sistema\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "A processar pedido [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Não foi indicada uma palavra-passe, a entrada não será permitida."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Chave da palavra-passe inválida\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Palavra-passe correcta\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Palavra-passe incorrecta\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Não forneceu uma palavra-passe. Palavras-passe vazias não são permitidas.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Saída do sistema pedida\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "A processar pedido [redireccionado]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "A ligação falhou "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Lokalize 2.0\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Arată aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "control distant aMule"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Variantă versiune:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "Client p2p bazat pe eMule pentru toate platformele \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,79 +50,79 @@ msgstr ""
 "Drept de autor (c) 2003-2019 Echipa aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Părți din aMule sunt bazate pe \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Rutare P2P bazată pe XOR metric.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Drept de autor (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Site web:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Verifică la pornire dacă au apărut versiuni noi"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Se conectează la Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Indisponibil"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Adaugă un prieten"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Trebuie să introduceți un IP valid și un port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informații"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Indexul utilizator specificat nu este valid!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -131,49 +131,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "După numele aplicației"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Conectare eșuată"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,103 +181,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "A eșuat deschiderea fișierului legătură eD2k."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât timp aveți lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Acum, se oprește aplicația principală..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Eșuat"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Se termină instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Se omoară instanța amuleweb cu pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule la ieșire: Se închide nucleul."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule închidere terminată."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultatele depanării memoriei pentru ieșirea aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Limba dumneavoastră a fost schimbată la cea implicită a sistemului datorită schimbării configurației. Regretăm."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +282,70 @@ msgstr ""
 "\n"
 "configurație EC"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ATENȚIE"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "EROARE"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "server web rulând pe pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nu se pot lega porturile la adresa specificată: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Portul %u nu este disponibil. Veți fi LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +360,48 @@ msgstr ""
 "\n"
 "Verificați rețeaua pentru a vă asigura că portul este deschis pentru intrare și ieșire."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "A eșuat crearea fișierului Semnătură Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "A eșuat crearea fișierului aMule Semnătură Online"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Localizarea selectată se pare că nu este instalată pe computer. (Notă: Se va încerca configurarea acesteia oricum)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Aceasta este prima dată când rulați aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Această versiune este o versiune de testare, actualizată zilnic și\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "nu vă dăm nici un fel de garanție dacă nu se va strica nimic, ardeți-vă casa,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "sau omorâți-vă câinele. Dar * ar trebui să fie * sigur de utilizat oricum.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mai multe informații, suport și versiuni noi pot fi găsite pe pagina noastră web,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "la https://amule-org.github.io, sau în canalul nostru IRC #aMule at irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportați orice fel de probleme la https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,224 +409,220 @@ msgstr ""
 "Dosarul specificat pentru Semnătura Online NU ESTE VALID!\n"
 "Semnătura Online va fi DEZACTIVATĂ până va fi reparată problema în preferințe."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Prealocarea spațiului pe disc pentru fișierul '%s' a eșuat: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "EROARE: nu se poate deschide fișierul jurnal"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ATENȚIE: fișierul jurnal este gol. Ceva este greșit."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Jurnalul a fost resetat"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesaj server: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Se omite descărcarea a %s, fiindcă fișierul solicitat nu este mai nou."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "A eșuat descărcarea listei de noduri."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "A eșuat deschiderea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Fișierul de verificare a versiunii este corupt"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Utilizați o versiune învechită de aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versiunea dumneavoastră de aMule este %i.%i.%i iar ultima versiune este %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ATENȚIE: Versiunea dumneavoastră aMuled este învechită: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Copia dumneavoastră aMule este actualizată."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "A eșuat descărcarea fișierului de verificare a versiunii"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Utilizatori: %s | Fișiere: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Utilizatori: E: %s K: %s | Fișiere: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Nu este selectată nicio rețea"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "cu LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "cu HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Conectat la %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Conectare la %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Deconectat de la eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad este pornit."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad este oprit."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Conectat la Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Nu se poate utiliza rețeaua Kad dacă portul UDP este dezactivat în preferințe, nu se pornește."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rețeaua Kad este dezactivată în preferințe, nu se conectează."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "EROARE: Demonul aMule nu poate fi utilizat când conexiunile externe sunt dezactivate. Pentru a se activa Conexiuni Externe, utilizați fie un aMule normal, se pornește amuled cu opțiunea --ec-config sau configurați cheia \"AcceptExternalConnections\" la 1 în fișierul ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "EROARE: Este necesară o parolă validă pentru utilizarea conexiunilor externe, iar demonul aMule nu se poate utiliza fără conexiuni externe. Pentru a rula demonul aMule, trebuie să configurați câmpul \"ECPassword\" în fișierul ~/.aMule/amule.conf cu o valoare corespunzătoare. Executați amuled cu marcajul --ec-config pentru configurarea parolei. Mai multe informații pot fi găsite la https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - se pornește temporizarea"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Nu se poate crea fișierul Pid"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "EROARE: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Acesta este aMule %s bazat pe eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,193 +632,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Nicio rețea"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "control la distanță aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Eroare fatală: Nu s-a putut crea temporizatorul nucleului"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Conectare la amule distant"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Conexiune pierdută"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Arată la ieșire"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -839,153 +820,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Eroare fatală: A eșuat crearea Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Se merge la bucla evenimentului..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Conectare..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "GUI distant rezolvare eveniment EC"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Conectare eșuată. Nu se poate conecta la %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Se închide"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Încercarea conectării la %s (%s:%i) a expirat."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Conectare la rețea."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Conectare eșuată. Nu se poate conecta la %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Pregătit"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Toate"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Indisponibilă"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Fișierul nu este găsit."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează directorul '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Se caută parteneri pentru conexiunea lowid"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versiune eMule falsă %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule fals)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule fals)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (bazat pe eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nume Nick: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitat: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -993,7 +964,7 @@ msgstr[0] "Stare fișiere pentru această sesiune: Acceptat %d din %d solicitat,
 msgstr[1] "Stare fișiere pentru această sesiune: Acceptate %d din %d solicitate, %s transferate\n"
 msgstr[2] "Stare fișiere pentru această sesiune: Acceptate %d din %d solicitate, %s transferate\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1001,119 +972,119 @@ msgstr[0] "Stare fișiere pentru toate sesiunile: Acceptat %d din %d solicitat, 
 msgstr[1] "Stare fișiere pentru toate sesiunile: Acceptate %d din %d solicitate, %s transferate\n"
 msgstr[2] "Stare fișiere pentru toate sesiunile: Acceptate %d din %d solicitate, %s transferate\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Solicitat fișier necunoscut"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mesaj filtrat de la '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Mesaj nou de la '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Utilizatorul %s (%u) a solicitat lista fișierelor partajate pentru un director inexistent '%s' -> se ignoră"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ATENȚIE: %s nu poate fi deschis."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ATENȚIE: S-a anulat lista de fișiere coruptă, conține antet nevalid."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Eroare IO în timpul citirii fișierului %s : %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Eroare în timpul salvării fișierului %s : %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Categorie nouă"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Alegeți un dosar pentru fișierele primite"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Trebuie să specificați un nume pentru categorie!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Trebuie să specificați o cale pentru categorie!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "A eșuat crearea directorului de primire pentru categorie. Specificați o cale validă!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "A pornit sesiunea de chat: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Conectat la client ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Se conectează la client ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** A eșuat conectarea la client / Conexiune pierdută ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Ați trecut verificarea captcha iar utilizatorul a primit mesajul dumneavoastră. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Răspunsul la verificarea captcha a fost greșit iar mesajul dumneavoastră a fost ignorat. Puteți solicita o nouă verificare captcha pentru a trimite un mesaj nou. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Discuție"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Închide tab"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Închide toate ferestrele"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Închide alte ferestre"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Adaugă la prieteni"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1121,7 +1092,7 @@ msgstr[0] "Fișierul credit este încărcat, %u client este cunoscut"
 msgstr[1] "Fișierul credit este încărcat, %u clienți sunt cunoscuți"
 msgstr[2] "Fișierul credit este încărcat, %u de clienți sunt cunoscuți"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1129,173 +1100,170 @@ msgstr[0] " - Credit expirat pentru %u client!"
 msgstr[1] " - Credit expirat pentru %u clienți!"
 msgstr[2] " - Credit expirat pentru %u de clienți!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Nu s-a găsit niciun fișier 'cryptkey.dat' , se creează."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detalii client"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Activat"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Susținut"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Nu este susținut"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Dezactivat"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectat"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Deconectat"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nu este finalizat"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Utilizator rău"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificat - ok"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Indisponibilă"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Utilizatorul %s (%u) solicită lista fișierelor partajate -> Acceptat"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Utilizatorul %s (%u) solicită lista fișierelor partajate -> Interzis"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Utilizatorul %s (%u) solicită lista directoarelor partajate -> Acceptat"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Utilizatorul %s (%u) solicită lista directoarelor partajate -> Interzis"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Utilizatorul %s (%u) solicită lista fișierelor partajate pentru directorul '%s' -> acceptat"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Utilizatorul %s (%u) solicită lista fișierelor partajate pentru directorul '%s' -> interzis"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Utilizatorul %s (%u) partajează directorul '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Utilizatorul %s (%u) trimite directoare partajate nesolicitate."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Utilizatorul %s (%u) trimite lista fișierelor partajate pentru directorul '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Utilizatorul %s (%u) a finalizat trimiterea listei fișierelor partajate"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Utilizatorul %s (%u) trimite o listă de fișiere nedorită"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Utilizatorul %s (%u) interzice accesul la lista directoarelor/fișierelor partajate"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Comentarii fișier"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Utilizator"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Denumire fișier"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Evaluare"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Comentariu"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Nu se poate face o căutare Kad dacă nu rulează Kad"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Se caută parteneri pentru conexiunea lowid"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Fără comentarii"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1303,268 +1271,258 @@ msgstr[0] "%u comentariu"
 msgstr[1] "%u comentarii"
 msgstr[2] "%u de comentarii"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Client interzis %s pentru trimiterea %s date corupte a %s total pentru fișierul '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "A eșuat încărcarea datei țării pentru '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Automat [Sc]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Automat [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Automat [În]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Înaltă"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Foarte ridicat"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Versiune"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Se solicită"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Se conectează prin server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Coadă plină"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "În coadă"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Se descarcă"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Se primesc indexări"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nu sunt părți necesare"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nu se poate conecta LowID la LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Prea multe conexiuni"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Conectare prin Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Prea multe conexiuni Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Interzis"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Eroare de conexiune"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Coadă distantă este plină"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Vechiul MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Noul MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Compatibil eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Server local"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Schimb surse"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasiv"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Legătură"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Semințe sursă"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Rezultat căutare"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminat"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "În curs"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "EROARE: Spațiu disc insuficient"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "EROARE: Nu s-a găsit partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "EROARE: Eroare IO!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "EROARE: Eșuare!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "În coadă"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Deja se descarcă"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Format fișier temporar necunoscut sau greșit."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Transferat"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Viteză"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Progres"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Surse"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritate"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Stare"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Timp rămas"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Văzut complet ultima dată"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Ultima recepție"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Sigur doriți să ștergeți fișierul selectat?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Sigur doriți să ștergeți fișierele selectate?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1573,109 +1531,106 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automat"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stop"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pauză"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Reluare"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "C&urăță terminate"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Schimbă acum fiecare A4AF la acest fișier"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Schimbă fiecare A4AF la acest fișier (automat)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Schimbă acum fiecare A4AF la oricare fișier"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opțiuni extinse"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Previzualizează"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Arată fișierele & detaliile"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Arată toate comentariile"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Copiază URI magnet în memoria temporară"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Coiază link-ul eD2k în memoria temporară"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiază feedback-ul în memoria temporară"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "neatribuit"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Atribuit la categoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Deshide fișierul"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Introduceți noul nume pentru acest fișier:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Redenumire fișier"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descărcări (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1684,47 +1639,47 @@ msgstr ""
 "Pentru a preveni apariția acestui avertisment la fiecare previzualizare,\n"
 "configurați în preferințe playerul video preferat (implicit este %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Previzualizare fișier"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "EROARE: A eșuat execuția playerului media extern! Comanda: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Se salvează fișierul parțial %u of %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Toate fișierele parțiale au fost salvate."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Se încarcă fișierul temporar de la %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Se încarcă fișierul parțial %u of %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "EROARE: A eșuat încărcarea fișierului de backup. Căutați pe https://github.com/amule-org/amule/discussions soluții de recuperare pentru .part.met"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Toate fișierele parțiale sunt încărcate."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nu s-au găsit fișiere parțiale"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1732,50 +1687,50 @@ msgstr[0] "S-a găsit %u fișier parțial"
 msgstr[1] "S-au găsit %u fișiere parțiale"
 msgstr[2] "S-au găsit %u de fișiere parțiale"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Sistemul de fișiere pentru directorul temporar nu poate manipula fișiere mari."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Sistemul de fișiere pentru directorul de intrare nu poate manipula fișiere mari."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Se descarcă %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Deja încercați să descărcați fișierul '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Deja aveți fișierul '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Deja aveți fișierul '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Deja încercați să descărcați fișierul %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Nu se poate converti legătura magnet la eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protocol necunoscut pentru legătura: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1783,251 +1738,250 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Legătură eD2k nevalidă! EROARE: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Clientul a trimis pachetul după eșuarea autentificării."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Conexiune externă închisă."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Conexiunile externe sunt dezactivate datorită lipsei parolei!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Conexiunile externe sunt dezactivate în fișierul de configurare"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Conexiune externă nouă acceptată"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "EROARE: nu se poate accepta o nouă conexiune externă"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Conexiunea externă este refuzată datorită lipsei parolei în preferințe!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Se conectează clientul: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Versiune necunoscută"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Incorecta EC versiune ID, poate fi o incompatibilitate de aplicații. Utilizați nucleul și aplicația distantă de la aceiași versiune."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Nu vă puteți conecta la o versiune lansată dintr-o versiune în dezvoltare arbitrară! *uf* se pot preveni disfuncțiile"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Versiune protocol nevalidă."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Lipsește eticheta versiunii protocolului."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentificare eșuată: indexul specificat este nevalid ca parolă EC."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Autentificare eșuată: parolă greșită."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Autentificare eșuată: lipsă parolă."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Solicitare nevalidă, autentificați-vă întâi."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Acces asigurat."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Trimite mesajul de eroare \"%s\" la client."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Încercare neautorizată de acces de la %s. Conexiune închisă."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "A eșuat comanda distantă a fișierului parțial: Nu a fost găsit fișierul index: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Indexul fișierului  nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Eroare la procesarea OpCode!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Serverul nu este adăugat"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "serverul nu este găsit: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "trebuie să definiți un server pentru a fi eliminat"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k este dezactivat în preferințe."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nu are nici un sens căutarea web de pe interfața distantă."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Căutare în desfășurare. Se readuc rezultatele imediat!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Nici un punct pentru grafic."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Clientul dumneavoastră nu este configurat pentru acest nivel detaliat."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Conexiune externă: închidere solicitată"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Deja se închide."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Conexiune externă: se adaugă legătura '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Legătură nevalidă sau care este deja în listă."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Fișierul nu este găsit."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Nume fișier nevalid."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nu se poate redenumii fișierul."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad este dezactivat din preferințe."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Deja este conectat la eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Se conectează la eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Deja este conectat la Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Se conectează la Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Toate rețelele sunt dezactivate."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Deconectat de la eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Deconectat de la Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Conexiune externă: S-a primit un opcode nevalid: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Opcode nevalid (versiune protocol greșită?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Extensie necunoscută '%s' pentru comanda '%s' .\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Comandă necunoscută '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2035,7 +1989,7 @@ msgstr ""
 "\n"
 "Această comandă nu poate avea un argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2043,7 +1997,7 @@ msgstr ""
 "\n"
 "Această comandă trebuie să aibă un argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2051,7 +2005,7 @@ msgstr ""
 "\n"
 "Această comandă este incompletă, trebuie să utilizați una dintre extensiile de mai jos.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2059,11 +2013,11 @@ msgstr ""
 "\n"
 "Extensii disponibile:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Comenzi disponibile:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2074,17 +2028,17 @@ msgstr ""
 "Toate comenzile nu sunt sensibile la majuscule.\n"
 "Tastați '%s <comandă>' pentru a obține informații detaliate la <comandă>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Ieși din aplicație."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Arată ajutorul."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2092,7 +2046,7 @@ msgstr ""
 "Pentru a obține ajutor la o comandă, tastați 'help <comandă>'.\n"
 "Pentru a obține lista completă a comenzilor tastați 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2103,46 +2057,46 @@ msgstr ""
 "Utilizați '%s' pentru lista de comenzi\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Eroare sintaxă!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Eroare la procesarea comenzii - nu ar trebui să se întâmple! Raportați defectul\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Această comandă nu ar trebui să aibă niciun parametru."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Comanda trebuie să aibă un parametru."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argument nevalid."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Aceasta este o comandă incompletă."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Tastați '%s' pentru a obține mai mult ajutor.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Aceasta este %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Aceasta este %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2150,7 +2104,7 @@ msgstr ""
 "\n"
 "Se creează clientul...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2159,7 +2113,7 @@ msgstr ""
 "\n"
 "Ok, se iese %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2171,331 +2125,326 @@ msgstr ""
 "Trebuie să specificați o parolă fie în fișierul de configurare\n"
 "sau în linia de comandă, sau introduceți una când se solicită.\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Arată acest text de ajutor."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Gazda unde aMule rulează. (implicit: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Portul aMule pentru conexiunea externă. (implicit: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Parolă conexiune externă."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Citește configurația din fișier."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Nu tipării nicio ieșire la stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Fi detaliat - arată și mesajele de depanare."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Configurează localizarea programului (limba)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Scrie opțiunile liniei de comandă la fișierul de configurare."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Creează fișierul de configurare bazat pe fișierul de configurare al aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Tipărește versiunea programului."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detalii fișier"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% realizat"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Bine ați venit!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Se conectează la persoane"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Stare conexiune:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Rețele"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Port TCP standard"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Port UDP extins (Kad / căutare globală)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Activează UPnP pentru înaintare port ruter"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Deja încercați să descărcați fișierul %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Actualizează automat lista serverelor la pornire"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navigare"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru citit!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru scris!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Prieteni"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Arată &Detaliile"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Adaugă un prieten"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Elimină prieten"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Trimite &Mesaj"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Vizualizare fișiere"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Stabilește slot prieten"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Sigur doriți să eliminați prietenul selectat?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Sigur doriți să eliminați prietenii selectați?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2503,11 +2452,11 @@ msgstr ""
 "Nu vă este permis să configurați mai mult de un slot prieten.\n"
 "A fost alocat numai un singur slot."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Selecții multiple"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2516,183 +2465,182 @@ msgstr ""
 "Nu vă este permis să configurați mai mult de un slot prieten.\n"
 "A fost alocat numai un singur slot."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Trimite mesaj utilizatorului"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mesaj de trimis:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Elimină dintre prieteni"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Trimite mesaj"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Schimbă la acest fișier"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "În coadă: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Întrebat de un alt fișier"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Se așteaptă slotul de încărcare"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "În coadă: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Se încarcă"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Niciunul"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nu"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Se descarcă..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Descărcare HTTP anulată"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "Adresa URL de descărcat nu poate fi goală"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Descărcat %d octeți"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Adresa URL %s a returnat: %i - Eroare (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Descărcare HTTP anulată"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Se descarcă un nou fișier GeoIP.dat de la %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Descărcarea fișierului GeoIP.dat a eșuat, se abandonează actualizarea."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "A eșuat eliminarea fișierului %s , se abandonează actualizarea."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "A eșuat redenumirea fișierului %s file, se abandonează actualizarea."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Actualizat cu succes %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Eroare la actualizarea GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "A eșuat descărcarea %s de la %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Se încarcă filtrele 'ipfilter.dat' și 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "A eșuat încărcarea fișierului ipfilter.dat '%s', s-a întâlnit un format necunoscut."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "A eșuat încărcarea fișierului ipfilter.dat '%s', nu se poate deschide fișierul."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2700,7 +2648,7 @@ msgstr[0] "S-a încărcat %u interval IP de la '%s'."
 msgstr[1] "S-au încărcat %u intervale IP de la '%s'."
 msgstr[2] "S-au încărcat %u de intervale IP de la '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2708,16 +2656,16 @@ msgstr[0] "%u linie incorectă a fost descărcată."
 msgstr[1] "%u linii incorecte au fost descărcate."
 msgstr[2] "%u de linii incorecte au fost descărcate."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "A eșuat redenumirea fișierului nou %s , se abandonează actualizarea."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "Filtrul IP este gata"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2725,56 +2673,52 @@ msgstr ""
 "Bootstrap de la \n"
 "clienți cunoscuți"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noduri (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ip nevalid pentru bootstrap"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Port nevalid la bootstrap"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Completați toate câmpurile solicitate"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mesaj"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Sigur doriți să descărcați un nou fișier nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Procedând astfel veți elimina nodurile curente și veți reporni conexiunea Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Se continuă?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: cuvântul cheie căutat este prea scurt"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Cuvântul cheie căutat este deja în lista de căutare:"
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "A eșuat citirea fișierului nodes.dat - prea vechi. Această versiune (0) nu mai este suportată."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2782,12 +2726,11 @@ msgstr[0] "Sa citit %u contact Kad"
 msgstr[1] "S-au citit %u contacte Kad"
 msgstr[2] "S-au citit %u de contacte Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Nu s-au găsit contacte, bootstrap, sau descărcați un fișier nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2795,7 +2738,7 @@ msgstr[0] "Este disponibil numai %d contact Kad, nodes.dat nu s-a scris"
 msgstr[1] "Sunt disponibile numai %d contacte Kad, nodes.dat nu s-a scris"
 msgstr[2] "Sunt disponibile numai %d de contacte Kad, nodes.dat nu s-a scris"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2803,801 +2746,774 @@ msgstr[0] "S-a scris %d contact Kad"
 msgstr[1] "S-au scris %d contacte Kad"
 msgstr[2] "S-au scris %d de contacte Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Rețea Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Denumire fișier"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Dimensiune fișier"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Rată de partajare"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Cerut"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Acceptat"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Surse complete"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ATENȚIE: Lista de fișiere cunoscute este coruptă, conține antet nevalid."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "A eșuat încărcarea intrării în lista de fișiere cunoscute, fișierul poate fi corupt"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Intrare nevalidă în lista de fișiere cunoscute, fișierul poate fi corupt:"
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Eroare necunoscută %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Nu se poate obține descrierea erorii pentru eroarea %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Se indexează"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Finalizat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Terminat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Întrerupt"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Eronat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Se așteaptă"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Trebuie să specificați o parolă."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Parolă nevalidă, nu este un index MD5!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Eșec la conectare"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Conexiune externă închisă."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Conexiune EC eșuată. Răspuns gol."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Conexiune externă: Răspuns greșit, a eșuat strângerea de mână. Conexiune închisă."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Succes! Conexiune stabilită la aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Succes! Conexiune stabilită."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Conexiune externă; Acces interzis fiindcă:"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Conexiune externă: A eșuat strângerea de mână."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Ascultare socket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "EROARE: Nu se poate asculta portul TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "EROARE:"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ATENȚIE:"
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Închide"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Taie"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiază"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Lipește"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Curăță"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Selectează tot"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Conectat"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Conectat"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Conectat la Kad (prin firewall)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP server"
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP server:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Neconectat"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "port TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Port TCP: Nu este pregătit"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "port UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "port UDP: Nu este pregătit"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informație client"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Limită încărcare"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Limită descărcare"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Arată aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Ascunde aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Ieşire"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Nelimitat"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Meniul aMule din bara de sistem"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Limite viteză:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "ÎN: Fără"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "ÎN: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DE: Fără"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DE: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Viteză descărcare: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Viteză încărcare: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Poreclă: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nu este selectată nicio poreclă!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID client:"
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Nume server:"
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP server"
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Nu este conectat"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Semnătură online: Activat"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Semnătură online: Dezactivat"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Timp conectare: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Fișiere partajate: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Clienți în coadă: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Total DE: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total ÎN: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Adaugă la nucleu un link eD2k sau magnet."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Adaugă la prieteni"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Apăsați aici pentru a adăuga legătura eD2k în controlul textului în coada de descărcare."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Evenimentele sunt afișate aici. Pentru o listă completă de evenimente, aveți referințe în jurnal în fila serverelor."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Se încarcă ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Numărul de utilizatori pe serverul la care sunteți conectat ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Utilizatori: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Utilizatori conectați la serverul curent și o estimare a numărului total de utilizatori."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "În: 0.0 | Desc: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Media curentă a ratelor de încărcare și descărcare. Dacă activați numerele dintre paranteze semnifică comunicația globală cu clientul."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Afișează starea conexiunii și transferurile active. Săgețile roșii semnifică faptul că nu sunteți actualmente conectat, săgețile galbene semnifică că aveți low ID (prin firewall) iar săgețile verzi semnifică faptul că aveți high ID (Tipul optim de conexiune)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Nu este conectat ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Server conectat curent."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Căutare"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Name:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Local"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parametrii extinși"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrare"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Tipul fişierului"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Oricare"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arhive"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imagini-CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Imagini"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programe"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Texte"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videoclipuri"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Extensie"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Dimensiune minimă"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Baiți"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MO"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GO"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Dimensiune maximă"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Disponibilitate"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtru:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Rezultate filtru"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Inversează rezultatul"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Ascunde fișierele cunoscute"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Începe"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Mai mult"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Oprește"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarcă"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Resetare câmpuri"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultate"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Curăță descărcările terminate"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Surse fișier:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "General"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Nume complet :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-File :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Index :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Dimensiune fișier :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Stare fișier parțial :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Văzut ultima oară complet :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "S-au găsit sursele :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Se transferă sursele :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Cantitate-fișiere parțiale :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Disponibil :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Timp activ de descărcare:"
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Transferat :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Dimensiune completă :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestionare inteligentă a fișierelor corupte"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Pierdut la corupte :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Câștigat prin compresie :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Pachete salvate de I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Partajare:"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Cereri"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Solicitări acceptate"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Date transferate"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Rată partajare"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Surse complete"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Fișiere partajate"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Încărcat: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Nu este apreciat"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titlu :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Denumiri fișier"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Preluare"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Curățire"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Aplică"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Comentariu/evaluare fișier (textul va fi vizibil tuturor utilizatorilor)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3605,1269 +3521,1265 @@ msgstr ""
 "Pentru un film puteți spune lungimea, scenariul, limba ...\n"
 "iar dacă este un fals, puteți spune aceasta altor utilizatori de aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Calitatea fișierului"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Nu este apreciat"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Nevalid / Corupt / Fals"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Slab"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Corect"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bun"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Excelent"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Alegeți evaluarea fișierului sau atenționați utilizatorii dacă fișierul este nevalid ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Deconectat de la Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Reîmprospătează"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Se descarcă, așteptați ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Mărime necunoscută"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informație solicitată"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Adresă IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informații suplimentare"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Nume utilizator:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Adaugă"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Medie sesiune"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Viteză-încărcare"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Descărcări active"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Arbore statistici"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Index utilizator:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Aplicație client:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versiune client:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "adresă IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Id. utilizator:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP server:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Nume server:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Disimulare:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferuri la client"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Solicitare curentă:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Rată medie de încărcare:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Rată medie de descărcare:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Încărcare (sesiune):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Descărcare (sesiune)"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Încărcat (total)"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Descărcat (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scoruri"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modificator De/În:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identificare sigură:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Rang coadă:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Scor coadă:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nick"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - Mule multi-platformă"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Acesta este numele pe care ceilalți utilizatori îl va vedea când se va conecta la dumneavoastră."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Limbă:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Întârzierea afișării sfaturilor."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Aceasta specifică limba utilizată la controale."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Verifică la pornire dacă au apărut versiuni noi"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Activând aceasta va face aMule să verifice după noi versiuni la pornire"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Pornește minimizat"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Activând aceasta face aMule să se minimizeze după pornire."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Arată la ieșire"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Face ca aMule să afișeze înainte de ieșire."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Activează miniatura în bara de sistem"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Aceasta activează/dezactivează miniatura de pe bara de sistem (sau bara de sarcini)."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Ascunde fereastra aplicației când este apăsat butonul de închidere"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizează în bara de sistem"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Activând aceasta va face ca aMule să se minimizeze pe bara de sistem, mai degrabă decât în bara de sarcini."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Timp de întârziere balon de ajutor:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "secunde"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Selecție navigator"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Deschide într-o fereastră nouă dacă este posibil"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Deschide pagina web într-o pagină nouă în schimbul unei ferestre noi când este posibil"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Player video"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Limite lățime de bandă"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Încărcare"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Alocare slot"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Porturi"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Acesta este portul standard eD2k și nu poate fi dezactivat."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Port UDP pentru cererile serverului (TCP+3)"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Acest port UDP este utilizat pentru solicitări extinse eD2k și rețeaua Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Port UPnP TCP (facultativ):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Număr maxim de surse pe fișier descărcat:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Conectare automată la pornire"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Reconectare la pierdere"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Elimină serverele moarte după"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "încercări"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Listă"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Actualizează lista serverelor la conectarea la un server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Actualizează lista serverelor când se conectează un client"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Utilizează prioritatea sistemului"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Utilizează verificarea inteligentă LowID la conectare"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Conectare sigură"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Conectează automat numai la serverele din lista statică"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Configurează serverele adăugate manual la prioritate înaltă"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Adaugă fișiere la descărcare în modul pauză"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Adaugă fișiere la descărcare cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Încearcă să descarci întâi prima și ultima bucată"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Pornește următorul fișier pauzat când un fișier s-a terminat"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Din aceeași categorie"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "În ordine alfabetică"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Prealocare spațiu pe disc pentru noile fișiere"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Pentru noile fișiere se prealocă spațiu pe disc pentru întreg fișierul, astfel se reduce fragmentarea"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Oprește descărcarea când s-a atins limita spațiului disponibil"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Selectați asta dacă doriți ca aMule să verifice spațiul liber pe disk"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Introduceți aici minimum de spațiu pe disc dorit."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Salvează 10 surse de fișiere rare (< 20 surse)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Încărcări"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Adaugă noile fișiere partajate cu prioritate automată"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Gestionare inteligentă a fișierelor corupte (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Activează"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "I.C.H. avansat acordă încredere fiecărui index (nu este recomandat)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Dosare partajate"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Click dreapta pe miniatura dosarului pentru partajare recursivă)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Partajează fișierele ascunse"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafice"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Întârziere actualizare : 5 secunde"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Timp pentru media graficului: 100 minute"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Scală grafic conexiuni: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Scală grafic descărcare:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Scală grafic încărcare:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Colori:"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Fundal"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Grilă"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Descărcare actuală"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Medie rulare descărcare"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Medie descărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Încărcare actuală"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Medie rulare încărcare"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Conexiuni active"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Miniatură rapidă pe bara de sistem"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Noduri Kad curente"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Noduri Kad care rulează"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Selectează"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Arbore"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Număr de versiuni client arătate (0=nelimitat)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ATENȚIE !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maxim conexiuni noi /5 secunde"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dimensiune fișier tampon: 240000 octeți"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Dimensiune coadă încărcare: 5000 clienți"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval reîmprospătare conexiune server: Dezactivat"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Dezactivează temporizarea modului de st-by al computerului"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Aspect interfață de utilizat:"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Arată \"Manipulator linkuri rapide eD2k\" în fiecare fereastră."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Arată informații extinse în fila categoriilor"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Arată în titlu versiunea aplicației"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Arată rata de transfer în titlu"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Înaintea numelui aplicației"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "După numele aplicației"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Arată lățimea de bandă globală"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientare verticală a barei de unelte"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Descărcare coadă fișiere"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Arată procentul progresului"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Arată bara de progres"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plat"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Interzice accesul oaspeților"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Parola de oaspete pentru serverul web"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4875,11 +4787,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4889,477 +4801,477 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Dezactivat [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "octet"
 msgstr[1] "octeți"
 msgstr[2] "octeți"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kO"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TO"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "octet/secundă"
 msgstr[1] "octeți/secundă"
 msgstr[2] "octeți/secundă"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MO/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "secunde"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minute"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ore"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "zile"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "toţi"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "toți ceilalți"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "incomplet"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Oprit"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arhivă"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Text"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Activă"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Utilizând directorul de configurare: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Se așteaptă ca procesul de conversie pentru fișierul parțial să moară..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Se importă %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Se citește dosarul temporar"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Se obține informația de bază din fișierul informație descărcat"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Se creează fișierul destinație"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Se încarcă datele din fișierul vechi descărcat (%u of %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Se salvează datele blocului într-un nou și unic fișier descărcat (%u of %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Se preia sursa informației fișierelor descărcate"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Se adaugă descărcarea și se salvează fișierul parțial nou"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Se importă fișiere parțiale"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Stare"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Fișier index"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disc: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Alegeți un dosar pentru a căuta descărcări temporare! (subdosarele vor fi incluse)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Doriți ca fișierele sursă ale descărcărilor importate cu succes să fie șterse?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Se elimină sursele?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "EROARE: A eșuat crearea fișierului parțial"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Se încearcă încărcarea copiei de siguranță a met-file de la %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "EROARE: A eșuat deschiderea fișierului part.met : %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "EROARE: fișierul part.met este de dimensiune 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "EROARE: Versiune nevalidă a fișierului part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Eroare: %s (%s) este corupt (etichete greșite: %s), nu se poate încărca fișierul."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "EROARE: %s (%s) este corupt (număr etichetă greșit), nu se poate încărca fișierul."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Se încearcă recuperarea informației fișierului..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Se recuperează fișierul nedenumit - se va încerca recuperarea ca RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "S-a recuperat toate fișierele informație disponibile :D - Se încearcă utilizarea lor..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Nu se poate recupera informația fișierului :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "A eșuat deschiderea %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ATENȚIE: %s ar putea fi corupt (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "EROARE în timpul salvării fișierului parțial: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Eșuare IO în timpul salvării fișierului parțial:"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "A eșuat salvarea fișierului part.met.seeds pentru %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5367,17 +5279,17 @@ msgstr[0] "S-a salvat %i sursă sămânță pentru fișierul parțial: %s (%s)"
 msgstr[1] "S-au salvat %i surse semințe pentru fișierul parțial: %s (%s)"
 msgstr[2] "S-au salvat %i de surse semințe pentru fișierul parțial: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Nu se poate citi fișierul semințe pentru fișierul parțial %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Eroare la citirea fișierului sămânță al fișierului parțial (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5385,334 +5297,334 @@ msgstr[0] "S-a găsit partea coruptă (%d) în %d fișierul parțial %s - Rezult
 msgstr[1] "S-a găsit partea coruptă (%d) în %d fișiere parțiale %s - Rezultat index fișier |%s| Index fișier |%s|"
 msgstr[2] "S-a găsit partea coruptă (%d) în %d de fișiere parțiale %s - Rezultat index fișier |%s| Index fișier |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "S-au găsit părți complete (%i) în %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "S-a finalizat reindexarea %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Eroare neașteptată în timpul finalizării %s. Fișier pauzat"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "S-a finalizat descărcarea: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "S-a finalizat descărcarea: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Se șterge fișierul: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "Atenție: Nu se poate indexa partea descărcată - indexare incompletă pentru '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "EROARE: Nu se poate indexa partea descărcătă - indexare incompletă (%s). Aceasta nu ar trebui să se întâmple"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF  în timpul indexării părții descărcate %u cu lungimea %u (max %u) de fișiere parțiale '%s' cu lungimea %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ATENȚIE: Nu este suficient spațiu liber pe disc! Se pauzează fișierul: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Partea descărcată %i este coruptă în fișierul: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: S-a recuperat partea coruptă %i pentru %s -> Octeți salvați: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Se alocă"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Spațiu pe disc insuficient"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descărcat"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Conexiune"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directoare"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servere"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Securitate"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Interfaţă"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtre"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Control la distanță"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Semnătură online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avansat"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Evenimente"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Depanare"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5722,15 +5634,15 @@ msgstr ""
 "    %PARTFILE - calea completă la fișier\n"
 "    %PARTNAME - numai nume fișier"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5745,35 +5657,35 @@ msgstr ""
 "aMule va rula perfect fără să ajustați nimic\n"
 "din aceste configurări."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "A eșuat conectarea Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la Cfg la widget cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Tipul de proxy la care sunteți conectat"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "A eșuat transferul datelor de la widget la Cfg cu ID %d și cheia %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Se verifică parola\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5781,41 +5693,41 @@ msgstr ""
 "aMule trebuie repornit pentru ca aceste modificări să fie activate:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- Portul TCP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- Portul UDP s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Portul conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Conectarea externă acceptă modificarea.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Interfața conexiunii externe s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Suportul protocolului disimulare s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5823,7 +5735,7 @@ msgstr ""
 "Lista de actualizare automată a serverelor este goală.\n"
 "'Actualizează automat lista serverelor la pornire' va fi dezactivată."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5831,33 +5743,33 @@ msgstr ""
 "Ați activat conexiunile externe dar nu ați specificat o parolă.\n"
 "Conexiunile externe nu se pot activa până ce nu va fi specificată o parolă validă."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Limba s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Dosarul temporar s-a schimbat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- Rețeaua ED2K s-a activat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Versiune protocol nevalidă."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5865,7 +5777,7 @@ msgstr ""
 "Ambele rețele eD2k și Kad sunt dezactivate.\n"
 "Nu vă puteți conecta doar după ce veți activa cel puțin una dintre ele."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5873,7 +5785,7 @@ msgstr ""
 "Kad nu va porni dacă portul UDP este dezactivat.\n"
 "Activați portul UDP sau dezactivați Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5883,69 +5795,69 @@ msgstr ""
 "Trebuie să reporniți aMule acum.\n"
 "Dacă nu îl reporniți acum, nu vă plângeți dacă ceva rău se întâmplă.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Dosar pentru fișiere descărcate temporar"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Configurarea parolei și conexiunile externe sunt activate."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5955,24 +5867,24 @@ msgstr ""
 "Introduceți în listă cel puțin o adresă URL pentru a se indica un fișier server.met valid.\n"
 "Apăsați butonul \"List\" cu această căsuță pentru a introduce o adresă URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Fișiere temporare"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Fișiere de intrare"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Semnături online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Alegeți un dosar pentru %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -5980,42 +5892,42 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Navigați pentru playerul video"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Selectare navigator"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Executabil%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Editare listă server"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6023,42 +5935,42 @@ msgstr ""
 "Adăugați aici adresele URL pentru descărcat fișierele server.met.\n"
 "Numai o singură adresă URL pe fiecare linie."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Surse complete"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stare:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6066,7 +5978,7 @@ msgstr[0] "Întârziere actualizare: %d secundă"
 msgstr[1] "Întârziere actualizare: %d secunde"
 msgstr[2] "Întârziere actualizare: %d de secunde"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6074,12 +5986,12 @@ msgstr[0] "Timp pentru media graficului: %d minut"
 msgstr[1] "Timp pentru media graficului: %d minute"
 msgstr[2] "Timp pentru media graficului: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Scală grafic conexiuni: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6087,7 +5999,7 @@ msgstr[0] "Dimensiune fișier tampon: %d octet"
 msgstr[1] "Dimensiune fișier tampon: %d octeți"
 msgstr[2] "Dimensiune fișier tampon: %d de octeți"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6095,7 +6007,7 @@ msgstr[0] "Dimensiune coadă încărcări: %d client"
 msgstr[1] "Dimensiune coadă încărcări: %d clienți"
 msgstr[2] "Dimensiune coadă încărcări: %d de clienți"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6103,236 +6015,236 @@ msgstr[0] "Interval reâmprospătare conexiune server: %d minut"
 msgstr[1] "Interval reâmprospătare conexiune server: %d minute"
 msgstr[2] "Interval reâmprospătare conexiune server: %d de minute"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Interval reâmprospătare conexiune server: Dezactivat"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "dezactivată"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Execută comanda la evenimentul '%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Activați executarea de comenzi în nucleu"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Comandă nucleu:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Activează execuția comenzi pe GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Comandă GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Următoarele variabile vor fi înlocuite:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dosare partajate"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dimensiunea maximă s-a ignorat."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Atenționare căutare"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Principal"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Nu se poate face o căutare eD2k dacă eD2k nu este conectat"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Cuvinte cheie de căutat: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Eroare neașteptată în timp ce se încerca o căutare Kad:"
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID fișier"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Nu este apreciat"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Descarcă în categoria"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obține %s pentru acest fișier"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Caută fișiere asociate (eD2k, server local)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Marchează ca fișier cunoscut"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiază link-ul eD2k în memoria temporară"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sunteți conectat la serverul pe care încercați să-l ștergeți, deconectați-vă întâi."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Anulat"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Nou"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "A eșuat conectarea la toate serverele disimulate listate. Se execută un alt pas fără disimulare."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "A eșuat conectarea la toate serverele disimulate listate. Se execută un alt pas fără disimulare."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "A eșuat conectarea la toate serverele listate. Se execută un alt pas."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "A eșuat conectarea la toate serverele listate. Se execută un alt pas."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rețeaua eD2k este dezactivată în preferințe, nu se conectează."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "În lista de servere nu s-au găsit servere valide pentru conectare"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Conectat la %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Conexiune stabilită cu: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Eroare fatală în timpul conectării. Conexiunea la internet poate fi căzută"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "S-a pierdut conexiunea cu %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) par să fie moarte."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) par să fie pline."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6340,48 +6252,48 @@ msgstr[0] "Se va reîncerca conectarea automată la server în %d secundă"
 msgstr[1] "Se va reîncerca conectarea automată la server în %d secunde"
 msgstr[2] "Se va reîncerca conectarea automată la server în %d de secunde"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Conexiunea la %s (%s:%i) a eșuat."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "EROARE: Soclu nevalid la expirarea verificării"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Încercarea conectării la %s (%s:%i) a expirat."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "S-a primit ultimele rezultate pentru căutarea DNS, se înlătură."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Se încarcă fișierul server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Fișierul server.met nu a fost găsit!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "A eșuat încărcarea fișierului server.met '%s', s-a întâlnit un format necunoscut."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "A eșuat deschiderea server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Fișierul server.met este corupt, s-a găsit o versiune de etichetă nevalidă: 0x%x, dimensiune %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6389,7 +6301,7 @@ msgstr[0] "S-a găsit %i server în server.met"
 msgstr[1] "S-au găsit %i servere în server.met"
 msgstr[2] "S-au găsit %i de servere în server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6397,236 +6309,235 @@ msgstr[0] "%d server adăugat"
 msgstr[1] "%d servere adăugate"
 msgstr[2] "%d de servere adăugate"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Eroare: fișierul 'server.met' este corupt:"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Eroare IO la citirea 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serverul nu s-a adăugat: [%s:%d] nu specifică un port valid."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serverul nu a fost adăugat: Adresa IP a [%s:%d] este filtrată sau nevalidă."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serverul nu s-a adăugat: S-a găsit în listă un server care se potrivește cu IP:Port [%s:%d] ."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Serverul s-a adăugat: Server la [%s:%d] utilizând numele '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Sunteți conectat la serverul pe care încercați să-l ștergeți, deconectați-vă întâi."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "A eșuat deschiderea '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "A eșuat salvarea server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL nevalid"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "S-a finalizat descărcarea listei serverelor de la %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Nu s-a găsit nici o adresă de intrare în lista serverelor în 'addresses.dat' . Lipiți o adresă validă listă server în acest fișier pentru a se actualiza automat lista serverelor"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Pornește descărcarea listei serverelor de la %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ATENȚIE: Adresa URL specificată pentru actualizarea automată a serverelor este nevalidă: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Nu este o adresă url de descărcare automată server.met validă în addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "A eșuat descărcarea listei serverelor de la %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Serverul local este filtrat de filtrele IP, reconectați la un server diferit!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nume server"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresă"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Descriere"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Utilizatori"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Static"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versiune"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Sunteți conectat la un server pe care încercați să-l ștergeți. Întâi deconectați-vă. Serverul NU a fost șters."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Nume necunoscut)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Sigur doriți să ștergeți serverul static %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servere (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectare la server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Marcați serverul ca static"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Marcați serverul ca ne-static"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcați serverele ca statice"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcați serverele ca ne-statice"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Elimină server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Elimină servere"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Elimină toate serverele"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Copiază link-urile eD2k în memoria temporară"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Reconectează la server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Sigur doriți să ștergeți toate serverele?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Sigur doriți să ștergeți serverul selectat?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Sigur doriți să ștergeți serverele selectate?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "EROARE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ATENȚIE: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Noul ID client este %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ATENȚIE: Ați primit Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tCel mai probabil este fiindcă vă aflați în spatele unui firewall sau router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPentru mai multe informații, consultați https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "S-a primit o informație server necunoscută - prea scurtă"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6634,177 +6545,177 @@ msgstr[0] "S-a primit %d server nou"
 msgstr[1] "S-au primit %d servere noi"
 msgstr[2] "S-au primit %d de servere noi"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Salvarea listei server terminată."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Serverul a respins ultima comandă"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "S-a primit un pachet fals de la serverul: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Eroare nerezolvată în timpul procesării pachetului de la server: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Nu se poate crea procesul de rezolvare DNS pentru conectarea la %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Adresa IP a serverului %s (%s) este filtrată. Nu se conectează."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "utilizând protocolul de disimulare."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Se conectează la %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Nu se poate rezolva dns pentru serverul %s: Nu se poate conecta!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Jurnal aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serverul nu s-a adăugat: Nu este specificat adresa IP sau numele de gazdă."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serverul nu s-a adăugat: Portul specificat pentru server este nevalid."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Stare eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Stare conexiune:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Conectat"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Stare Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Rulare în mod LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Rulează"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Stare Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Stare:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Stare conexiune:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Cu firewall - deschideți portul TCP %d în ruter sau firewall"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Stare conexiune UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Cu firewall - deschideți portul UDP %d în ruter sau firewall"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Stare firewall:"
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Nici un prieten nu necesită - port TCP deschis"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Nici un prieten nu necesită - port UDP deschis"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nici un prieten"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Se conectează la persoane"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectat cu prietenul la %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Surse indexate:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Cuvinte cheie indexate:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Note indexate:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Încărcare indexate:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Medie utilizatori:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Medie fișiere:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Nu rulează"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Se adaugă fișierul %s la partajări"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6812,7 +6723,7 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6820,7 +6731,7 @@ msgstr[0] "S-a găsit %i fișier partajat cunoscut, %i necunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute, %i necunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute, %i necunoscute"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6828,416 +6739,416 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "EROARE: Se încearcă partajarea %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Directorul partajat nu a fost găsit, se omite: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Nume utilizator"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Viteză descărcare"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Viteză încărcare"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Părți disponibile"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Stare încărcare"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Stare descărcare"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Nume fișier local"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Listă fișiere partajate"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Părți obținute"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Cale director"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Adaugă comentariu/evaluare"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Editare comentariu/evaluare"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Rdenumire"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adaugă fișierele în colecție la lista de transfer"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Copiază &URI magnet în memoria temporară"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Copiază link-ul eD2k în memoria temporară (&sursă)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Copiază link-ul eD2k în memoria temporară (sursă) (opțiunile &With Crypt)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Copiază link-ul eD2k în memoria temporară (&nume gazdă)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Copiază link-ul eD2k în memoria temporară (nume gazdă) (opțiuni With &Crypt)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Copiază link-ul eD2k în memoria temporară (informație &AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Copiază link-ul eD2k în memoria temporară (sursă + informație &AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Vă trebuie un HighID pentru a se crea o legătură sursă validă"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nume fișier distant"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Date încărcate (sesiune (total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Adițional total (pachete): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Adițional cerere fișiere (pachete): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Adițional schimb surse (pachete): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Adițional server (pachete): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Adițional kad (pachete): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Adițional criptate (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Încărcări active: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Încărcări în așteptare: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Total încărcări realizate cu succes pe sesiuni: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Total încărcări eșuate pe sesiuni: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Medie timp încărcare: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Date descărcate (sesiune(total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Surse găsite: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Descărcări active (bucăți): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Raport ÎN:Des sesiune (total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Medie rată descărcare (sesiune): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Medie rată încărcare (sesiune): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Rată maximă descărcare (sesiune): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Rată maximă încărcare (sesiune): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Reconectări: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Timpul de la primul transfer: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Conectat la server din: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Conexiuni active (estimativ): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "S-a atins limita maximă de conexiuni: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Medie conexiuni (estimativ): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Vârf conexiuni (estimare): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Clienți"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Necunoscut: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrat: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Interzis: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Total: %i Cunoscute: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servere funcționale: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servere eșuate: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servere șterse: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servere filtrate: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Utilizatori pr serverele funcționale: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Fișiere pe serverele funcționale: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Total utilizatori: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Total fișiere: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Ocupare server: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Număr de fișiere partajate: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Dimensiunea totală a fișierelor partajate: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Medie dimensiune fișier: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistem de operare"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Nu s-a primit"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Conexiuni active (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Indisponibil"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Niciodată"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Comanda '%s' cu pid '%d' s-a finalizat cu cod stare '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Execută <str> și ieși."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Format IP nevalid. Utilizați xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Această comandă necesită un argument. Argumentele valide sunt: 'toate', nume fișier, sau un număr.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Se procesează după index:"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Se procesează după nume fișier:"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Această comandă necesită un argument. Argumente valide: un index fișier.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Nu este un număr valid\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Nu este un index valid (lungimea trebuie să fie exact 32 caractere)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7248,7 +7159,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7259,7 +7170,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7267,82 +7178,80 @@ msgstr ""
 "Nu s-a definit nici un tip de căutare.\n"
 "Tastați 'ajutor căutare' pentru a obține mai mult ajutor.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Descărcare fișier: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Solicitarea a eșuat cu o eroare necunoscută."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operația a fost un succes."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Solicitarea a eșuat cu următoarea eroare: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtrarea IP pentru clienți este %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "OPRIT"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "PORNIT"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtrarea IP pentru servere este %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Nivelul actual al filtrului IP este %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Limite lățime de bandă: În: %u kB/s, Desc: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Conectat la %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Se conectează acum"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "cu firewall"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7351,7 +7260,7 @@ msgstr ""
 "\n"
 "Descărcat:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7360,7 +7269,7 @@ msgstr ""
 "\n"
 "Încărcat:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7369,7 +7278,7 @@ msgstr ""
 "\n"
 "Clienți în coadă:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7378,46 +7287,46 @@ msgstr ""
 "\n"
 "Total surse:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Fișier parțial]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Numărul rezultatelor căutării: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Progres căutare: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Progresul căutării nu este disponibil"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "S-a primit un răspuns necunoscut de la server, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Arată o scurtă informație de stare."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Arată starea conexiunii, viteza curentă de încărcare/descărcare, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Afișează arborele complet al statisticilor."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7431,11 +7340,11 @@ msgstr ""
 "\n"
 "Exemplu: 'statistici 5' va arăta numai primele 5 versiuni de început pentru fiecare tip de client.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Închide aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7445,35 +7354,35 @@ msgstr ""
 "Aceasta va închide de asemenea și clientul text, fiind nefuncțional fără un\n"
 "nucleu care rulează.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Reîncarcă obiectul dat."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Reîncarcă tabelul de filtrare IP."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Reîncarcă tabelul curent de filtrare IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Actualizează tabelul de filtrare IP din URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Dacă adresa URL este omisă este utilizată în schimb adresa URL din preferințe."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Conectare la rețea."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7485,35 +7394,35 @@ msgstr ""
 "numai la acel server. Adresa IP trebuie să fie o adresă IPv4 zecimală despărțită de puncte,\n"
 "sau un nume DNS rezolvabil."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Conectează numai la eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Conectează numai la Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Deconectează de la rețea."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Aceasta va deconecta de la toate rețelele la care sunteți actualmente conectat.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Deconectează numai de la eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Deconectează numai de la Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Adaugă la nucleu un link eD2k sau magnet."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7531,51 +7440,51 @@ msgstr ""
 "\n"
 "Link-ul magnet trebuie să conțină indexul eD2k și lungimea fișierului.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Configurează o valoare preferată."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Configurează preferințele filtrării IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Pornește filtrarea IP pentru clienți și servere."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Oprește filtrarea IP pentru clienți și servere."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Activați/dezactivați filtrarea IP pentru clienți."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Pornește filtrarea IP pentru clienți."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Oprește filtrarea IP pentru clienți."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Activează/dezactivează filtrarea IP pentru servere."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Pornește filtrarea IP pentru servere."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Oprește filtrarea IP pentru servere."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Selectați nivelul de filtrare IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7583,73 +7492,73 @@ msgstr ""
 "Nivelele de filtrare valide sunt în domeniul 0-255, iar valoarea implicită (inițială)\n"
 "este 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Configurare limite lățime de bandă."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Valoarea dată acestei comenzi trebuie să fie în kiloocteți/secundă.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Configurare limită lățime de bandă încărcare."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Valoarea dată trebuie să fie în kiloocteți/secundă.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Configurare limită lățime de bandă descărcare."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Valoarea dată trebuie să fie în kiloocteți/secundă.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Ia și afișează o valoare preferată."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Obține preferințele filtrării IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Obține starea filtrării IP pentru clienți și servere."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Obține starea filtrării IP numai pentru clienți."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Obține starea filtrării IP numai pentru servere."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Obține nivelul filtrării IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Obține limitele lățimii de bandă."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Execută o căutare."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7668,44 +7577,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Execută o căutare globală."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Execută o căutare locală"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Execută o căutare kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Arată rezultatul ultimei căutări."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Arată progresul unei căutări."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Pornește descărcarea unui fișier"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7713,80 +7622,80 @@ msgstr ""
 "Trebuie dat numărul unui fișier de la ultima căutare.\n"
 "Exemplu: 'descarcă 12' va porni descărcarea fișierului cu numărului 12 a căutării anterioare.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pauzează descărcarea."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Reia descărcarea."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Anulează descărcarea."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Configurare prioritate descărcare."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Configurați prioritatea unei descărcări la Scăzută, Normală, Înaltă sau Automată.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Configurează prioritatea la scăzută."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Configurează prioritatea la normală."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Configurează prioritatea la înaltă."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Configurează prioritatea la automată."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Arată cozile/listele."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Arată coada de încărcare/descărcare, lista serverelor sau fișierele partajate.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Arată coada încărcărilor."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Arată coada descărcărilor."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Arată jurnalul."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Arată lista serverelor."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Reîncarcă lista fișierelor partajate."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Resetare jurnal."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Comandă învechită, utilizați '%s' în schimb."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7795,261 +7704,258 @@ msgstr ""
 "Este o comandă învechită, și poate fi înlăturată în viitor.\n"
 "Utilizați '%s' în schimb.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "client text aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Se convertește vechile indexări AICH în '%s' la 64b în '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ATENȚIE: Numele fișierului '%s' este nevalid și a fost redenumit la '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ATENȚIE: Fișierul '%s' deja există, noul fișier este redenumit la '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Sigur doriți să anulați și să ștergeți toate fișierele din această categorie?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Confirmare necesară"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Sunt suportate numai 99 de categorii."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Prea multe categorii!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Toate celelalte"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Selectează filtrul de vizualizare"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Adaugă categorie"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Editează categoria"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Elimină categoria"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Indexare solicitată pentru fișierul necunoscut: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Se reia încărcarea fișierului: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Se suspendă încărcarea fișierului: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "A eșuat executarea comenzii `%s' la evenimentul `%s' ."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Descărcare completă"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Calea completă la fișier."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Numele fișierului fără componenta de cale."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Indexul eD2k al fișierului."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Dimensiunea fișierului în octeți."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Timp cumulat activitate de descărcare:"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "O nouă sesiune chat este pornită"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Expeditor mesaj."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Fără spațiu"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Partiție disc."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Eroare la finalizare"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Se procesează numărul fișierului %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ați fost întrebat pentru indexările parțiale (Utilizat numai pentru fișiere > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fișier inexistent !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, creatorul de link-uri eD2k aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Bine ați venit!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parametrii de intrare"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fișier de indexat"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Adaugă o adresă URL facultativă pentru acest fișier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Introduceți aici fișierul pentru care doriți să calculați linkul eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Introduceți aici adresa URL pe care doriți să o adăugați la linkul eD2k: Adaugă / la sfârșit pentru a permite aLinkCreator să adauge numele de fișier curent"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Creează un link cu indexuri parțiale"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ajutați să popularizați rapid fișierele noi și rare, cu costul unei măriri a dimensiunii linkului"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Fișier index MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Fișier index eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "legătură eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Salvează"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Copiază în clipboard"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Deschide"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Deschide un fișier pentru a calcula legătura sa eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Copiază în memoria temporară link-ul eD2k calculat"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Salvează ca"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Salvează legătura eD2k calculată în fișier"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Despre aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Selectați fișierul pentru care doriți să calculați legătura eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Nu se poate deschide memoria temporară"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Nimic de copiat pentru acum !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Selectați fișierul link-ului calculat eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Nu se poate deschide"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Introduceți un nume de fișier valid"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Nimic de salvat pentru acum !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8069,167 +7975,159 @@ msgstr ""
 "\n"
 "Distribuit sub GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Se indexează..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator lucrează pentru dumneavostră"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Se calculează indexul MD4..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Se calculează indexurile eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Anulat !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Realizat în %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ați adăugat deja acest URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Introduceți un URL valid"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Nu se poate deschide %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "S-a depășit memoria în timpul calculului indexului ed2k!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i zi(e) %i oră(e) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Statistici online aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Rată maximă de descărcare de când wxCas rulează"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Rată maximă absolută de descărcare în timpul rulării anterioare a wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Resetare"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Oprește reîmprospătarea automată"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Salvează imaginea statisticilor online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Tipărește imaginea statisticilor online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Configurare preferințe"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Despre wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Pornește reîmprospătarea automată"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Reîmprospătarea automată oprită"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Reîmprospătarea automată pornită"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Salvează imaginea statisticilor"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Statistici online aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8237,11 +8135,11 @@ msgstr ""
 "A fost o problemă cu tipărirea.\n"
 "Poate imprimanta curentă nu este configurată corect?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Tipărire"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8259,403 +8157,392 @@ msgstr ""
 "\n"
 "Distribuit sub GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Vai vai, aMule nu rulează..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule rulează"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule rulează, dar deconectat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule se conectează..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Vai vai, starea aMule este necunoscută..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr "a rulat pentru"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr "este oprit !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr "nu este conectat !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr "se conectează..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr "se întâmplă ceva ciudat, verificați !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr "este conectat la"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "dezactivat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr "este pornit"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr "cu"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Descărcat în total:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Încărcat: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Descărcat în această sesiune:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Descărcare:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Încărcare:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Partajare:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fișier(ere), Clienți în coadă:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Timp:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " pornit "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Medie încărcare sistem (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Sistem activ:"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Director care conține fișierul amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Introduceți aici directorul unde se află fișierul amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Interval rată de reîmprospătare în secunde"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Generează o imagine statistică la fiecare reîmprospătare a evenimentului"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Introduceți aici directorul unde doriți să se genereze imaginea statistică"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Încărcați periodic imaginea statistică pe un server FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Url FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Cale FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Introduceți aici adresa URL a serverului FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Introduceți aici directorul unde puneți imaginea statistică pe serverul FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Utilizator"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Introduceți aici numele de utilizator pentru autentificare pe serverul FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Introduceți aici parola de autentificare în serverul FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Rată interval actualizare FTP în minute"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validează"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Dosar care conține fișierul semnătură"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Dosar unde se generează imaginea statistică"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Încarcă modelul <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Port server web HTTP"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Utilizează înaintarea portului UPnP pe portul serverului web"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Port UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Parola pentru accesul nerestricționat pentru serverul web"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Parola de oaspete pentru serverul web"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Permite accesul oaspeților"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Interzice accesul oaspeților"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Încarcă/salvează configurările serverului web de la/la aMule distant"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Calea fișierului de configurare aMule. NU UTILIZAȚI DIRECT!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Dezactivează interpretorul PHP (învechit)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Recompilează paginile PHP la fiecare solicitare"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Serverul Web aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "conexiunea clientului web este acceptată\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "EROARE: nu se poate accepta conexiunea clientului web\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Solicitare eșuată cu următoarea eroare: %s. "
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Fișierul index nu a fost găsit:"
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesiune expirată - se solicită autentificarea\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesiunea este ok, sunteți autentificat\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesiunea este ok, nu sunteți autentificat\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nu este deschisă nicio sesiune - va solicita autentificare\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sesiunea s-a creat - se solicită autentificarea\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Se procesează cererea [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Nu s-a specificat nicio parolă, autentificarea nu va fi permisă."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Se verifică parola\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Index parolă nevalid\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Parolă validă\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Parolă greșită\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Nu ați introdus nicio parolă. Nu se permite fără parolă.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Deautentificare solicitată\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Se procesează cererea [redirecționat]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Conectare eșuată"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -26,21 +26,21 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Показать aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Удаленное управление aMule"
 
 # Used only in CVS!
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Версия CVS:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -48,7 +48,7 @@ msgstr ""
 "Многоплатформенный p2p клиент основанный на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -57,79 +57,79 @@ msgstr ""
 "Copyright (c) 2003-2019 команда aMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Часть aMule основана на \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: пиринговый роутинг на основе XOR-метрики.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr "Copyright (c) 2002-2011 Петр Маймунков ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Сайт:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Форум:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Проверка наличия новой версии при запуске"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Подключаюсь к Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Недоступен"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Добавить в друзья"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Вы должны ввести правильный IP-адрес и порт."
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Информация"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Указанный хеш пользователя недопустим."
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -138,49 +138,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "После имени приложения"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Попытка подключиться не удалась "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -189,103 +188,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Не удалось открыть файл ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить себя в качестве источника для eD2k ссылки если у вас lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Выходим из основного приложения..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Неудачно"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Завершаем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Убиваем процесс amuleweb с pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Прекращаем работу ядра."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "выключение aMule завершено."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Результаты дебага памяти при выходе из aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "В связи со сменой версии, значение вашей локали было изменено на значение по умолчанию. Извините."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Сведения"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -293,74 +289,70 @@ msgstr ""
 "\n"
 "EC конфигурация"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ПРЕДУПРЕЖДЕНИЕ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Сети"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "веб-сервер работает с pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Невозможно связать порты с указанными адресами: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u не доступен. У вас будет LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -375,48 +367,48 @@ msgstr ""
 "\n"
 "Проверьте вашу сетевую конфигурацию, убедитесь что необходимый порт открыт."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Не удалось создать aMule OnlineSig файл"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Выбранная локаль отсутствует в вашей системе (тем не менее, будет произведена попытка ее использовать)."
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Это первый запуск aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Эта версия является тестовой и обновляется ежедневно.\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "мы не предоставляем никаких гарантий на случай каких либо повреждений, пожара \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "или же смерти вашей любимой собачки. И все же использование ее *должно* быть безопасным. \n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Дополнительную информацию, поддержку и обновленные версии вы найдете на нашем сайте \n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, или на нашем irc-канале #aMule, находящемся на сервере irc.libera.chat. \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Сообщайте нам о найденных ошибках на форум https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -424,228 +416,224 @@ msgstr ""
 "Указан неверный каталог для файлов Online-подписей!\n"
 "Online-подписи будут отключены пока вы не исправите это в настройках."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Выделение место под файл '%s' не удалось: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "Ошибка: невозможно открыть файл журнала"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл журнала пуст. Что-то здесь не так :-("
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Журнал был очищен"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Сообщение сервера: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Пропущена загрузка %s, так как запрашиваемый файл не новее."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Ошибка при загрузке списка узлов."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Поврежден файл контроля версии"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Вы используете устаревшую версию aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Версия вашего aMule - %i.%i.%i, тогда как актуальная версия - %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ВНИМАНИЕ: Версия вашего aMule устарела: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копия aMule актуальна."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Ошибка при загрузке файла контроля версии"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Польз.: %s | Файлов: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Польз.: E: %s K: %s | Файлов: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Нет выделенной сети"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Соединен с %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Подключение к %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Отсоединен от eD2k"
 
 # Kad как сеть, или служба - поэтому в женском роде
 # да, согласен
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad запущена."
 
 # Kad как сеть, или служба - поэтому в женском роде
 # согласен
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad остановлена."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Подключен к Kad (норм.)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Отключился от Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Сеть Kad не может быть использована если порт UDP выключен в настройках. Отменяю запуск."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Сеть Kad выключена в настройках. Отменяю соединение."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ОШИБКА: демон aMule не может быть использован когда внешние соединения выключены. Чтобы включить внешние соединения, используйте aMule, или запустите amuled с параметром --ec-config, или установите ключ \"AcceptExternalConnections\" равным 1 в файле ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ОШИБКА: Для использования внешних соединений необходим пароль, а без внешних соединений демон aMule бесполезен. Чтобы запустить aMule-демона необходимо заполнить поле \"ECPassword\" в файле ~/.aMule/amule.conf. Запустите amuled с флагом --ec-config чтобы создать пароль. Более подробную информацию вы найдете на https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - запускаем таймер"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Не удалось создать pid-файл"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "Ошибка: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s (основан на eMule)."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -655,193 +643,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Нет сети"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "удаленное управление aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Фатальная Ошибка: не удалось создать таймер ядра"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Подключиться к удаленному aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Соединение утрачено"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Подтверждение при выходе"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -850,153 +831,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Фатальная Ошибка: не удалось создать Poll-таймер"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Переходим в событийный цикл..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Подключаемся..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Обработчик событий EC удаленного GUI"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Неудачное соединение. Невозможно соединиться с %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Выключаемся"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Время ожидания соединения с %s (%s:%i) вышло."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Подключиться к сети."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Неудачное соединение. Невозможно соединиться с %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Готов"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Все"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Не доступно"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Файл не найден."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ссылка неверна или уже в списке."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Не удается создать директорию '%s' для категории '%s', оставляем директорию '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Не удалось получить список доступных файлов от '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Ищем друга для lowid-соединения"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Поддельная версия eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (имитация eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (имитация eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (на основе eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Псевдоним: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Запрошено: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1004,7 +975,7 @@ msgstr[0] "Статистика для текущего сеанса: приня
 msgstr[1] "Статистика для текущего сеанса: принято %d из %d запросов, %s передано\n"
 msgstr[2] "Статистика для текущего сеанса: принято %d из %d запросов, %s передано\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1012,119 +983,119 @@ msgstr[0] "Статистика для всех сеансов: принято %
 msgstr[1] "Статистика для всех сеансов: принято %d из %d запросов, %s передано\n"
 msgstr[2] "Статистика для всех сеансов: принято %d из %d запросов, %s передано\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Запрошен неизвестный файл"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Отфильтрованное сообщение от '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Новое сообщение от '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов из несуществующего каталога %s -> Проигнорировано"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: файл %s не может быть открыт"
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Список отмененных файлов поврежден, содержит некорректный заголовок."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Ошибка ввода/вывода при чтении файла %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Ошибка при сохранении файла %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Введите код"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Новая категория"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Выберите каталог для входящих файлов"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Вы должны указать имя для категории!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Вы должны указать путь для категории!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Не удалось создать каталог для загружаемых файлов категории. Укажите верный путь."
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Сеанс чата запущен: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Соединен с клиентом ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Соединение с клиентом ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Не удалость соединиться с клиентом / Соединение разорвано ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Код введен верно. Пользователь получил ваше сообщение. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Код введен неверно. Ваше сообщение проигнорировано. Вы можете повторить ввод кода отправив новое сообщение. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Чат"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Закрыть вкладку"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Закрыть все вкладки"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Закрыть остальные вкладки"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Добавить в список друзей"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1132,7 +1103,7 @@ msgstr[0] "Файл кредитов загружен, %u клиент изве�
 msgstr[1] "Файл кредитов загружен, %u клиента известно"
 msgstr[2] "Файл кредитов загружен, %u клиентов известно"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1140,174 +1111,171 @@ msgstr[0] " - Кредиты перестали действовать для %u
 msgstr[1] " - Кредиты перестали действовать для %u клиентов!"
 msgstr[2] " - Кредиты перестали действовать для %u клиентов!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Файл 'cryptkey.dat' не найден. Создаю заново."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Сведения о клиенте"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Разрешено"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Поддерживается"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Не поддерживается"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Запрещено"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Подключен"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Отключен"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Не завершен"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Нарушитель"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Проверено - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Не доступно"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов -> Принято"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов -> Отказано"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Пользователь %s (%u) запросил список публикуемых папок -> Принято"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Пользователь %s (%u) запросил список публикуемых папок -> Отказано"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов из каталога '%s' -> Принято"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов из каталога '%s' -> Отказано"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Пользователь %s (%u) сделал доступным каталог '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Пользователь %s (%u) отправил незапрошенный список публикуемых папок."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Пользователь %s (%u) отправил список публикуемых каталогов из каталога '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Пользователь %s (%u) закончил передачу списка публикуемых файлов."
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Пользователь %s (%u) отправил список публикуемых файлов, который не нужен."
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Пользователь %s (%u) отказал в доступе к списку публикуемых файлов/папок"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Комментарии к файлам"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Имя файла"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Комментарий"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
 # unification
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Поиск по сети Kad не может быть произведен когда она отсоединена."
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Ищем друга для lowid-соединения"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Нет комментариев"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1315,269 +1283,259 @@ msgstr[0] "%u комментарий"
 msgstr[1] "%u комментария"
 msgstr[2] "%u комментариев"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Клиент %s забанен за отсыл %s поврежденных данных из %s всего для файла '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Не удалось загрузить данные страны для %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Авто [Низк]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Авто [Норм]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Авто [Выс]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Высокий"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Очень высокий"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Релиз"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Запрос"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Соединение через сервер"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Очередь заполнена"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В очереди"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Загружается"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Получение контрольных сумм"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Нет нужных частей"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Клиенты с LowID не могут подключаться друг с другом"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Слишком много соединений"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Подключение Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Слишком много соединений Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Заблокированы"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Ошибка подключения"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Удаленная очередь полна"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Старый MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Новый MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Совместимый с eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Локальный сервер"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Обмен источниками"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Пассивный"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Ссылка"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Источники"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Результаты поиска"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершено"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "В процессе"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ОШИБКА: Недостаточно места на диске"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ОШИБКА: Не найден файл part.met"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ОШИБКА: Ошибка ввода/вывода!"
 
 # знаю что звучит глупо. если есть идеи - прошу
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ОШИБКА: Неудачно!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "В очереди"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Уже скачивается"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Неизвестный или нарушенный формат временного файла."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Часть"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Передано"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорость"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Выполнено"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Источники"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Состояние"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Осталось времени"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Последний раз файл был доступен полностью"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Последнее получение данных"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Удалить выбранный файл?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Удалить выбранные файлы?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1586,109 +1544,106 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Авто"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Остановить"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Пауза"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Возобновить"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Очистить &завершенные"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Использовать все A4AF источники для этого файла"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Использовать все A4AF источники для этого файла (авто)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Отдать все A4AF источники этого файла другим файлам"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Дополнительные настройки"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "По&казать подробности"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Показать все комментарии"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Скопировать magnet URL в буфер обмена"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Копировать eD2k &ссылку в буфер"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Скопировать доп. информацию в буфер обмена"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "отменить категорию"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Присвоить категорию"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Открыть файл"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Введите новое имя файла:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Переименовать файл"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Загрузки (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1698,47 +1653,47 @@ msgstr ""
 "при каждом предпросмотре, установите предпочитаемый\n"
 "видео проигрыватель в настройках (по умолчанию %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Предварительный просмотр"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ОШИБКА: невозможно запустить видео-проигрыватель. Команда: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Сохранаяем файл %u из %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Все файлы сохранены."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Загружаются файлы из %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Загружается файл %u из %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ОШИБКА: не удалось загрузить резервный файл. Ищите на https://github.com/amule-org/amule/discussions как восстановить файл part.met"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Все файлы загружены."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Частично загруженных файлов не найдено"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1746,50 +1701,50 @@ msgstr[0] "Найден %u частично закаченный файл"
 msgstr[1] "Найдено %u частично закаченных файла"
 msgstr[2] "Найдено %u частично закаченных файлов"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Файловая система каталога временных файлов не поддерживает файлы больших размеров"
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Файловая система каталога принятых файлов не поддерживает файлы больших размеров"
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Прием %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Вы уже загружаете файл '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "У вас уже есть файл '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "У вас уже есть файл '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Вы уже пытаетесь загрузить файл %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Не удается преобразовать magnet-ссылку в eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Неизвестный протокол ссылки: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1797,252 +1752,251 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Неверная eD2k ссылка! ОШИБКА: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Клиент послал пакет после ошибки идентификации."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Внешнее соединение закрыто."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Внешние соединения выключены из-за отсутствия пароля."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Внешние соединения выключены в конфигурационном файле"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Принято новое внешнее соединение"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ОШИБКА: невозможно принять новое внешнее соединение"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Отказано во внешнем соединении из-за пустого пароля"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Соединение с клиентом: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Неизвестная версия"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Неверный идентификатор версии ВС. Возможна бинарная несовместимость. Используйте ядро и компонент удаленного доступа одинаковой версии."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Вы не можете подсоединиться к релизной версии с произвольной SVN версии! Возможный сбой предотвращен"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Недопустимая версия протокола."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Тег версии протокола отсутствует."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Ошибка авторизации: в качестве EC-пароля указан неправильный хэш."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Ошибка идентификации: неверный пароль."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Ошибка идентификации: пароль не задан."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Неверный запрос, сначала пройдите идентификацию."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Доступ получен."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Клиенту отправлено сообщение об ошибке \"%s\"."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Попытка неавторизированного доступа с %s. Соединение разорвано."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Удаленная команда PartFile не удалась: хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файла не найден: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Ошибка при выполнении OpCode."
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Сервер не добавлен"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не найден: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "необходимо выделить сервер для удаления"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "Сеть eD2k отключена в настройках"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
 # Explained by Jacobo221.
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "При удаленном использовании aMule WWW поиск бесполезен."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Поиск запущен. Ждите результатов."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "В графике нет точек."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клиент не настроен на этот уровень детализации."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Внешнее соединение: запрошено выключение"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Уже завершаю работу."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: добавляю ссылку '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Ссылка неверна или уже в списке."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Файл не найден."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Неверное имя файла."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Невозможно переименовать файл."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad выключена в настройках."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Уже подсоединен к сети eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Подсоединение к сети eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Уже подключен к Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Подключаюсь к Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Все сети выключены."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Отсоединен от сети eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Отключен от Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Внешнее соединение: получен неверный код операции: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Неверный opcode (Возможно, не та версия протокола)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Неизвестное расширение '%s' для команды '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Неизвестная команда '%s.'\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2050,7 +2004,7 @@ msgstr ""
 "\n"
 "У этой команды не может быть аргументов.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2058,7 +2012,7 @@ msgstr ""
 "\n"
 "У этой команды должен быть аргумент.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2066,7 +2020,7 @@ msgstr ""
 "\n"
 "Команда не завершена. Необходимо использовать одно из следующих расширений.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2074,11 +2028,11 @@ msgstr ""
 "\n"
 "Доступные расширения:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Доступные команды:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2089,17 +2043,17 @@ msgstr ""
 "Все команды чувствительны к регистру.\n"
 "Наберите '%s <имя команды>' чтобы получить справку по этой команде.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Завершить работу с приложением."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Показать справку."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2107,7 +2061,7 @@ msgstr ""
 "Чтобы получить справку по команде, наберите  'help <имя команды>'.\n"
 "Чтобы получить полный список команд, наберите 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2118,46 +2072,46 @@ msgstr ""
 "Введите '%s' для получения списка команд\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Синтаксическая ошибка!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Ошибка при обработке команды - это не должно было произойти! Пожалуйста, сообщите нам об этой ошибке\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "У этой команды не должно быть параметров."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "У этой команды должен быть параметр."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Неверный аргумент."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Команда введена не полность."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Наберите '%s' для подробной справки.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Это %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Это %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2165,7 +2119,7 @@ msgstr ""
 "\n"
 "Создается клиент...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2174,7 +2128,7 @@ msgstr ""
 "\n"
 "Ok, выход из %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2188,331 +2142,326 @@ msgstr ""
 "\n"
 "Завершение работы...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Показать эту справку."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Узел, на котором работает aMule (по умолчанию: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Порт aMule для внешних подключений (по умолчанию: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Пароль для внешнего соединения."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Прочесть настройки из файла."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Не выводить ничего в поток стандартного вывода."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Детально - выводить отладочную информацию."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Установить локаль программы (язык)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Записать параметры командной строки в конфигурационный файл."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Создает конфигурационный файл на основе оного из aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Вывести версию программы."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Детали файла"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% готово"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/сек"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Добро пожаловать!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Соединяем с другом"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Состояние соединения:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Сети"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Стандартный порт TCP"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Дополнительный порт UDP (Kad / Глобальный поиск)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Разрешить UPnP форвардинг портов роутера"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Инициализация"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Вы уже пытаетесь загрузить файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Автоматически обновлять список серверов при запуске"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Открыть"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Папка для временных файлов"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Не удалось открыть список друзей 'emfriends.met' для чтения!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Не удалось открыть список друзей 'emfriends.met' для записи!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Друзья"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Показать &подробности"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Добавить в друзья"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Удалить из друзей"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Послать &сообщение"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Просмотр файлов"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Создать слот для друга"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Удалить выбранного пользователя из списка друзей?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Удалить выбранных пользователей из списка друзей?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2520,11 +2469,11 @@ msgstr ""
 "Устанавка более одного слота для друзей запрещена.\n"
 " Был выделен только один слот."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Множественный выбор"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2533,183 +2482,182 @@ msgstr ""
 "Устанавка более одного слота для друзей запрещена.\n"
 " Был выделен только один слот."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Послать сообщение пользователю"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Сообщение:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Удалить из списка друзей"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Отправить сообщение"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Переключить на этот файл"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "В очереди: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Запрошен другой файл"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Ожидание слота отдачи"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "В очереди: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Отдается"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Да"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Принимается..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "загрузка HTTP отменена"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "URL загрузки не может быть пустым"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Не удалось получить список доступных файлов от '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Папка для временных файлов"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Загружено %d байт"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "Обработка URL %s: %i - Ошибка (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "загрузка HTTP отменена"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Загружен новый GeoIP.dat с %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Загрузка GeoIP.dat неудачна, прекращаем обновление."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Удаление файла %s неудачно, прекращаем обновление."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Переименование файла %s неудачно, прекращаем обновление."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Обновление %s успешно."
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Ошибка обновления GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Не удалось загрузить %s с %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Загружаю IP-фильтры 'ipfilter.dat' и 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Не удалось загрузить ipfilter.dat файл '%s', формат файла неизвестен."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Не удалось загрузить ipfilter.dat файл '%s', не удалось открыть файл."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2717,7 +2665,7 @@ msgstr[0] "Загружен %u IP-диапазон из '%s'."
 msgstr[1] "Загружено %u IP-диапазона из '%s'."
 msgstr[2] "Загружено %u IP-диапазонов из '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2725,17 +2673,17 @@ msgstr[0] "%u испорченная строка была пропущена."
 msgstr[1] "%u испорченных строки было пропущено."
 msgstr[2] "%u испорченных строк было пропущено."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Переименование нового файла %s неудачно, прекращаем обновление."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP-фильтр готов"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2743,56 +2691,52 @@ msgstr ""
 "Инициализация от \n"
 "известных клиентов"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Узлы (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Неверный IP для инициализации"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Неверный порт для инициализации"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Пожалуйста, заполните все необходимые поля"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Сообщение"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Вы уверены что хотите загрузить новый файл nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Это удалит используемые в данный момент узлы и перезапустит Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Продолжить?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kad: слово запроса лишком коротко"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: ключевое слово поиска уже в списке поиска:"
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Ошибка чтения nodes.dat - формат файла устарел. Эта версия (0) больше не поддерживается."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2800,12 +2744,11 @@ msgstr[0] "Считан %u контакт Kad"
 msgstr[1] "Считано %u контакта Kad"
 msgstr[2] "Считано %u контактов Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Не найдено контактов. Произведите инициализацию, или загрузите файл nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2813,7 +2756,7 @@ msgstr[0] "Доступен только %d контакт Kad, файл nodes.d
 msgstr[1] "Доступно только %d контакта Kad, файл nodes.dat не записан"
 msgstr[2] "Доступно только %d контактов Kad, файл nodes.dat не записан"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2821,806 +2764,779 @@ msgstr[0] "Записан %d Kad контакт"
 msgstr[1] "Записано %d Kad контакта"
 msgstr[2] "Записано %d Kad контактов"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Сеть Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Имя файла"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Размер файла"
 
 # по крайней мере торренты называют его так
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Рейтинг"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Запрошено"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Разрешено"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Полных источников"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Список известных файлов поврежден, содержит некорректный заголовок."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Ошибка загрузки элемента списка известных файлов, файл возможно поврежден"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Неверный элемент списка известных файлов, файл возможно поврежден:"
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Неизвестная ошибка %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Невозможно получить описание ошибки %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Хешируется"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Завершается"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Завершен"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Приостановлен"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Ошибочный"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ожидает"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Необходимо указать пароль."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Неверный пароль. Не MD5-хеш!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Подключение не удалось"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Внешнее соединение закрыто."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC соединение не удалось. Пустой ответ."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Внешнее соединение: Некорректный ответ, авторизация неудачна. Соединение закрыто."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Успешное подключение к aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Соединение установлено."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Внешнее Соединение: В доступе отказано по причине:"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Внешнее Соединение: авторизация неудачна."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Автоматическое обновление начато"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ОШИБКА: невозможно открыть TCP порт."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ОШИБКА:"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Вырезать"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Копировать"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистить"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Выделить все"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Подключен"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Подключен"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Подключен к Kad (за брандмауэром)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP-адрес сервера: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP сервера:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Отсоединен"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP порт: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP порт: Не готово"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP порт: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP порт: Не готово"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Информация о клиенте"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Ограничение отдачи"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Ограничение приема"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Показать aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Свернуть aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Выйти"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "кБ/сек"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Неограниченно"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Меню aMule в области уведомлений"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Ограничения скорости:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Нет"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Нет"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Скорость приема: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Скорость отдачи: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Псевдоним: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Псевдоним не выбран!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID клиента: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Имя сервера: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP-адрес сервера: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Не подключен"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Онлайн-подпись: Включена"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Онлайн-подпись: Выключена"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Время работы: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Опубликованные файлы: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Клиентов в очереди: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Всего загружено: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Всего передано: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Добавить eD2k или magnet-ссылку в ядро"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Добавить в список друзей"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Нажмите сюда чтобы добавить eD2k ссылку из текстового поля в очередь загрузок."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Тут отображаются события. Для полного списка событий, обратитесь к журналу в окне \"Сети\"."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Загружается..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Количество пользователей на сервере, к которым вы подключены..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Пользователей: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Пользователи, подключенные к данному серверу и оценка общего количества пользователей."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Передача: 0.0 | Прием: 0.0"
 
 # Тултип. Лучше оставить как можно более коротким (не все системы автоматом
 # делают их многострочными ;-))
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Входящая и исходящая усредненные скорости. Значения в скобках (если включены), отображают служебный трафик (трафик связи между клиентами)."
 
 # Тултип. Лучше оставить как можно более коротким (не все системы автоматом
 # делают их многострочными ;-))
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Статус соединения. Красная стрелка - нет соединения, желтая - LowID (вы за маршрутизатором или брандмауэром), зеленая - HighID (оптимальный вариант)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Не подключен..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Подключен к серверу."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Поиск"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Локальный"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Глобальный"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Дополнительные параметры"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Фильтрация"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Тип файла"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Любой"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Архив"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Аудио"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-образ"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Изображение"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Программа"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Текст"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Видео"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Расширение"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Мин. размер"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Байт"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "КБ"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "МБ"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "ГБ"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Макс. размер"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Доступность"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Фильтр:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Фильтровать результаты"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Инвертировать"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Скрывать известные файлы"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Начать"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Дополнительно"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Остановить"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Загрузка"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Сбросить значения"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Результаты"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Очистить результаты"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Источников:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Общие"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Полное имя :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Файл met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Хеш:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Размер файла:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Передача"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Статус:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Последний раз полный файл был доступен :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Найдено источников:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Передающие источники:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Число частей:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Доступно:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Время активности закачки:"
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Передано:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Завершено:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Потери из-за повреждений :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Выигрыш сжатия:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Экономия пакетов I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Передача другим: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Запросов"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Принятых запросов"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Передано данных"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Коэффициент передачи"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Полных источников"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Публикуемые файлы"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Передано: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Без оценки"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Заголовок :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Имя файла"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Очистить"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Применить"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Комментарий/Оценка файла (Текст будет доступен всем пользователям)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3628,1278 +3544,1274 @@ msgstr ""
 "Например, для фильма вы можете указать его длительность, сюжет, язык...\n"
 "Если это - фальшивка, вы можете сообщить об этом остальным пользователям aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Качество файла"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Без оценки"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Ошибочный / Поврежденный / Фальшивка"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Плохой"
 
 # было "очень хороший" непонятно почему. это название среднего рейтинга (обе
 # полоски белые)
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Нормальный"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Хороший"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Великолепный"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Выберите оценку файлу, или сообщите пользователям, что это - утка..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Отключился от Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Обновить"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Идет загрузка, подождите..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Неизвестный размер"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Обязательная информация"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP адрес :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Порт :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Дополнительная информация"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Имя пользователя :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Добавить"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Скорость отдачи"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Активные передачи"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Дерево статистики"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Имя пользователя:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Хеш пользователя:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Клиентское ПО:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Версия клиентского ПО:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP адрес:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID пользователя:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP сервера:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Имя сервера:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Вуалирование:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Передача"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Текущий запрос:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Средняя скорость отдачи:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Средняя скорость приема:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Передано (сеанс):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Принято (этот сеанс):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Передано всего:"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Принято всего:"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Счет"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Модификатор DL/UP:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Безопасная идентификация:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "QR:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Счет на передачу:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Псевдоним"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - многоплатформный Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Это имя, которое будет показано пользователям, подключающимся к вам."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Язык:"
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Задержка отображения контекстных подсказок (как эта) в секундах."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Выберите язык интерфейса."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Проверка наличия новой версии при запуске"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "При запуске aMule будет проверено наличие новой версии"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Сворачиваться при запуске"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Сразу после запуска  aMule будет минимизирован в область уведомлений."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Подтверждение при выходе"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Делать подтверждающий запрос перед выходом"
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Значок в области уведомлений"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Эта опция включает/выключает значок в области уведомлений"
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Сворачивать в область уведомлений"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Сворачивать aMule в область уведомлений, а не в панель задач."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Показывать уведомления о завершении загрузки"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Время задержки подсказок:"
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "секунд"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Выбор браузера"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Открывать в новой вкладке"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Открывать веб-страницы в новой вкладке, а не в отдельном окне, если это возможно"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Видео-проигрыватель"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Ограничения загрузки"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Слот"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Порты"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Это стандартный порт eD2k, он не может быть отключен."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запросов сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Этот порт UDP используется для дополнительных eD2k запросов и Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (Не обязательно):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Максимум источников на файл:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Соединяться автоматически после запуска"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Восстановить соединение в случае разрыва"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Удалить нерабочий сервер после"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "попыток"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Список"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Обновлять список серверов при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Обновлять список серверов при подключении к клиенту"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Использовать систему приоритетов"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Проверка на LowID при подключении к серверу"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Безопасное подключение"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоподключение только к статическим серверам"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Высокий приоритет серверов, добавленных вручную"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Добавлять файлы на загрузку в режиме паузы"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Добавлять файлы в загрузку с авто приоритетом"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Пытаться сначала загрузить первую и последнюю части"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Возобновлять следующий файл на паузе при завершении загрузки"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Из той же категории"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "В алфавитном порядке"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Заранее выделять место для новых фалов"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Сразу выделяет место под весь файл. Таким образом уменьшается фрагментация"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Останавливать загрузки по окончанию свободного места на диске"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Отметьте это если  хотите чтобы aMule проверял наличие свободного места"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Введите здесь минимальное количество свободного места на диске."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Оставлять 10 источников для редких файлов (<20 источников)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Отдача"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Добавлять новые файлы для публикации с авто приоритетом"
 
 # слишком уж частая аббривеатура. написать И.О.О. - никто не поймет
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Интеллектуальная Обработка Ошибок (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Разрешить"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "AICH-доверие для каждого хэша (не рекомендуется)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Публикуемые папки"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(кликните правой кнопкой на значке каталога для рекурсивной публикации)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Включая скрытые файлы"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Графики"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Интервал обновления: 5 сек"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Время для среднестатического графика: 100 минут"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Масштаб графика соединений: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Масштаб графика загрузки:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Масштаб графика отдачи:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Цвета:"
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Сетка"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Текущая загрузка"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Средняя общая загрузка"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Средняя загрузка за сеанс"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Текущая отдача"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Средняя общая отдача"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Активные соединения"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Скорость передачи в области уведомлений"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Узлы Kad (текущие)"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Узлы Kad (действующие)"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Число отображаемых версий клиентов (0=неогр.)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ВНИМАНИЕ !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Предел количества новых соединений за 5 секунд"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Размер буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Размер очереди: 5000 клиентов"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Интервал обновления соединения с сервером: Отключено"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Отключить засыпание компьютера"
 
 # в LA помнится так и перевели - "шкурка", но по-моему глупо.
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Скин:"
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показывать строку \"быстрой загрузки\" в каждой вкладке."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Показывать дополнительную информацию на закладках категорий"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Выводить скорость передачи в заголовке"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Перед именем приложения"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "После имени приложения"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Показывать скорость служебного трафика"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальное расположение панели инструментов"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
 # This is the heading for the preference options regarding the files in the
 # transfer list.
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Загружаемые файлы"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Показывать процент загрузки"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Показывать полосу выполнения"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Плоская"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Запрещать ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Пароль веб-сервера для ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4907,11 +4819,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4921,482 +4833,482 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Файлы"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Отключено [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "Б"
 msgstr[1] "байт"
 msgstr[2] "байт"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "КБ"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "ТБ"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "К"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "М"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "Г"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "Т"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "Б/с"
 msgstr[1] "байт/сек"
 msgstr[2] "байт/сек"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "МБ/с"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "с"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "м"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ч"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "д"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "все"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "все остальные"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Незавершенные"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Остановлен"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Видео"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Архив"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Текст"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Активные"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Используем директорию конфигурации: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Ожидание завершения нити конвертации файла..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Импортируется %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Чтение из временного каталога"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Извлекаю основную информацию из информационного файла загрузки"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Создаю целевой файл"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Загружаю данные из старого файла загрузки (%u из %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Сохраняю данные в новый монолитный файл загрузки (%u из %u)"
 
 # не уверен что верно
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Получаем информацию по источникам"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Добавляю загрузку и сохраняю новый частично закачанный файл"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Импорт частично загруженных файлов"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Состояние"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Хеш файла"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Диск: %s)"
 
 # Полностью лучше не переводить - это титул небольшого диалога.
 # Если перевести полностью - будет маленький, но широоооокий диалог :)
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Укажите каталог для поиска незавершенных загрузок."
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Вы хотите, чтобы исходные файлы импортированных закачек были удалены?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Удалить исходные файлы?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "ОШИБКА: невозможно создать part-файл"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Попытка загрузки резервной копии файла '.met'  из %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ОШИБКА: не удалось открыть файл part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ОШИБКА: файл part.met пуст: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ОШИБКА: неверная версия файла part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "ОШИБКА: %s (%s) поврежден (неверные теги: %s), невозможно открыть файл."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ОШИБКА: %s (%s) поврежден (неверное число тегов), невозможно открыть файл."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Попытка восстановления информации о файле..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Восстановление безымянного файла - попытка восстановить его как 'RecoveredFile.dat'"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Восстановлена вся возможная информация о файлах ;-))) Попытаемся ее использовать..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Не удалось восстановить информацию о файлах :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Не удалось открыть %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: %s возможно поврежден (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "Ошибка сохранения part-файла: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Ошибка ввода-вывода во время сохранения файла:"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Не удалось сохранить файл 'part.met.seeds' для %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5404,17 +5316,17 @@ msgstr[0] "Сохранен %i источник для файла %s (%s)"
 msgstr[1] "Сохранено %i источника для файла %s (%s)"
 msgstr[2] "Сохранено %i источников для файла %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Сохранен %i источник для файла %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Ошибка при чтении источников частично загруженного файла (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5422,335 +5334,335 @@ msgstr[0] "Найдена испорченная часть (%d) в %d част�
 msgstr[1] "Найдена испорченная часть (%d) в %d частях файла %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Найдена испорченная часть (%d) в %d частях файла %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Найдена завершенная часть (%i) в %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Завершено повторное хеширование %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Неожиданная ошибка во время завершения %s. Файл приостановлен."
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Загрузка завершена: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Загрузка завершена: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Удаление файла: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Не удается схэшировать загруженную часть - хэш-набор неполон для '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ОШИБКА: Не удается схэшировать загруженную часть - хэш-набор неполон (%s). Это никогда не должно происходить"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF при хешировании загруженной части %u с длиной %u (макс %u) файла '%s' с длиной %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: не достаточно свободного места на диске. Файл приостановлен: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Загруженная часть %i повреждена: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Восстановлена поврежденная часть %i для %s -> Выигрыш: %s Б"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Выделяется место"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Недостаточно места на диске"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Загружено"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Соединение"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Каталоги"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Сервера"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Файлы"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Интерфейс"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Прокси"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Фильтры"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Удаленный контроль"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Online-подпись"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "События"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Отладчик"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5760,15 +5672,15 @@ msgstr ""
 "   %PARTFILE - полный путь к файлу\n"
 "   %PARTNAME - только имя файла"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5784,35 +5696,35 @@ msgstr ""
 "aMule будет превосходно работать и БЕЗ ИЗМЕНЕНИЯ вами\n"
 "этих настроек."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Не удалось подключить Cfg к widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Не удалось передать данные из Cfg к Widget с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Тип прокси-сервера, который вы используете"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Не удалось передать данные из Widget к Cfg с ID %d и ключом %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Проверяю пароль\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5820,42 +5732,42 @@ msgstr ""
 "Необходимо перезапустить aMule чтобы следующие изменения вступили в силу:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- изменен порт TCP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- изменен порт UDP.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Порт для внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Принятие внешних соединений изменено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Интерфейс внешних соединений изменен.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Вуалирование протокола"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5863,7 +5775,7 @@ msgstr ""
 "Список авто обновления пуст.\n"
 "Автоматическое обновление списка серверов отключено."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5871,33 +5783,33 @@ msgstr ""
 "Вы включили внешние соединения, но не указали пароль.\n"
 "Внешние соединения нельзя включить до тех пор, пока не указан пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Изменен язык.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Изменен временный каталог.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- сеть eD2k включена. \n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Недопустимая версия протокола."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5905,7 +5817,7 @@ msgstr ""
 "Сети eD2k и Kad обе отключены.\n"
 "Вы не сможете подсоединиться пока не подключите хотя бы одну из них."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5913,7 +5825,7 @@ msgstr ""
 "Kad не будет запущена, если UDP-порт выключен.\n"
 "Включите UDP-порт или выключите Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5923,69 +5835,69 @@ msgstr ""
 "Вам НЕОБХОДИМО перезапустить aMule немедленно.\n"
 "Иначе не жалуйтесь, если произойдет какая-нибудь неприятность.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматическое обновление начато"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Папка для временных файлов"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль задан и внешние соединения разрешены."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5995,24 +5907,24 @@ msgstr ""
 "Пожалуйста, внесите в список хотя бы один URL, указывающий на корректный 'server.met'.\n"
 "Щелкните на кнопке \"Список\" чтобы ввести URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Временные файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Входящие файлы"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online-подписи"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Выберите каталог для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6020,42 +5932,42 @@ msgstr[0] "Найден %i известный публикуемый файл."
 msgstr[1] "Найдено %i известных публикуемых файла."
 msgstr[2] "Найдено %i известных публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Выбрать видео-проигрыватель"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Выберите броузер"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Команда запуска%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Системный"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Редактировать список серверов"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6063,42 +5975,42 @@ msgstr ""
 "Впишите сюда адреса для получения файлов 'server.met'.\n"
 "Только один URL в одной строчке."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Полных источников"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Статус:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6106,7 +6018,7 @@ msgstr[0] "Интервал обновления: %d с"
 msgstr[1] "Интервал обновления: %d сек"
 msgstr[2] "Интервал обновления: %d сек"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6114,12 +6026,12 @@ msgstr[0] "Отрезок времени, охватывающийся граф�
 msgstr[1] "Отрезок времени, охватывающийся графиком: %d минут"
 msgstr[2] "Отрезок времени, охватывающийся графиком: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Масштаб графика соединений: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6127,7 +6039,7 @@ msgstr[0] "Файловый буфер: %d Б"
 msgstr[1] "Размер буфера: %d байт"
 msgstr[2] "Размер буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6135,7 +6047,7 @@ msgstr[0] "Размер очереди отдачи: %d"
 msgstr[1] "Размер очереди отдачи: %d клиентов"
 msgstr[2] "Размер очереди отдачи: %d клиентов"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6143,238 +6055,238 @@ msgstr[0] "Частота связи с сервером: %d м"
 msgstr[1] "Интервал обновления соединения с сервером: %d минут"
 msgstr[2] "Интервал обновления соединения с сервером: %d минут"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Обновление соединения с сервером: Отключено"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "выключена"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Выполнить команду при событии '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Включить выполнение команд в ядре"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Команда ядра:"
 
 # никто ни в жизни не поймет переведенную аббревиатуру
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Включить выполнение команд в GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Команда GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Следующие переменные будут заменены:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Обновить список публикуемых файлов"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Публикуемые папки"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Обновить список публикуемых файлов."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Публикуемые папки"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Поиск"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Мин. размер должен быть меньше макс. размера. Игнорирую макс. размер."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Общая"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Поиск по сети eD2k  не может быть произведен когда она отсоединена."
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Ключевое слово поиска: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ошибка при поиске через Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Без оценки"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Загрузить в категории"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Получить %s для этого файла"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Искать связанные файлы (eD2k, локально)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Отметить как известный"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Копировать eD2k ссылку в буфер"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Вы соединены с сервером, который вы пытаетесь удалить. Отключитесь от него."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Отменено"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Новый"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Не могу соединиться ни с одним завуалированным сервером в списке. Пробую еще раз, но без вуалирования."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Не могу соединиться ни с одним завуалированным сервером в списке. Пробую еще раз, но без вуалирования."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Не удалось соединиться ни с одним указанным сервером. Еще один заход."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Не удалось соединиться ни с одним указанным сервером. Еще один заход."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Сеть eD2k отключена в настройках, не соединяется."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "В списке серверов не найдено ни одного доступного сервера"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Подключен к %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Установлено соединение с: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Ошибка во время соединения. Возможно нет соединения с Интернет."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Утеряно соединение с %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) вероятно умер."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) вероятно заполнен."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6382,48 +6294,48 @@ msgstr[0] "Автоматическое соединение с сервером
 msgstr[1] "Автоматическое соединение с сервером будет предпринято через %d секунды"
 msgstr[2] "Автоматическое соединение с сервером будет предпринято через %d секунд"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Подключение к %s (%s:%i) завершилось ошибкой."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ОШИБКА: сокет был закрыт по таймауту"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Время ожидания соединения с %s (%s:%i) вышло."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Получен старый результат поиска DNS, опускаем."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Загружается файл 'server.met': %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Файл 'server.met' не найден!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Не удалось загрузить файл server.met '%s', потому что он имеет неправильный формат."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Не удалось открыть файл 'server.met'!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Файл server.met поврежден. Неверная метка версии: 0x%x, размер %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6431,7 +6343,7 @@ msgstr[0] "В файле 'server.met' найден %i сервер"
 msgstr[1] "В файле 'server.met' найдено %i сервера"
 msgstr[2] "В файле 'server.met' найдено %i серверов"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6439,236 +6351,235 @@ msgstr[0] "%d сервер добавлен"
 msgstr[1] "%d сервера добавлено"
 msgstr[2] "%d серверов добавлено"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Ошибка: файл 'server.met' поврежден:"
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Ошибка ввода/вывода при чтении файла known.met: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Сервер не был добавлен: [%s:%d] не указывает на подходящий порт."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Сервер не был указан: IP адрес [%s:%d] был отфильтрован или неверен."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Сервер не был добавлен: сервер с совпадающим IP:порт [%s:%d] был найден в списке."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Сервер добавлен: сервер [%s:%d] использует имя '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Вы соединены с сервером, который вы пытаетесь удалить. Отключитесь от него."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Невозможно открыть %s"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Не удалось сохранить файл 'server.met'."
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Неверный URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Завершена загрузка списка серверов с %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Не найдено адресов списков серверов в 'addresses.dat'. Пожалуйста, введите правильные адреса чтобы авто-обновление работало."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Начинаю загружать список серверов с %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: неверный URL для авто-обновления серверов: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Отсутствует допустимый 'server.met' файл по адресу для автоматического обновления серверов"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Не удалось получить список серверов из %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Локальный сервер отфильтрован через IPFilters. Подключаюсь к другому серверу!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Имя сервера"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Адрес"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Порт"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Описание"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Пользователей"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Статический"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версия"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Вы соединены с сервером, который вы пытаетесь удалить. Сначала нужно отключиться от него. Сервер НЕ удален."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Неизвестное имя)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Вы уверены, что хотите удалить сервер %s из статического списка "
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Серверов (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Сервер"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Подключиться к серверу"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Внести в список статических серверов"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Удалить из списка статических серверов"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Внести в список статических серверов"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Удалить из списка статических серверов"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Удалить выбранный сервер"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Удалить выбранные серверы"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Удалить все сервера"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Копировать eD2k ссылки в буфер"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Восстановить соединение с сервером"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Вы уверены, что хотите удалить все сервера?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Удалить выбранный сервер?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Удалить выбранные серверы?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ОШИБКА: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Новый ID клиента %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: вы получили Low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tСкорее всего это из-за того, что вы находитесь за брандмауэром или маршрутизатором."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tДля подробностей, обратитесь к https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Получена неизвестная информация о сервере. - слишком коротко"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6676,177 +6587,177 @@ msgstr[0] "Получен %d новый сервер"
 msgstr[1] "Получено %d новых сервера"
 msgstr[2] "Получено %d новых серверов"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Сохранение списка серверов завершено."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Сервер отклонил последнюю команду"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Подложный пакет получен от сервера: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Неизвестная ошибка при обработке пакета от сервера: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Невозможно создать поток разрешения DNS для соединения с %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP адрес сервера %s (%s) запрещен фильтром.  Соединение отменено."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "использую вуалирование протокола."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Установка соединения с %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Не удалось разрешить DNS для сервера %s: Невозможно подключиться."
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Журнал aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Сервер не был добавлен: не указан адрес сервера."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Сервер не был добавлен: указан неверный порт сервера."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Статус eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Состояние соединения:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Подключен"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Статус Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Работает в режиме LAN"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Выполняется"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Статус Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Статус:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Состояние соединения:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "За брандмауэром - откройте TCP порт %d на вашем роутере или брандмауэре"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Состояние UDP соединения:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "За брандмауэром - откройте UDP порт %d на вашем роутере или брандмауэре"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Состояние брандмауэра:"
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Друг не требуется - TCP порт открыт"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Друг не требуется - UDP порт открыт"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Нет друзей"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Соединяем с другом"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Соединяем с другом на %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Проиндексировано источников:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Ключевые слова проиндексированы:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Проиндексировано записей:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Загрузки проиндексированы:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Пользователей в среднем:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Файлов в среднем:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Не запущен"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Добавляем файл %s к списку опубликованных"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6854,7 +6765,7 @@ msgstr[0] "Найден %i известный публикуемый файл."
 msgstr[1] "Найдено %i известных публикуемых файла."
 msgstr[2] "Найдено %i известных публикуемых файлов."
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6862,7 +6773,7 @@ msgstr[0] "Найден %i известный публикуемый файл, %
 msgstr[1] "Найдено %i известных публикуемых файла, %i неизвестных."
 msgstr[2] "Найдено %i известных публикуемых файлов, %i неизвестных."
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6871,423 +6782,423 @@ msgstr[1] ""
 msgstr[2] ""
 
 # ей-богу не понимаю что за ошибка и когда вылазит
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ОШИБКА: попытка опубликовать %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Публикуемая директория не найдена, пропускаем: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Нет публикуемых файлов в директории: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Имя пользователя"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Скорость загрузки"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Скорость отдачи"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Доступные части"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Статус отдачи"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Статус принимаемых файлов"
 
 # Source of a source. I mean, it's where a client came from.
 # (GonoszTopi)
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Откуда"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Локальное имя файла"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Файлы"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Полученные части"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Каталог"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Добавить комментарий/рейтинг"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Редактировать комментарий/рейтинг"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Переименовать"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Добавить файлы коллекции в список для закачки"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Скопировать magnet URL в буфер &обмена"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Копировать eD2k ссылку в буфер (&Источник)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Копировать eD2k ссылку в буфер (Источник) (&С шифрованием)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Копировать eD2k ссылку в буфер (Имя &хоста)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Копировать eD2k ссылку в буфер (Имя хоста) (С &шифрованием)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Копировать eD2k ссылку в &буфер (информация AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Копировать eD2k ссылку в &буфер (информация AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Для создания ссылки на источник требуется HighID"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Публикуемые файлы (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Удаленное имя файла"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Передано за сеанс (всего): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Служебный трафик (пакеты): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Трафик запросов (пакеты): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Трафик обмена источниками (пакеты): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Трафик с сервером (пакеты): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Служебный трафик Kad (пакеты): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Потери шифрования (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Активные отдачи: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Ожидающие отдачи: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Всего успешных сессий отдачи: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Всего неудачных сессий отдачи: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Среднее время отдачи: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Принято за сеанс (всего): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Найдено источников: %s"
 
 # chunk, конечно, никакой не пакет.... но фиг знает
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Активных загрузок (фрагменты файлов): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Соотношение UL:DL (всего): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Средняя скорость закачки (Сессия): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Средняя скорость отдачи (Сессия): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Максимальная скорость закачки (Сессия): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Максимальная скорость отдачи (Сессия): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Пересоединений: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Прошло после первой передачи: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Время подключения к серверу: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Активных соединений (примерно): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Достигнуто макс. число соединений: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Соединений в среднем (прибл.): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Максимальное число соединений (примерно): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Клиенты"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Неизвестны: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Отфильтрованы: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Заблокированы: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Всего: %i Известно: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Работающих серверов: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Сбойных серверов: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Всего: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Удаленных серверов: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Отфильтрованных серверов: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Пользователей на работающих серверах: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Файлов на работающих серверах: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Всего пользователей: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Всего файлов: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Загруженность сервера: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Число публикуемых файлов: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Общий размер публикуемых файлов: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Средний размер файлов: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Операционная система"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Не получено"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Активные соединения (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Недоступен"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Никогда"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Команда `%s' с pid `%d' завершилась с кодом статуса `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Выполнить <str> и выйти."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Неверный формат IP-адреса. Пример: xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Этой команде требуется аргумент. Доступные аргументы: 'all', имя файла или номер.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Обрабатывается по хэшу:"
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Обрабатывается по имени:"
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Эта команда требует аргумента. Допустимые аргументы: хэш файла.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Недопустимый номер\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Недопустимый хеш (длина должна быть равна 32 символам)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7296,7 +7207,7 @@ msgstr "Наберите '%s' для подробной справки.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7305,90 +7216,88 @@ msgstr "Наберите '%s' для подробной справки.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Наберите '%s' для подробной справки.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Прием %s"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Запрос не удался - неизвестная ошибка."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Операция выполнена успешно."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Запрос не удался: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP-фильтрация клиентов: %s\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "ВЫКЛ"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "ВКЛ"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP-фильтрация серверов: %s\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Текущий уровень IP-фильтра: %d.\n"
 
 # писать тут "вверх" и "вниз" по-моему глупо. да и не поймет никто
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Ограничения загрузки: UL: %u kB/сек, DL: %u kB/сек.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Подключен к %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Идет подключение"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "за брандмауэром"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7397,7 +7306,7 @@ msgstr ""
 "\n"
 "Закачка:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7406,7 +7315,7 @@ msgstr ""
 "\n"
 "Отдача:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7415,7 +7324,7 @@ msgstr ""
 "\n"
 "Клиентов в очереди:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7424,46 +7333,46 @@ msgstr ""
 "\n"
 "Всего источников:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[частично]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Число результатов поиска: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Состояние поиска: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Состояние поиска неизвестно"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Получен неверный ответ сервера, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Показать краткую информацию о статусе."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Показать состояние соединения, такущие скорости отдачи/закачки, и т.д.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Показать полную статистику."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7477,11 +7386,11 @@ msgstr ""
 "\n"
 "Пример:  'statistics 5' покажет только пять наиболее частых номеров версий каждого клиента .\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Закрыть aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7491,35 +7400,35 @@ msgstr ""
 "Это так же завершит работу текстового клиента, т.к.\n"
 "без ядра он бесполезен.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Обновить данный объект."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Обновить список публикуемых файлов."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Обновить таблицу IP фильтра."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Обновить локальную таблицу IP фильтра."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Обновить таблицу IP фильтра с URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Если URL пропущен, используется URL из настроек."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Подключиться к сети."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7531,35 +7440,35 @@ msgstr ""
 "подключиться, в форме IP:Порт. В поле IP вводится либо\n"
 "сетевой адрес вида x.x.x.x, либо доменное имя."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Подключиться только к eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Подключиться только к Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Отключиться от сети."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Это отключит от всех подсоединенных сетей.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Отключиться только от eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Отсоединиться от Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Добавить eD2k или magnet-ссылку в ядро"
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7579,51 +7488,51 @@ msgstr ""
 "\n"
 "magnet-ссылка должна содержать eD2k хэш и длину файла.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Установить значение параметра."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Установить настройки IP фильтра."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Включить IP-фильтрацию для клиентов и серверов."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Выключить IP-фильтрацию для клиентов и серверов."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Включить/выключить IP-фильтрацию для клиентов."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Включить IP-фильтрацию для клиентов."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Выключить IP-фильтрацию для клиентов."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Включить/выключить IP-фильтрацию для серверов."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Включить IP-фильтрацию для серверов."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Выключить IP-фильтрацию для серверов."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Выбирите уровень IP фильтрации."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7631,74 +7540,74 @@ msgstr ""
 "Допустимые уровни фильтрации находятся в диапазоне 0-255,\n"
 "значением по умолчанию является 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Укажите пределы канала."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Значения тут указываются в кб/сек (килобайтах в секунду).\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Укажите ограничение скорости отдачи."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Значения тут указываются в кб/сек (килобайтах в секунду).\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Укажите ограничение скорости загрузки."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Значения тут указываются в кб/сек (килобайтах в секунду).\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Получить и отобразить значение параметра."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Получить параметры IP фильтра."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Получить состояние IP фильтра для клиентов и серверов."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Получить состояние IP фильтра только для клиентов."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Получить состояние IP фильтра только для серверов."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Получить уровень IP фильтрации."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Получить ограничения полосы пропускания."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Выполнить поиск."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7717,44 +7626,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Выполнить глобальный поиск."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Выполнить локальный поиск"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Выполнить поиск в Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Показать результаты последнего поиска."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Показать состояние поиска."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Начать загрузку файла."
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7762,81 +7671,81 @@ msgstr ""
 "Должен быть указан номер файла из последнего поиска.\n"
 "Пример: 'download 12' запустит загрузку файла номер 12 из последнего поиска.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Приостановить закачку."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Продолжить закачку."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Отменить закачку."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Установить приоритет загрузки."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Установить для загрузки низкий, нормальный, высокий или автоматический приоритет.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Установить низкий приоритет."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Установить нормальный приоритет."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Установить высокий приоритет."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Установить авто-приоритет."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Показать очереди/списки."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Показать очереди на закачку/отдачу, список серверов или публикуемых файлов.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Показать очередь на отдачу."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Показать очередь на закачку."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Показать журнал."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Показать список серверов."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Обновить список публикуемых файлов."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Очистить журнал."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Устаревшая команда, используйте вместо нее '%s'."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7845,261 +7754,258 @@ msgstr ""
 "Устаревшая команда, и возможно в будущем будет удалена.\n"
 "Используйте вместо нее '%s'.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Текстовый клиент aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Конвертирую старые AICH хеши из '%s' в 64b в '%s'"
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Имя файла '%s' - неверно и было изменено на '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Файл '%s' уже существует. Новый файл назван '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Вы уверены, что хотите отменить и удалить все файлы в этой категории?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Требуется подтверждение"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Поддерживается только 99 категорий."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Слишком много категорий!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Все остальные"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Выбрать фильтр просмотра"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Добавить категорию"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Редакировать категорию"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Удалить категорию"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Запрошен набор хешей для неизвестного файла: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Возобновляется отдача файла: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Приостанавливается отдача файла: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Не удалось выполнить команду `%s' при событии `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Загрузка завершена"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Полный путь к файлу"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Имя файла без пути"
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "eD2k хэш файла"
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Размер файла в байтах"
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Общее время загрузки"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Начата новая беседа"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Отправитель"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Недостаточно места"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Раздел диска"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Ошибка при завершении"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Обрабатывается файл под номером %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Вы запросили частичные хеши (используется только для файлов > 9.5 MБ)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Файл не существует !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, программа для создания eD2k ссылок для aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Добро пожаловать!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Параметры ввода"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Файл для хеширования"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Добавьте возможные URL для этого файла"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Введите здесь файл для которого вы хотите получить eD2k ссылку"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Введите здесь URL который вы хотите добавить к eD2k ссылке: добавьте / в конце если хотите чтобы aLinkCreator присоеденил текущее имя файла"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Создать ссылку с хешами частей"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Помогите распространить новые и редкие файлы быстрее, за счет увеличения размера ссылки"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Хеш MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k хэш-файл"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k ссылка"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Скопировать в буфер обмена"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Открыть"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Открыть файл и получить его eD2k ссылку"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Копировать полученную eD2k ссылку в буфер"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Сохранить как"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Сохранить полученную eD2k ссылку в файл"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "О программе aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Выберите файл для которого вы хотите получить eD2k ссылку"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Невозможно открыть буфер"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Сейчас нечего копировать!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Выберите файл в который сохранить полученную eD2k ссылку"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Невозможно открыть "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Пожалуйста, введите не пустое имя файла"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Сейчас нечего сохранять!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8119,167 +8025,159 @@ msgstr ""
 "\n"
 "Лицензия - GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Идет хеширование..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator работает для вас"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Считаем MD4 хэш..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Считаем eD2k хэши..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Отменено."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Выполнено за %.2f сек"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Этот URL уже добавлен !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Введите URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Не удалось открыть %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i дней %i часов %i минут %i секунд"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uд %02uч %02uмин %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uч %02uмин %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02uмин %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, модуль статистики aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Максимальная скорость загрузки за время работы wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Абсолютная максимальная скорость загрузки за время работы wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Сбросить"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Система"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Остановить автоматическое обновление"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Сохранить картинку со статистикой"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Распечатать картинку со статистикой"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Настройки"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "О модуле wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Начать авто обновление"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Автоматическое обновление остановлено"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Автоматическое обновление начато"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Сохранить картинку со статистикой"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Онлайн-статистика"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8287,11 +8185,11 @@ msgstr ""
 "Проблема с печатью.\n"
 "Возможно принтер неправильно установлен."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Печать"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8309,405 +8207,394 @@ msgstr ""
 "\n"
 "Лицензия - GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Ох-ох... aMule то не запущен..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule запущен"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule запущен, но не подключен"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule подключается..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Ох-ох... статус aMule неизвестен..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " работает "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " остановлен!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " не подключен!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " подключается..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " делает что-то непонятное, проверьте!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " подключен к "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "отключен"
 
 #  stands for $User is on $server
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " на "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " с "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Всего принято: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Передано: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Принято за сеанс: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Прием: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/сек, Передача: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Передача другим: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr "файлов, клиентов в очереди: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Время:"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " на "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Системная загрузка (за 1-5-15 мин): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Время работы системы: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Каталог, содержащий файл amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Введите здесь путь к вашему файлу amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Интервал обновления в секундах"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Генерировать картинку со статистикой после каждого события обновления"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Укажите здесь каталог, в который вы хотите сохранять картинку со статистикой"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Периодическая загрузка картинки со статистикой на FTP сервер"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP Url"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP путь"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Введите здесь адрес вашего FTP сервера"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Введите здесь путь для сохранения картинки со статистикой на FTP сервере"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Пользователь"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Введите здесь имя пользователя для вашего FTP сервера"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Введите здесь пароль для вашего FTP сервера"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Интервал обновления через FTP в минутах"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Проверить"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Каталог, в котором хранится файл-подпись"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Каталог, в котором будет сохранятся картинка со статистикой"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Загрузить шаблон <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "HTTP порт веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Использовать UPnP форвардинг портов для порта веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP-порт"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Пароль веб-сервера для полного доступа"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Пароль веб-сервера для ограниченного доступа"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Позволять ограниченный доступ"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Запрещать ограниченный доступ"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Загрузить/сохранить настройки веб-сервера из/в удаленный aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Путь к файлу конфигурации aMule. НЕ ИСПОЛЬЗУЙТЕ ПРЯМОЙ ПУТЬ!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Отключить PHP (не рекомендуется)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Компилировать PHP-страницы при каждом запросе"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Веб-сервер aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "соединение Веб-клиента принято\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ОШИБКА: невозможно принять соединение web-клиента\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Запрос не удался из-за следующей ошибки: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Индексный файл не найден:"
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Сессия просрочена - запрашиваю логин\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Сессия в порядке, авторизован\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Сессия в порядке, не авторизован\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Нет открытых сессий - буду запрашивать логин\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Сессия открыта - запрашиваю логин\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Обрабатываю запрос [исходный]:"
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Не указан пароль, авторизация запрещена."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Проверяю пароль\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Хеш пароля неверен\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Пароль верен\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Неверный пароль\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Вы не ввели пароль. Пустой пароль недопустим.\n"
 
 # в eMule - так и пишут: логин/логаут, но мне не нравится
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Запрошено отсоединение\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Обрабатываю запрос [перенаправленный]:"
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Попытка подключиться не удалась "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -22,20 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Prikaži aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Oddaljen nadzor aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Posnetek:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -43,7 +43,7 @@ msgstr ""
 "Odjemalec P2P, ki temelji na eMule in je za vse platforme\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -52,79 +52,79 @@ msgstr ""
 "Avtorske pravice © 2003–2019 ekipa aMule\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Del aMule temelji na\n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: usmerjanje med enakovrednimi, ki temelji na metriki XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Avtorske pravice 2002–2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Ob zagonu preveri za novo različico"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Povezovanje s Kad ..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Ni na voljo"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Dodaj prijatelja"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Vnesti morate veljaven IP in vrata."
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Podatki"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Navedena koda uporabnika ni veljavna."
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -133,49 +133,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Za imenom programa"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Povezovanje ni uspelo "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -184,103 +183,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Ni bilo mogoče odpreti datoteke ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezavo eD2k."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Sedaj, zapuščanje glavnega programa …"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Neuspeh"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Končanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Ubijanje izvoda amuleweb s PID »%d« ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Končevanje jedra."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Zaustavitev aMule zaključena."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Rezultati razhroščevanja pomnilnika za izhod iz aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vaše področne nastavitve so bile spremenjene na sistemsko privzete zaradi spremembe v nastavitvah. Oprostite."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Podatki"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -288,74 +284,70 @@ msgstr ""
 "\n"
 "Nastavitev zunanje povezave"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "OPOZORILO"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "NAPAKA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "spletni strežnik teče s PID %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Vrat ni bilo moč povezati z navedenim naslovom: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Vrata %u niso razpoložljiva. Imeli boste nizek ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -370,49 +362,49 @@ msgstr ""
 "\n"
 "Preverite omrežje in se prepričajte, da so vrata odprta za izhod in vhod."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti datoteke spletnega podpisa"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Ni bilo mogoče ustvariti aMule datoteke spletnega podpisa"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Kot kaže izbrana področna nastavitev ni nameščena na vašem računalniku. (Opomba: vseeno se jo bo poskusilo nastaviti)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "To je vaš prvi zagon aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "To je testna različica, posodobljena dnevno in\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne dajemo zagotovila, da ne bo ničesar poškodovala, zažgala vaše hiše\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ali ubila vašega psa. Vendar bi vseeno morala biti varna za uporabo.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Več informacij, podporo in nove različice, lahko najdete na naši domači strani,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 #, fuzzy
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -420,226 +412,222 @@ msgstr ""
 "Navedena mapa za datoteke za spletni podpis je NEVELJAVNA.\n"
 "Spletni podpis bo ONEMOGOČEN, dokler težave ne odpravite v nastavitvah."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Vnaprejšnja dodelitev prostora na disku za datoteko »%s« ni uspela: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "NAPAKA: ni mogoče odpreti dnevniške datoteke"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "OPOZORILO: dnevniška datoteka je prazna. Nekaj je narobe."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Dnevnik je bil ponastavljen"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sporočilo strežnika: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Prejemanje %s je bilo preskočeno, ker zahtevana datoteka ni novejša."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Ni bilo mogoče prejeti seznama vozlišč."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Ni bilo mogoče odpreti prejete datoteke za preverjanje različice"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Datoteka za preverjanje različice je pokvarjena"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Uporabljate zastarelo različico aMule."
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Različica vaše aMule je %i.%i.%i, najnovejša različica pa je %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 #, fuzzy
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "OPOZORILO: vaša različica aMule je zastarela: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Uporabljate najnovejšo različico aMule."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Ni bilo mogoče prejeti datoteke za preverjanje različice"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Uporabniki: %s | Datoteke: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Uporabniki: E: %s K: %s | Datoteke: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Izbranega ni nobenega omrežja"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "z nizkim ID-jem"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "z visokim ID-jem"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Povezano na %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Povezovanje z %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Povezava z eD2k prekinjena"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad zagnan."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad ustavljen."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Povezano v Kad (v redu)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Omrežja Kad ni mogoče uporabljati, če so vrata UDP onemogočena v nastavitvah. Kad ni zagnan."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Omrežje Kad je onemogočeno v nastavitvah. Ni povezave."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "NAPAKA: Ne morete uporabljati demona aMule, ko so zunanje povezave onemogočene. Za vklop zunanjih povezav uporabite ali navaden aMule ali zaženite amuled z možnostjo --ec-config ali pa nastavite vrednost ključa\"AcceptExternalConnections\"  na 1 v datoteki ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "NAPAKA: Za uporabo zunanjih povezav je potrebno veljavno geslo, demona aMule pa brez zunanjih povezav ni mogoče uporabiti. Za zagon demona aMule morate ključ »ECPassword« v datoteki ~/.aMule/amule.conf nastaviti na ustrezno vrednost. Za nastavitev gesla zaženite amuled z možnostjo --ec-config. Več informacij lahko najdete na https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - zaganjanje časomerilnika"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Ni moč ustvariti datoteke PID"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "NAPAKA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To je aMule %s, ki temelji na eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -649,192 +637,185 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Brez omrežja"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Oddaljeni nadzor aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Usodna napaka: ni bilo mogoče ustvariti osrednjega časomerilnika"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Poveži se z oddaljenim aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Povezava izgubljena"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Opozori ob končanju"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -843,153 +824,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Usodna napaka: ni bilo mogoče ustvariti časomerilnika za povpraševanje"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Prehod v dogodkovno zanko …"
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Povezovanje …"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Rokovalnik z dogodki zunanje povezave oddaljenega vmesnika"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Povezava ni uspela. Ni se moč povezati z %s: %d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Zaustavljanje"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Čas za poskus povezovanja z %s (%s:%i) je potekel."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Poveži se z omrežjem."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Povezava ni uspela. Ni se moč povezati z %s: %d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Pripravljen"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Vse"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Ni na voljo"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Datoteke ni mogoče najti."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »%s«."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznano"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Iskanje kolega za povezavo z nizkim ID-jem"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (lažna različica eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (lažni eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (lažni eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (temelji na eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Vzdevek: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Zahtevano: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -998,7 +969,7 @@ msgstr[1] "Statistika datotek v tej seji: Sprejetih %d od %d zahteve, %s prenese
 msgstr[2] "Statistika datotek v tej seji: Sprejetih %d od %d zahtev, %s prenesenih\n"
 msgstr[3] "Statistika datotek v tej seji: Sprejetih %d od %d zahtev, %s prenesenih\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1007,119 +978,119 @@ msgstr[1] "Statistika datotek vseh sej: Sprejetih %d od %d zahteve, %s preneseni
 msgstr[2] "Statistika datotek vseh sej: Sprejetih %d od %d zahtev, %s prenesenih\n"
 msgstr[3] "Statistika datotek vseh sej: Sprejetih %d od %d zahtev, %s prenesenih\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Zahtevana neznana datoteka"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtrirano sporočilo od »%s« (IP: %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Novo sporočilo od »%s« (IP: %s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uporabnik %s (%u) je zahteval seznam deljenih datotek za mapo »%s« → prezrto"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "OPOZORILO: %s ni moč odpreti."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "OPOZORILO: Seznam preklicanih datotek je pokvarjen, vsebuje neveljavno glavo."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Vhodno/izhodna napaka med branjem datoteke %s: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Napaka med shranjevanjem datoteke %s: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Nova kategorija"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Izberite mapo za prejete datoteke"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Navesti morate ime za kategorijo."
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Navesti morate pot za kategorijo."
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Ni bilo mogoče ustvariti mape prejetih datotek za kategorijo. Prosimo, navedite veljavno pot."
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Pogovorna seja se je začela: %s (%s:%u) – %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Povezan z odjemalcem ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Povezovanje z odjemalcem ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Povezava z odjemalcem ni uspela / povezava izgubljena ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Prestali ste preverjanje z besedilom na sliki in uporabnik je prejel vaše sporočilo. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Odgovor na preizkus z besedilom na sliki je bil napačen in vaše sporočilo je bilo prezrto. S pošiljanjem novega sporočila lahko zahtevate nov preizkus. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Klepet"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Zapri zavihek"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Zapri vse zavihke"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Zapri druge zavihke"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Dodaj med prijatelje"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1128,7 +1099,7 @@ msgstr[1] "Datoteka s krediti naložena, %u znan odjemalec"
 msgstr[2] "Datoteka s krediti naložena, %u znana odjemalca"
 msgstr[3] "Datoteka s krediti naložena, %u znani odjemalci"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1137,173 +1108,170 @@ msgstr[1] " - Zasluge potekle za %u odjemalec."
 msgstr[2] " - Zasluge potekle za %u odjemalca."
 msgstr[3] " - Zasluge potekle za %u odjemalce."
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Datoteka »cryptkey.dat« ne obstaja. Ustvarjanje."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Podrobnosti o odjemalcu"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Nizek ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Visok ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Omogočeno"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Podprto"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Ni podprto"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Onemogočeno"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Povezano"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Ni povezave"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nezaključeno"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Baraba"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Preverjeno – v redu"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Ni na voljo"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Uporabnik %s (%u) je zahteval vaš seznam deljenih datotek → sprejeto"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Uporabnik %s (%u) je zahteval vaš seznam deljenih datotek → zavrnjeno"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Uporabnik %s (%u) je zahteval vaš seznam deljenih map → sprejeto"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Uporabnik %s (%u) je zahteval vaš seznam deljenih map → zavrnjeno"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Uporabnik %s (%u) je zahteval seznam deljenih datotek za mapo »%s« → sprejeto"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Uporabnik %s (%u) je zahteval seznam deljenih datotek za mapo »%s« → zavrnjeno"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Uporabnik %s (%u) deli mapo »%s«"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Uporabnik %s (%u) je poslal nezahtevane deljene mape."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Uporabnik %s (%u) je poslal seznam deljenih datotek za mapo »%s«"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Uporabnik %s (%u) je zaključil s pošiljanjem seznama deljenih datotek"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Uporabnik %s (%u) je poslal nezaželen seznam deljenih datotek"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Uporabnik %s (%u) je zavrnil dostop do seznama deljenih datotek/map"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Komentarji o datoteki"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocena"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komentar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Iskanje preko Kad ni mogoče, če Kad ne teče"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Iskanje kolega za povezavo z nizkim ID-jem"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Ni komentarjev"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1312,268 +1280,258 @@ msgstr[1] "%u komentar"
 msgstr[2] "%u komentarja"
 msgstr[3] "%u komentarji"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Izločil odjemalca %s, ker je poslal %s pokvarjenih podatkov od skupno %s za datoteko »%s«"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Nalaganje državnih podatkov za »%s« ni uspelo."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Samod. [Ni]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Samod. [No]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Samod. [Vi]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoka"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Zelo visoka"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Najvišja"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Povpraševanje"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Povezovanje preko strežnika"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Vrsta polna"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "V vrsti"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Prejemanje"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Prejemanje nabora kod"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Nič uporabnih delov"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Povezava nizkega ID-ja z nizkim ID-jem ni mogoča"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Preveč povezav"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Povezovanje preko Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Preveč povezav Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Izločen"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Napaka povezave"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Oddaljena vrsta polna"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Star MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Nov MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule združljiv"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Krajevni strežnik"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Izmenjava virov"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasivno"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Povezava"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Izvorna semena"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Rezultat iskanja"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zaključeno"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "V teku"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "NAPAKA: zmanjkalo je prostora na disku"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "NAPAKA: ni bilo moč najti datoteke partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "NAPAKA: vhodno/izhodna napaka"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "NAPAKA: neuspeh"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "V vrsti"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Datoteka se že prejema"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Neznan ali pokvarjen format začasne datoteke."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Preneseno"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hitrost"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Napredek"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Viri"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prednost"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Stanje"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Preostali čas"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Nazadnje videno celotno"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Zadnji sprejem"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Ali res želite izbrisati izbrano datoteko?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Ali res želite izbrisati izbrane datoteke?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1582,109 +1540,106 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Samod."
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Ustavi"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Premor"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Nadaljuj"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Počisti &zaključene"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Prenesi vse vire PZDD na to datoteko zdaj"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Prenesi vse vire PZDD na to dat. (samod.)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Prenesi vse vire PZDD na druge datoteke"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Dodatne možnosti"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Ogled"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Prikaži po&drobnosti datoteke"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Prikaži vse komentarje"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Skopiraj magnet URI na odložišče"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Skopiraj &povezavo eD2k na odložišče"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Skopiraj odziv na odložišče"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "prekliči dodelitev"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Dodeli kategoriji"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Odpri datoteko"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Vnesite novo ime za to datoteko:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Preimenuj datoteko"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MiB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Prejemanja (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1693,48 +1648,48 @@ msgstr ""
 "Da preprečite to opozorilo ob vsakem ogledu,\n"
 "nastavite svoj priljubljen predvajalnik video posnetkov (privzet je %s)"
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Ogled datoteke"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "NAPAKA: Ni bilo mogoče zagnati zunanjega predvajalnika. Ukaz: »%s«"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Shranjevanje delne datoteke %u od %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Vse delne datoteke shranjene."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Nalaganje začasnih datotek iz %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Nalaganje delne datoteke %u od %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 #, fuzzy
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "NAPAKA: nalaganje varnostne kopije ni uspelo. Na https://github.com/amule-org/amule/discussions pošičite rešitve za obnavljanje datotek .part.met."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Vse delne datoteke naložene."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Ni mogoče najti delnih datotek"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1743,50 +1698,50 @@ msgstr[1] "Najdena %u delna datoteka"
 msgstr[2] "Najdeni %u delni datoteki"
 msgstr[3] "Najdene %u delne datoteke"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Datotečni sistem z začasno mapo ne more shranjevati velikih datotek."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Datotečni sistem z mapo prejetih datotek ne more shranjevati velikih datotek."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Prejemanje %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Datoteko »%s« že poskušate prejeti."
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Datoteko »%s« že imate."
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Datoteko »%s« že imate."
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Datoteko %s že poskušate prejemati"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Povezave magnet ni moč pretvoriti v eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Neznan protokol povezave: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1795,251 +1750,250 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Neveljavna povezava eD2k. NAPAKA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Po neuspelem overjanju je odjemalec poslal paket."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Zunanja povezava se je zaprla."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Zunanje povezave onemogočene zaradi praznega gesla."
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Zunanje povezave onemogočene v nastavitveni datoteki"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Nova zunanja povezava sprejeta"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "NAPAKA: nove zunanje povezave ni bilo moč sprejeti"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Zunanja povezava zavrnjena zaradi praznega gesla v nastavitvah."
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Povezovanje z odjemalcem: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Neznana različica"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Napačen ID različice za zunanje povezave; lahko pride do binarne nezdružljivosti. Uporabite jedro in oddaljen odjemalec iz istega posnetka."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ne morete se povezati s stabilno različico iz poljubne razvojne različice. Preprečeno morebitno sesutje."
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Neveljavna različica protokola."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Manjka oznaka različice protokola."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Overjanje ni uspelo: kot geslo za zunanje povezave je bila podana napačna koda."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Overjanje ni uspelo: napačno geslo."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Overjanje ni uspelo: manjkajoče geslo."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Neveljavna zahteva, najprej se morate overiti."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Dostop dovoljen."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Odjemalcu je bilo poslano sporočilo o napaki »%s«."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Nepooblaščen poskus dostopa od %s. Povezava prekinjena."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Ukaz za oddaljeno delno datoteko ni uspel: Ni bilo mogoče najti kode datoteke: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Kode datoteke ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "UPS. Napaka pri obdelavi OpCode."
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Strežnik ni bil dodan"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "strežnika ni mogoče najti: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "morate navesti strežnik za odstranitev"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Spletno iskanje iz oddaljenega vmesnika nima smisla."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Iskanje poteka. Ponovno poglejte za rezultati čez nekaj trenutkov."
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Ni točk za graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Vaš odjemalec ni nastavljen za to stopnjo podrobnosti."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Zunanja povezava: zahtevana zaustavitev"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Ustavljanje že poteka."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Zunanja povezava: dodajanje povezave »%s«."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Neveljavna povezava oz. je že na seznamu."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Datoteke ni mogoče najti."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Neveljavno ime datoteke."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ni mogoče preimenovati datoteke."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad je onemogočen v nastavitvah."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Povezava z eD2k že obstaja."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Povezovanje z eD2k …"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Povezava s Kad že obstaja."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Povezovanje s Kad …"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Vsa omrežja so onemogočena."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Povezava z eD2k prekinjena."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Povezava s Kad prekinjena."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Zunanja povezava: prejeta je bila neveljavna operacijska koda: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Neveljavna operacijska koda (napačna različica protokola?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Neznana razširitev »%s« za ukaz »%s«.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Neznan ukaz »%s«.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2047,7 +2001,7 @@ msgstr ""
 "\n"
 "Ta ukaz nima argumentov.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2055,7 +2009,7 @@ msgstr ""
 "\n"
 "Ta ukaz mora imeti argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2063,7 +2017,7 @@ msgstr ""
 "\n"
 "Ta ukaz je nepopoln, uporabiti morate eno od spodnjih razširitev.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2071,11 +2025,11 @@ msgstr ""
 "\n"
 "Razpoložljive razširitve:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Razpoložljivi ukazi:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2086,17 +2040,17 @@ msgstr ""
 "Ukazi niso občutljivi na velikost črk.\n"
 "Napišite »%s <ukaz>« za podrobne informacije o <ukaz>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Konča program."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Prikaži pomoč."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2104,7 +2058,7 @@ msgstr ""
 "Za pomoč pri ukazu napišite »help <ukaz>«.\n"
 "Za celoten seznam ukazov napišite »help«.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2115,46 +2069,46 @@ msgstr ""
 "Uporabite »%s« za seznam ukazov\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Napaka v skladnji."
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Napaka pri obdelavi ukaza – se ne bi smelo zgoditi. Prosimo, poročajte o hrošču.\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Ta ukaz ne sme imeti parametrov."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Ta ukaz mora imeti parameter."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Neveljaven argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Ukaz ni popoln."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Napišite »%s« za dodatno pomoč.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "To je %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "To je %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2162,7 +2116,7 @@ msgstr ""
 "\n"
 "Ustvarjanje odjemalca …\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2171,7 +2125,7 @@ msgstr ""
 "\n"
 "V redu, končevanje %s …\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2185,331 +2139,326 @@ msgstr ""
 "\n"
 "Končevanje …\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Prikaži to besedilo pomoči."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Gostitelj kjer teče aMule. (privzeto: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Vrata aMule za zunanje povezave. (privzeto: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Geslo za zunanje povezave."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Preberi nastavitve iz datoteke."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Ne izpisuj izhodnih podatkov na standardni izhod."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Zgovorno – prikaži tudi razhroščevalna sporočila."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Nastavi področne nastavitve (jezik) programa."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Zapiši možnosti ukazne vrstice v nastavitveno datoteko."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Ustvari nastavitveno datoteko, ki temelji na nastavitveni datoteki aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Izpiši različico programa."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Podrobnosti datoteke"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f %% zaključeno"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Dobrodošli!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Povezovanje s kolegom"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Stanje povezave:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Omrežja"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standardna vrata TCP "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Dodatna vrata UDP (globalno/Kad iskanje) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Omogoči posredovanje vrat na usmerjevalniku"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Začetno nalaganje"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Datoteko %s že poskušate prejemati"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Brskanje"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti za branje."
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti za pisanje."
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Prijatelji"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Prikaži po&drobnosti"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Dodaj prijatelja"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Odstrani prijatelja"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Pošlji &sporočilo"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Prikaži datoteke"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Ustvari mesto za prijatelja"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Ali res želite izbrisati izbranega prijatelja?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Ali res želite izbrisati izbrane prijatelje?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2517,11 +2466,11 @@ msgstr ""
 "Ne morete dodeliti več kot enega mesta za prijatelja.\n"
 "Samo eno mesto je bilo dodeljeno."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Izbira večih"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2530,183 +2479,182 @@ msgstr ""
 "Ne morete dodeliti več kot enega mesta za prijatelja.\n"
 "Samo eno mesto je bilo dodeljeno."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Pošlji uporabniku sporočilo"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Sporočilo:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Odstrani s seznama prijateljev"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Pošlji sporočilo"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Prenesi k tej datoteki"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "PZDD"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "V vrsti: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Prosil za drugo datoteko"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Čakanje na mesto za pošiljanje"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "V vrsti: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Pošiljanje"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Brez"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Da"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Prejemanje …"
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "Prejemanje HTTP preklicano"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "URL za prejemanje ne sme biti prazen"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Prejetih %d bajtov"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s je vrnil: %i – Napaka (%i)."
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Prejemanje HTTP preklicano"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Pridobi novo datoteko GeoIP.dat od %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Prejemanje datoteke GeoIP.dat ni uspelo, posodobitev preklicana."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Odstranitev datoteke %s ni uspela, posodobitev preklicana."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Preimenovanje datoteke %s ni uspelo, posodobitev preklicana."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s je bila uspešno posodobljena"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Napaka pri posodabljanju GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Prejemanje %s od %s ni uspelo"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Nalaganje datotek filtrov IP »ipfilter.dat« in »ipfilter_static.dat«."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Ni bilo mogoče naložiti datoteke ipfilter.dat »%s«, neznan format."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Ni bilo mogoče naložiti datoteke ipfilter.dat »%s«, ni bilo moč odpreti datoteke"
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2715,7 +2663,7 @@ msgstr[1] "Naložen %u niz IP iz '%s'."
 msgstr[2] "Naložena %u niza IP iz '%s'."
 msgstr[3] "Naloženi %u nizi IP iz '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2724,16 +2672,16 @@ msgstr[1] "%u nepravilna vrstica je bila izpuščena."
 msgstr[2] "%u nepravilni vrstici sta bili izpuščeni."
 msgstr[3] "%u nepravilne vrstice so bile izpuščene."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Preimenovanje nove datoteke %s ni uspelo, posodobitev preklicana."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "Filter IP je pripravljen"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2741,56 +2689,52 @@ msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Vozlišča (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Neveljaven IP za začetno nalaganje"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Neveljavna vrata za začetno nalaganje"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Prosimo, izpolnite vsa zahtevana polja"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Sporočilo"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ali res želite prejeti novo datoteko nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "S tem boste odstranili trenutna vozlišča in ponovno zagnali povezavo Kad."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Ali želite nadaljevati?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: iskalni niz je prekratek"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: iskalna ključna beseda je že na iskalnem seznamu: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Branje datoteke nodes.dat ni uspelo – prestara je. Ta različica (0) ni več podprta."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2799,12 +2743,11 @@ msgstr[1] "Prebran %u stik Kad"
 msgstr[2] "Prebrana %u stika Kad"
 msgstr[3] "Prebrani %u stiki Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Najdenega ni bilo nobenega stika. Opravite začetno nalaganje ali pa pridobite datoteko nodes.dat."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2813,7 +2756,7 @@ msgstr[1] "Na voljo je samo %d stik Kad, nodes.dat ni bila zapisana"
 msgstr[2] "Na voljo sta samo %d stika Kad, nodes.dat ni bila zapisana"
 msgstr[3] "Na voljo so samo %d stiki Kad, nodes.dat ni bila zapisana"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2822,801 +2765,774 @@ msgstr[1] "Zapisan %d stik Kad"
 msgstr[2] "Zapisana %d stika Kad"
 msgstr[3] "Zapisani %d stiki Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Omrežje Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Ime datoteke"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Velikost datoteke"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Delilno razmerje"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Zahtevano"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Sprejeto"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Popolnih virov"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "OPOZORILO: seznam znanih datotek je pokvarjen, vsebuje neveljavno glavo."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Nalaganje vnosa iz seznama znanih datotek ni uspelo, datoteka je morda pokvarjena"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Neveljaven vnos na seznamu znanih datotek, datoteka je morda pokvarjena: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Neznana napaka %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Ni moč dobiti opisa napake za napako %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Ustvarjanje kode"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Zaključevanje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Zaključeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Prekinjeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vsebuje napake"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Na čakanju"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Navesti morate neprazno geslo."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Neveljavno geslo, ni zgoščena vrednost MD5."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Napaka med povezovanjem"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Zunanja povezava se je zaprla."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "Zunanja povezava ni uspela. Prazen odgovor."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Zunanja povezava: slab odgovor, rokovanje ni uspelo. Povezava prekinjena."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Uspeh! Vzpostavljena povezava z aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Uspeh! Povezava vzpostavljena."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Zunanja povezava: dostop je bil zavrnjen. Razlog: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Zunanja povezava: rokovanje ni uspelo."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "Vtičnica za poslušanje: v redu."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "NAPAKA: ni moč poslušati na vratih TCP."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "NAPAKA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "OPOZORILO: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Zapri"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Izreži"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Skopiraj"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Prilepi"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Počisti"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Izberi vse"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Povezano"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Povezano"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Povezano v Kad (za požarnim zidom)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP strežnika: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP strežnika:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Ni povezave"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Vrata TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Vrata TCP: niso pripravljena"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Vrata UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Vrata UDP: niso pripravljena"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Podatki o odjemalcu"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Omejitev pošiljanja"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Omejitev prejemanja"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Prikaži aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Skrij aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Končaj"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Neomejeno"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule meni sistemske vrstice"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Omejitve hitrosti"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Gor: brez"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Gor: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Dol: brez"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Dol: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Hitrost prejemanja: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Hitrost pošiljanja: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Vzdevek: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Izbran ni noben vzdevek."
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Odjemalčev ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Ime strežnika: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP strežnika: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Ni povezave"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Spletni podpis: omogočen"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Spletni podpis: onemogočen"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Neprekinjeno delovanje: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Deljene datoteke: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Odjemalci v vrsti: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Skupno dol: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Skupno gor: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Dodaj povezavo magnet ali povezavo ed2k v jedro."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Dodaj med prijatelje"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Kliknite za dodajanje povezave eD2k v vrsto za prejemanje."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Dogodki so prikazani tukaj. Za celoten seznam dogodkov, poglejte v zapisnik na zavihku Strežniki."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Nalaganje …"
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Število uporabnikov na strežniku na katerega ste povezani …"
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Uporabnikov: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Število uporabnikov povezanih na ta strežnik in ocena skupnega števila uporabnikov."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Gor: 0,0 | Dol: 0,0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Trenutno povprečje prenosa v obe smeri. Če je vklopljen prikaz presežka, številke v oklepaju ponazarjajo presežek prenosa od komunikacije med odjemalci."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Prikazuje stanje povezave in dejavne prenose. Rdeče puščice pomenijo, da trenutno niste povezani, rumene puščice pomenijo, da imate nizek ID (ste za požarnim zidom) in zelene puščice pomenijo, da imate visok ID (optimalna povezava)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Ni povezave …"
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Trenutno povezan strežnik."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Iskanje"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Ime:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Krajevno"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globalno"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Dodatni parametri"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtriranje"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Vrsta datoteke"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Vse"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arhivi"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Zvok"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Odtisi CD-jev"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Slike"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programi"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Besedila"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Video"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Končnica"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min. velikost"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bajtov"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MiB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GiB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Maks. velikost"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Razpoložljivost"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtriraj rezultate"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Obrni rezultat"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Skrij znane datoteke"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Začni"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Več"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Ustavi"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Pridobi"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Ponastavi polja"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultati"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Počisti zaključena prejemanja"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Viri datoteke:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "Ni na voljo"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Splošno"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Polno Ime:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Datoteka met:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Koda:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Velikost datoteke:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Prenos"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Stanje delne datoteke:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Nazadnje videno celotno:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Najdenih virov:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Prenašajoči viri:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Število delov:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Razpoložljivih:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Čas dejavnega prejemanja: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Preneseno:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Zaključeno:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Inteligentno rokovanje s poškodbami"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Izguba zaradi poškodb:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Pridobitev zaradi stiskanja:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paketi rešeni z I.R.P.:"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Deljenih: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Zahteve"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Sprejete zahteve"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Prenesenih podatkov"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Delilno razmerje"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Popolni viri"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Deljene datoteke"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", poslanega: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Ni ocenjena"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Naslov:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Imena datoteke"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Prevzemi"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Počisti"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Uveljavi"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Komentirajte/ocenite datoteko (besedilo bo vidno vsem uporabnikom)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3624,1272 +3540,1268 @@ msgstr ""
 "Za film lahko poveste njegovo dolžino, zgodbo, jezik ...\n"
 "in če je lažna, lahko to sporočite drugim uporabnikom."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Kakovost datoteke"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Ni ocenjena"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Neveljavna/poškodovana/lažna"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Slaba"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Povprečna"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Dobra"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Odlična"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Izberite oceno datoteke ali sporočite uporabnikom, če datoteka ni veljavna …"
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Povezava s Kad prekinjena"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Osveži"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Prejemanje, prosimo počakajte …"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Neznana velikost"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Zahtevani podatki"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Naslov IP:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatni podatki"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Uporabniško ime:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Povprečje seje"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Hitrost pošiljanja"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistično drevo"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Uporabniško ime:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Program odjemalca:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Različica odjemalca:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Naslov IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID uporabnika:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP strežnika:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Ime strežnika:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Maskiranje:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Prenosi do uporabnika"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Trenutna zahteva:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Povprečna hitrost pošiljanja:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Povprečna hitrost prejemanja:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Poslano (seja):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Prejeto (seja):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Poslano (skupno):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Prejeto (skupno):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Točke"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Količnik dol/gor:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Varna identifikacija:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Položaj v vrsti:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Točke v vrsti:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Vzdevek"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io – Mule za vse platforme"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "To je ime, ki ga vidijo ostali uporabniki, ko se povežejo z vami."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Jezik: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Zakasnitev preden se pojavi namig z navodili."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "To določa jezik vmesnika programa."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Ob zagonu preveri za novo različico"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ob vklopu te možnosti, bo aMule ob vsakem zagonu preveril za novo različico programa."
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Zaženi pomanjšano"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Vklop te možnosti pomanjša aMule ob zagonu."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Opozori ob končanju"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Preden se aMule konča vas o tem opozori."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Ikona v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Vklopi/izklopi ikono v sistemski vrstici."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Skrij okno programa, ko kliknete okno za zapiranje"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Pomanjšaj v sistemsko vrstico"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Ob vklopu te možnosti se bo aMule pomanjšal v sistemsko vrstico, namesto v opravilno vrstico."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "Prikaži obvestilo ob zaključku prejemanja"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Če to omogočite, bo aMule ob zaključku prejemanja prikazal obvestilo."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Zakasnitev namigov: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekund"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Izbira brskalnika"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Odpri v novem zavihku, če je mogoče"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Če je mogoče, odpre stran v novem zavihku namesto v novem oknu."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video predvajalnik"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Omejitve povezave"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Hitrost za eno mesto"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Vrata"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To so standardna vrata za eD2k in jih ni moč onemogočiti."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Vrata UDP za zahtevke strežnika (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ta vrata UDP se uporabljajo za dodatne zahtevke eD2k in omrežje Kad."
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "Vrata TCP za UPnP (neobvezno):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Največ virov na prejemanje:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Samodejno se poveži ob zagonu"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Ponovno se poveži ob prekinjeni povezavi"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Izbriši nedosegljiv strežnik po"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "poskusih"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Seznam"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Ob povezavi na strežnik posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Ob povezavi odjemalca posodobi seznam strežnikov"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Uporabi sistem prednosti"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Uporabi preverjanje za nizek ID ob povezavi"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Varno povezovanje"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Samodejna povezava samo na strežnike na statičnem seznamu"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Nastavi ročno dodane strežnike na visoko prednost"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Na novo dodani prejemi naj bodo zaustavljeni"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Na novo dodani prejemi naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Najprej poskusi prejeti prvi in zadnji del"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Po zaključku datoteke začni naslednjo prekinjeno"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Iz iste kategorije"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Po abecednem vrstnem redu"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Novim datotekam vnaprej dodeli prostor na disku"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Za nove datoteke v naprej dodeli prostor na disku v velikosti celotne datoteke, kar zmanjša razdrobljenost."
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Ustavi prejemanja, ko prostor na disku doseže "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Izberite, če želite, da aMule preverja prostor na disku"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Sem vnesite min. želen prostor na disku."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shrani 10 virov pri redkih datotekah (< 20 virov)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Pošiljanja"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Nove deljene datoteke naj imajo samodejno prednost"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Inteligentno rokovanje s poškodbami (I.R.P.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Omogoči"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Napredni I.R.P. zaupa vsaki kodi (ni priporočeno)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Deljene mape"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(desni klik na ikono mape izbere tudi podmape)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Deli skrite datoteke"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafi"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Zamik posodabljanja: 5 sek."
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Čas za graf povprečja: 100 min."
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Merilo za graf povezav: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Merilo za graf prejemanj:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Merilo za graf pošiljanj:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Barve: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Ozadje"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Mreža"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Trenutno prejemanje"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Povprečje prejemanja"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Povprečje seje za prejemanje"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Trenutno pošiljanje"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Povprečje pošiljanja"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Dejavne povezave"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Prikaz hitrosti v sistemski vrstici"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Trenutna vozlišča Kad"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Vozlišča Kad v teku"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Izberi"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Drevo"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Število prikazanih različic odjemalcev (0 = neomejeno)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! OPOZORILO !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Maks. novih povezav / 5 sek."
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Datotečni medpomnilnik: 240000 bajtov"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Velikost vrste za pošiljanje: 5000 odjemalcev"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogoči"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Onemogoči prehod računalnika v pripravljenost"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Uporabljena preobleka: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Prikaži hitri rokovalnik s povezavami eD2k v vsakem oknu."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Prikaži razširjene podatke na zavihkih kategorij"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "V naslovni vrstici pokaži različico programa"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Kaži hitrosti prenosa v naslovni vrstici"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Pred imenom programa"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Za imenom programa"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Kaži presežek prenosov"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Usmeri orodjarno navpično"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Datoteke v vrsti prejemanj"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Prikaži odstotek napredka"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Prikaži črto napredka"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Plosko"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Zavrni dostop gostom"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Geslo za goste na spletnem strežniku"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4897,11 +4809,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4911,234 +4823,234 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Onemogočeno [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "bajtov"
@@ -5146,31 +5058,31 @@ msgstr[1] "bajt"
 msgstr[2] "bajta"
 msgstr[3] "bajti"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "bajtov/sek."
@@ -5178,212 +5090,212 @@ msgstr[1] "bajt/sek."
 msgstr[2] "bajta/sek."
 msgstr[3] "bajti/sek."
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MiB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sek."
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "min."
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ur"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dni"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "vse"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "vse ostalo"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Nezaključeno"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Ustavljeno"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arhiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Besedilo"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Dejavno"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Uporaba mape z nastavitvami: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Čakanje na zamrtje niti za pretvarjanje delnih datotek …"
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Uvažanje %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Branje začasne mape"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Pridobivanje osnovnih podatkov iz datoteke o prejemanjuh"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Ustvarjanje ciljne datoteke"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Nalaganje podatkov iz stare datoteke prejemanja (%u od %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Shranjevanje podatkovnega bloka v novo enojno datoteko prejemanja (%u od %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Pridobivanje podatkov o izvorni datoteki prejemanja"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Dodajanje prejemanja in shranjevanje nove delne datoteke"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Uvozi delne datoteke"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Stanje"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Koda datoteke"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (disk: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Prosimo, izberite mapo za iskanje začasnih prejemanj (vključene bodo tudi podmape)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Ali želite izbrisati izvorne datoteke uspešno uvoženih prejemanj?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Ali želite odstraniti vire?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "NAPAKA: delne datoteke ni bilo mogoče ustvariti"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Poskus nalaganja varnostne kopije datoteke met iz %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "NAPAKA: odpiranje datoteke part.met ni uspelo: %s → %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "NAPAKA: datoteka part.met je velika 0: %s → %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "NAPAKA: neveljavna različica datoteke part.met: %s → %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Napaka: %s (%s) je pokvarjena (slabe oznake: %s), ni mogoče naložiti datoteke."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "NAPAKA: %s (%s) je pokvarjena (napačno število oznak), ni mogoče naložiti datoteke."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Poskus reševanja podatkov o datoteki …"
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Reševanje neimenovane datoteke – rešena bo kot RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Rešeni vsi podatki o datoteki, ki so na voljo :D – Poskus njihove uporabe …"
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Ni mogoče rešiti podatkov o datoteki :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Ni bilo mogoče odpreti %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "OPOZORILO: %s je morda pokvarjena (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "NAPAKA med shranjevanjem delne datoteke: %s (%s → %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Vhodno/izhodna napaka med shranjevanjem delne datoteke: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Ni bilo mogoče shraniti datoteke part.met.seeds za %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5392,17 +5304,17 @@ msgstr[1] "Shranjeno %i izvorno seme za delno datoteko: %s (%s)"
 msgstr[2] "Shranjeni %i izvorni semeni za delno datoteko: %s (%s)"
 msgstr[3] "Shranjena %i izvorna semena za delno datoteko: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Ni moč brati datoteke s semeni za delno datoteko %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Napaka pri branju datoteke s semeni delne datoteke (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5411,27 +5323,27 @@ msgstr[1] "Najden pokvarjen del (%d) v %d delni datoteki %s - - FileResultHash |
 msgstr[2] "Najden pokvarjen del (%d) v %d delnih datotekah %s - - FileResultHash |%s| FileHash |%s|"
 msgstr[3] "Najden pokvarjen del (%d) v %d delnih datotekah %s - - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Najden zaključen del (%i) v %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Zaključeno ponovno ustvarjanje kode za %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Nepričakovana napaka med zaključevanjem %s. Datoteka prekinjena."
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Zaključeno prejemanje: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5440,307 +5352,307 @@ msgstr ""
 "Zaključeno prejemanje:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Brisanje datoteke: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "OPOZORILO: ni moč ustvariti kode za prejet del – nabor kod za »%s« ni popoln"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "NAPAKA: ni moč ustvariti kode za prejet del – nabor kod ni popoln (%s). To se nikoli ne bi smelo zgoditi."
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "Konec datoteke med ustvarjanjem kode prejetega dela %u z dolžino %u (maks. %u) delne datoteke »%s« z dolžino %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "OPOZORILO: na disku ni dovolj prostora. Datoteka prekinjena: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Prejet del %i v datoteki je pokvarjen: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "IRP: rešen pokvarjen del %i za %s → Rešenih bajtov: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Dodeljevanje"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Premalo prostora na disku"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Prejeto"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Povezava"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mape"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Strežniki"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Varnost"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Vmesnik"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Posrednik"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Oddaljeno upravljanje"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Spletni podpis"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Dogodki"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Razhroščevanje"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5750,15 +5662,15 @@ msgstr ""
 "    %PARTFILE – polna pot do datoteke\n"
 "    %PARTNAME – samo ime datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5774,35 +5686,35 @@ msgstr ""
 "aMule bo deloval dobro tudi brez\n"
 "spreminjanja teh nastavitev."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Nastavitve ni bilo moč povezati z gradnikom z ID-jem %d in ključem %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Podatkov iz nastavitev ni bilo moč prenesti v gradnik z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Vrsta posrednika s katerim se hočete povezati"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Podatkov iz gradnika ni bilo moč prenesti v nastavitve z ID-jem %d in ključem %s."
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Preverjanje gesla\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5810,41 +5722,41 @@ msgstr ""
 "Potreben je ponoven zagon aMule za uveljavitev teh sprememb:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "• Vrata TCP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "• Vrata UDP so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "• Vrata za zunanje povezave so spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "• Sprejemljivost zunanjih povezav je spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "• Vmesnik za zunanje povezave je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "• Podpora za maskiranje protokola je bila spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5852,7 +5764,7 @@ msgstr ""
 "Seznam za samodejno posodobitev strežnikov je prazen.\n"
 "Možnost »Ob zagonu samodejno posodobi seznam strežnikov« bo onemogočena."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5860,33 +5772,33 @@ msgstr ""
 "Omogočili ste zunanje povezave, vendar niste navedli gesla.\n"
 "Zunanje povezave ne morejo biti omogočene, dokler ne navedete veljavnega gesla."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "• Jezik je spremenjen.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "• Mapa za začasne datoteke spremenjena.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "• Omrežje eD2k je omogočeno.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Neveljavna različica protokola."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5894,7 +5806,7 @@ msgstr ""
 "Omrežji eD2k in Kad sta onemogočeni.\n"
 "Ne boste se mogli povezati, dokler ne omogočite vsaj enega izmed njih."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5902,7 +5814,7 @@ msgstr ""
 "Kad se ne bo zagnal, če so vrata UDP onemogočena.\n"
 "Omogočite vrata UDP ali pa onemogočite Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5912,69 +5824,69 @@ msgstr ""
 "aMule morate NUJNO ponovno zagnati.\n"
 "Če tega ne storite zdaj, se ne pritožujte, če se zgodi kaj slabega.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapa za začasne datoteke prejemanj"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Geslo je bilo nastavljeno in zunanje povezave omogočene."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5984,24 +5896,24 @@ msgstr ""
 "Vnesite vsaj en URL do veljavne datoteke server.met.\n"
 "Kliknite na gumb »Seznam«, zraven potrditvenega polja, za vnos URL-ja."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Začasne datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Prejete datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Spletni podpisi"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Izberite mapo za %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6010,42 +5922,42 @@ msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Prebrskajte za video predvajalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Izberite brskalnik"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Izvedljiva datoteka %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Uredi seznam strežnikov"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6053,42 +5965,42 @@ msgstr ""
 "Sem dodajte URL-je do datotek server.met.\n"
 "Po en URL v vsako vrstico."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Popolnih virov"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Stanje:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6097,7 +6009,7 @@ msgstr[1] "Osveži vsakih: %d sekundo"
 msgstr[2] "Osveži vsakih: %d sekundi"
 msgstr[3] "Osveži vsakih: %d sekunde"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6106,12 +6018,12 @@ msgstr[1] "Čas za graf trenutnega povprečja: %i minuta"
 msgstr[2] "Čas za graf trenutnega povprečja: %i minuti"
 msgstr[3] "Čas za graf trenutnega povprečja: %i minute"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Merilo za graf povezav: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6120,7 +6032,7 @@ msgstr[1] "Datotečni medpomnilnik: %d bajt"
 msgstr[2] "Datotečni medpomnilnik: %d bajta"
 msgstr[3] "Datotečni medpomnilnik: %d bajti"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6129,7 +6041,7 @@ msgstr[1] "Velikost vrste za pošiljanje: %d odjemalec"
 msgstr[2] "Velikost vrste za pošiljanje: %d odjemalca"
 msgstr[3] "Velikost vrste za pošiljanje: %d odjemalci"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6138,234 +6050,234 @@ msgstr[1] "Čas med osvežitvama povezave na strežnik: %d minuta"
 msgstr[2] "Čas med osvežitvama povezave na strežnik: %d minuti"
 msgstr[3] "Čas med osvežitvama povezave na strežnik: %d minute"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Čas med osvežitvama povezave na strežnik: onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "onemogočeno"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Izvrši ukaz ob dogodku »%s«"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Omogoči izvrševanje ukazov na jedru"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Ukaz jedra:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Omogoči izvrševanje ukazov v vmesniku"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Ukaz vmesnika:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Sledeče spremenljivke bodo nadomeščene:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Deljene mape"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Napaka iskanja"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni upoštevana."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Opozorilo iskanja"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Glavna"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Iskanje preko eD2k ni mogoče, če eD2k ni povezan"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Brez ključne besede za iskanje – prekinjam"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nepričakovana napaka med iskanjem Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID datoteke"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Ni ocenjena"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Prejemaj v kategoriji"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Dobi %s za to datoteko"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Poišči sorodne datoteke (eD2k, krajevni strežnik)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Označi kot znano datoteko"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiraj povezavo eD2k na odložišče"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Povezani ste na strežnik, ki ga poskušate izbrisati. Prosimo, najprej prekinite povezavo."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Preklicano"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Novo"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Ni bilo mogoče vzpostaviti maskirane povezave na strežnike na seznamu. Ponoven poskus brez maskiranja."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Ni bilo mogoče vzpostaviti maskirane povezave na strežnike na seznamu. Ponoven poskus brez maskiranja."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Ni se bilo mogoče povezati na katerega koli izmed strežnikov na seznamu. Ponoven poskus."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Ni se bilo mogoče povezati na katerega koli izmed strežnikov na seznamu. Ponoven poskus."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Omrežje eD2k je onemogočeno v nastavitvah, brez povezovanja."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Na seznamu ni bilo moč najti nobenega veljavnega strežnika za povezavo"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Povezano na %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Povezava vzpostavljena z: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Kritična napaka med povezovanjem. Internetna povezava je mogoče prekinjena"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Izgubljena povezava z %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) je nedosegljiv."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) je poln."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6374,48 +6286,48 @@ msgstr[1] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekun
 msgstr[2] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekundi"
 msgstr[3] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekunde"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Povezovanje z %s (%s:%i) ni uspelo."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "NAPAKA: po poteku časa je bila vtičnica neveljavna"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Čas za poskus povezovanja z %s (%s:%i) je potekel."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Prejel zapoznjen rezultat poizvedbe DNS, preziram"
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Nalaganje datoteke server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Ni bilo mogoče najti datoteke server.met."
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Ni bilo mogoče naložiti datoteke server.met »%s«, neznan format."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Ni bilo mogoče odpreti server.met."
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Datoteka server.met je pokvarjena, napačna oznaka različice: 0x%x, velikost %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6424,7 +6336,7 @@ msgstr[1] "%i najden strežnik v server.met"
 msgstr[2] "%i najdena strežnika v server.met"
 msgstr[3] "%i najdeni strežniki v server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6433,237 +6345,236 @@ msgstr[1] "%d strežnik dodan"
 msgstr[2] "%d strežnika dodana"
 msgstr[3] "%d strežniki dodani"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Napaka: datoteka »server.met« je pokvarjena: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "Vhodno/izhodna napaka med branjem »server.met«: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Strežnik ni bil dodan: [%s:%d] nima navedenih veljavnih vrat."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Strežnik ni bil dodan: [%s:%d] IP je filtriran ali neveljaven."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Strežnik ni bil dodan: Strežnik z IP:vrata [%s:%d] že obstaja na seznamu."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Strežnik dodan: Strežnik na [%s:%d], z imenom »%s«."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Povezani ste na strežnik, ki ga poskušate izbrisati. Prosimo, najprej prekinite povezavo."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Ni bilo mogoče odpreti »%s«"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ni bilo mogoče shraniti server.met."
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Neveljaven URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Prejemanje seznama strežnikov od %s zaključeno"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "V »addresses.dat« ni bil najden noben vnos za seznam strežnikov. Za samodejno posodobitev seznama strežnikov morate v to datoteko vnesti veljaven naslov seznama strežnikov."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Začni s prejemanjem seznama strežnikov od %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "OPOZORILO: za samodejno posodabljanje strežnikov je bil naveden neveljaven URL: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "V addresses.dat ni veljavnega server.met URL-ja za samodejno posodabljanje."
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Ni bilo mogoče prejeti seznama strežnikov od %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "IP Filter je filtriral krajevni strežnik. Povezovanje z drugim strežnikom."
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime strežnika"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Naslov"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Vrata"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Opis"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Odziv"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Uporabniki"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statičen"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Različica"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Povezani ste na strežnik, ki ga poskušate izbrisati. Prosimo, najprej prekinite povezavo. Strežnik NI bil izbrisan."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(neznano ime)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ali res želite izbrisati statičen strežnik %s?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Strežniki (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Strežnik"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Poveži se na strežnik"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Označi strežnik kot statičen"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Označi strežnik kot ne-statičen"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Označi strežnike kot statične"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Označi strežnike kot ne-statične"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Odstrani strežnik"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Odstrani strežnike"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstrani vse strežnike"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Skopiraj povezave eD2k na odložišče"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Ponovno se poveži na strežnik"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Ali res želite izbrisati vse strežnike?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Ali res želite izbrisati izbrani strežnik?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ali res želite izbrisati izbrane strežnike?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "NAPAKA: %s (%s) – %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "OPOZORILO: %s (%s) – %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Nov odjemalčev ID je %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "OPOZORILO: prejeli ste nizek ID."
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tPo vsej verjetnosti ste za požarnim zidom ali usmerjevalnikom."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 #, fuzzy
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tZa več informacij se obrnite na https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Prejeti neznani podatki o strežniku – prekratko"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6672,176 +6583,176 @@ msgstr[1] "Prejet %d nov strežnik"
 msgstr[2] "Prejeta %d nova strežnika"
 msgstr[3] "Prejeti %d novi strežniki"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Shranjevanje seznama strežnikov zaključeno."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Strežnik je zavrnil zadnji ukaz"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Nepravi paket prejet od strežnika: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Neobravnavana napaka med obdelavo paketa od strežnika: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Ni mogoče ustvariti niti za razrešitev DNS pri povezavi z %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Strežnikov IP %s (%s) je filtriran.  Ni povezave."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "z maskiranim protokolom."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Povezovanje z %s (%s – %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Ni mogoče razrešiti DNS za strežnik: %s: Povezava ni mogoča."
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule dnevnik"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Strežnik ni bil dodan: IP ali ime gostitelja nista navedena."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Strežnik ni bil dodan: navedena so neveljavna vrata strežnika."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Stanje eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Stanje povezave:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Povezano"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Stanje Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Teče v načinu krajevnega omrežja"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Teče"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Določilnik odjemalca Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Stanje:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Stanje povezave:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Za požarnim zidom – v požarnem zidu ali na usmerjevalniku odprite vrata TCP %d"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Stanje povezave UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Za požarnim zidom – v požarnem zidu ali na usmerjevalniku odprite vrata UDP %d"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Stanje za požarnim zidom: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Potreben ni noben kolega – vrata TCP odprta"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Potreben ni noben kolega – vrata UDP odprta"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Brez kolegov"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Povezovanje s kolegom"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Povezano s kolegom na %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indeksirani viri:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indeksirane ključne besede:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indeksirane opombe:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indeksirana obremenitev:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Povprečno uporabnikov:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Povprečno datotek:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Ne teče"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Dodajanje datoteke %s med deljene"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6850,7 +6761,7 @@ msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6859,7 +6770,7 @@ msgstr[1] "Najdena %i znana deljena datoteka, %i neznanih"
 msgstr[2] "Najdeni %i znani deljeni datoteki, %i neznanih"
 msgstr[3] "Najdene %i znane deljene datoteke, %i neznanih"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6868,416 +6779,416 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "NAPAKA: poskus delitve %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Deljene mape ni bilo moč najti, preskakujem: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Uporabniško ime"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Hitrost pošiljanja"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Razpoložljivi deli"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Stanje pošiljanja"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Stanje prejemanja"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Izvor"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Krajevno ime datoteke"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Deli seznam datotek"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Dobljeni deli"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Pot mape"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Dodaj komentar/oceno"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Uredi komentar/oceno"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Preimenuj"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Dodaj datoteke iz zbirke na seznam prenosov"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Skopiraj magnet &URI na odložišče"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Skopiraj povezavo eD2k na odložišče (&vir)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Skopiraj povezavo eD2k na odložišče (vir) (&s šifrirnimi možnostmi)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Skopiraj povezavo eD2k na odložišče (&gostitelj)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Skopiraj povezavo eD2k na odložišče (gostitelj) (s &šifrirnimi možnostmi)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Skopiraj povezavo eD2k na odložišče (&podatki NIRP)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Skopiraj povezavo eD2k na odložišče (&podatki NIRP + vir)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Potrebujete visok ID, da ustvarite povezavo z virom"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Oddaljeno ime datoteke"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Poslani podatki (seja (skupno)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Skupni presežek (paketov): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Presežek zahtev datotek (paketov): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Presežek izmenjav virov (paketov): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Presežek strežnikov (paketov): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Presežek Kad (paketov): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Presežek šifriranja (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Dejavna pošiljanja: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Čakajoča pošiljanja: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Skupno št. uspelih sej pošiljanj: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Skupno št. neuspelih sej pošiljanj: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Povprečen čas pošiljanja: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Prejeti podatki (seja (skupno)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Najdeni viri: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Dejavna prejemanja (deli): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Razmerje poslano/prejeto te seje (skupno): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Povprečna hitrost prejemanja (seja): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Povprečna hitrost pošiljanja (seja): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Največja hitrost prejemanja (seja): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Največja hitrost pošiljanja (seja): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Ponovne povezave: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Čas od prvega prenosa: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Na strežnik povezano od: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Dejavnih povezav (ocena): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Dosežnih največ možnih povezav: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Povprečno povezav (ocena): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Največ povezav (ocena): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Odjemalci"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Neznani: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrirani: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Izločeni: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Skupno: %i Znani: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Delujoči strežniki: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Nedelujoči strežniki: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Skupno: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Izbrisani strežniki: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtrirani strežniki: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Uporabniki na delujočih strežnikih: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Datoteke na delujočih strežnikih: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Skupno uporabnikov: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Skupno datotek: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zasedenost strežnikov: %.2f %%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Število deljenih datotek: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Skupna velikost deljenih datotek: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Povprečna velikost datoteke: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operacijski sistem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Ni prejeto"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Dejavne povezave (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Ni na voljo"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Nikoli"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Ukaz »%s« s PID-jem »%d« se je končal s statusno kodo »%d«."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Izvrši <str> in končaj."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Neveljaven format IP. Uporabite xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Ta ukaz potrebuje argument. Veljavni argumenti: »all«, ime datoteke ali število.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Obdelovanje po kodi: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Obdelovanje po imenu datoteke: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Ta ukaz potrebuje argument. Veljaven argument: koda datoteke.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Ni veljavno število\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Ni veljavna koda (dolžina mora biti točno 32 znakov)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7288,7 +7199,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7299,7 +7210,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7307,82 +7218,80 @@ msgstr ""
 "Vrsta iskanja ni bila navedena.\n"
 "Napišite »help search« za dodatno pomoč.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Prejmi datoteko: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Zahteva spodletela z neznano napako."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operacija je bila uspešna."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Zahteva ni uspela zaradi napake: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtriranje IP za odjemalce je %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "IZKLOPLJENO"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "VKLOPLJENO"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtriranje IP za strežnike je %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Trenutna stopnja IP filtriranja je %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Omejitve prenosa: Gor: %u kB/s, Dol: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Povezano na %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Povezovanje"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "za požarnim zidom"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "v redu"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7391,7 +7300,7 @@ msgstr ""
 "\n"
 "Prejemanje:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7400,7 +7309,7 @@ msgstr ""
 "\n"
 "Pošiljanje:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7409,7 +7318,7 @@ msgstr ""
 "\n"
 "Odjemalci v vrsti:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7418,46 +7327,46 @@ msgstr ""
 "\n"
 "Skupno virov:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Delna datoteka]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Število rezultatov iskanja: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Napredek iskanja: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Napredek iskanja ni na voljo"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Prejet neznan odgovor od strežnika, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Prikaži kratke podatke o stanju."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Prikaži stanje povezave, trenutne hitrosti prenosov, itd.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Prikaži celotno statistično drevo."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7471,11 +7380,11 @@ msgstr ""
 "\n"
 "Primer: »statistics 5« bo prikazalo 5 najpogostejših različic vsakega tipa odjemalca.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Zaustavi aMule"
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7484,35 +7393,35 @@ msgstr ""
 "Zaustavi oddaljeno tekoče jedro (amule/amuled).\n"
 "To bo zaustavilo tudi besedilnega odjemalca, ker brez tekočega jedra ni uporaben.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Ponovno naloži naveden objekt."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Ponovno naloži seznam deljenih datotek."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Ponovno naloži seznam za filtriranje IP-jev."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Ponovno naloži trenutni seznam za filtriranje current IP-jev."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Posodobi seznam za filtriranje IP-jev iz URL-ja."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Če je URL izpuščen, se uporabi URL iz nastavitev."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Poveži se z omrežjem."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7524,35 +7433,35 @@ msgstr ""
 "za povezavo samo s tem strežnikom. IP mora biti s pikami ločen\n"
 "decimalen naslov IPv4 ali razrešljivo ime DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Poveži se samo z eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Poveži se samo s Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Prekini povezavo z omrežjem."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "To bo prekinilo povezavo z vsemi omrežji, v katera ste povezani.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Prekini samo povezavo z eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Prekini samo povezavo s Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Dodaj povezavo magnet ali povezavo ed2k v jedro."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7569,123 +7478,123 @@ msgstr ""
 "\n"
 "Povezava magnet mora vsebovati kodo eD2k in dolžino datoteke.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Nastavi vrednost nastavitve."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Nastavi filtriranje IP-jev."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Vključi filtriranje IP-jev za odjemalce in strežnike."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Izključi filtriranje IP-jev za odjemalce in strežnike."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Omogoči/onemogoči filtriranje IP-jev za odjemalce."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Vključi filtriranje IP-jev za odjemalce."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Izključi filtriranje IP-jev za odjemalce."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Omogoči/onemogoči filtriranje IP-jev za strežnike."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Vključi filtriranje IP-jev za strežnike."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Izključi filtriranje IP-jev za strežnike."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Izberite stopnjo filtriranja IP-jev."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr "Veljavne stopnje filtriranja so od 0-255, privzeta stopnja je 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Nastavi omejitve povezave."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Vrednost podana tem ukazom mora biti v kilobajtih/sek.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Nastavi omejitev pošiljanja."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Podana vrednost mora biti v kilobajtih/sek.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Nastavi omejitev prejemanja."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Podana vrednost mora biti v kilobajtih/sek.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Dobi in prikaži vrednost nastavitve."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Dobi nastavitve filtriranja IP-jev."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Dobi stanje filtriranja IP-jev za odjemalce in strežnike."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Dobi stanje filtriranja IP-jev samo za odjemalce."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Dobi stanje filtriranja IP-jev samo za strežnike."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Dobi stopnjo filtriranja IP-jev."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Dobi omejitve prenosov."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Izvrši iskanje."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7704,44 +7613,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Izvrši globalno iskanje."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Izvrši krajevno iskanje."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Izvrši iskanje kad."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Prikaže rezultate zadnjega iskanja."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Prikaže napredek iskanja."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Začni prejemati datoteko"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7749,80 +7658,80 @@ msgstr ""
 "Navesti morate številko datoteke iz zadnjega iskanja.\n"
 "Primer: ukaz »download 12« bo dodal na seznam prejemanj datoteko št. 12 iz zadnjega iskanja.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Prekini prejemanje."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Nadaljuj prejemanje."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Prekliči prejemanje."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Nastavi prednost prejemanja."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Nastavi prednost prejemanja na nizko, običajno, visoko ali samodejno.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Nastavi prednost na nizko."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Nastavi prednost na običajno."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Nastavi prednost na visoko."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Nastavi prednost na samodejno."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Prikaži čakalne vrste/sezname."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Prikaži čakalno vrsto prenosov, seznam strežnikov ali deljenih datotek.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Prikaži čakalno vrsto pošiljanj."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Prikaži čakalno vrsto prejemanj."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Prikaži dnevnik."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Prikaži seznam strežnikov."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Prikaži seznam deljenih datotek."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Ponastavi dnevnik."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Opuščen ukaz, namesto njega uporabite »%s«."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7831,261 +7740,258 @@ msgstr ""
 "Ta ukaz je opuščen in bo morda v prihodnosti odstranjen.\n"
 "Namesto njega uporabite »%s«.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule besedilni odjemalec"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Pretvarjanje starih naborov kod NIRP v »%s« v 64b v »%s«."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "OPOZORILO: ime datoteke »%s« ni veljavno in je bilo spremenjeno v »%s«."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "OPOZORILO: datoteka »%s« že obstaja, nova datoteka je preimenovana v »%s«."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Ali res želite preklicati prejemanja in izbrisati vse datoteke iz te kategorije?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Potrebna je potrditev"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Podprtih je največ 99 kategorij."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Preveč kategorij."
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Vse drugo"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Izberite filter prikaza"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Dodaj kategorijo"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Uredi kategorijo"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Odstrani kategorijo"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Zahtevan je bil nabor kod za neznano datoteko: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Nadaljevanje ppošiljanja za datoteko: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Ustavljanje pošiljanja za datoteko: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Ni bilo mogoče izvesti ukaza »%s« za dogodek »%s«."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Prejemanje zaključeno"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Polna pot datoteke."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Ime datoteke brez poti."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Koda eD2k datoteke."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Velikost datoteke v bajtih."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Skupni čas dejavnega prejemanja."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Začeta je bila nova seja klepeta."
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Pošiljatelj sporočila."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Zmanjkalo je prostora"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Razdelek diska."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Napaka pri zaključevanju"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Obdelovanje datoteke številka %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Zahtevali ste kode delov (uporabljeno samo za datoteke > 9,5 MiB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s → Datoteka ne obstaja.\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, ustvarjalnik povezav eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Dobrodošli!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Vhodni parametri"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Ustvari kodo za datoteko"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Dodaj URL-je za to datoteko (neobvezno)"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Sem vnesite datoteko, za katero želite ustvariti povezavo eD2k."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Sem vnesite URL, ki ga želite dodati povezavi eD2k. Na konec dodajte »/«, da aLinkCreator doda trenutno ime datoteke."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Ustvari povezavo s kodami delov"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Pomaga pri hitrejšem razširjanju novih in redkih datotek, za ceno večje dolžine povezave"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Koda MD4 datoteke"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "Koda eD2k datoteke"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "Povezava eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Shrani"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Skopiraj na odložišče"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Odpri"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Odpre datoteko za ustvaritev povezave eD2k zanjo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Skopira ustvarjeno povezavo eD2k na odložišče"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Shrani kot"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Shrani ustvarjeno povezavo eD2k v datoteko"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "O aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Izberite datoteko za ustvaritev povezave eD2k zanjo"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Odložišča ni moč odpreti"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Zaenkrat ni ničesar za skopirati."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Izberite datoteko za ustvaritev povezave eD2k"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Ni mogoče odpreti "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Prosimo, vnesite neprazno ime datoteke"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Zaenkrat ni ničesar za shraniti."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8105,167 +8011,159 @@ msgstr ""
 "\n"
 "Razširja se pod pogoji licence GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Ustvarjanje kode …"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator dela za vas"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Izračunavanje kode MD4 …"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Izračunavanje kode eD2k …"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Preklicano."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Zaključeno v %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ta URL ste že dodali."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Prosimo, vnesite neprazen URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Ni mogoče odpreti %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Med izračunavanjem kode eD2k je zmanjkalo pomnilnika."
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dni %i ur %i min. %i sek."
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KiB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MiB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GiB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TiB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, spletna statistika aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Najhitrejše prejemanje odkar teče wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolutno najhitrejše prejemanje med vsemi prejšnjimi sejami wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Ponastavi"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Ustavi samodejno osveževanje"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Shrani sliko spletne statistike"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Natisni sliko spletne statistike"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Nastavitve"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "O wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Zaženi samodejno osveževanje"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Samodejno osveževanje ustavljeno"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Samodejno osveževanje začeto"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Shrani statistično sliko"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Spletna statistika aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8273,11 +8171,11 @@ msgstr ""
 "Pri tiskanju se je pojavila težava.\n"
 "Morda privzeti tiskalnik ni pravilno nastavljen?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Tiskanje"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8295,403 +8193,392 @@ msgstr ""
 "\n"
 "Na voljo pod licenco GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMule ne teče."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule teče."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule teče, vendar ni povezave."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule se povezuje …"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Stanje aMule je neznano."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " teče že "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " je ustavljen."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " ni povezan."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " se povezuje …"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " dela nekaj nenavadnega, preverite."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " je povezan z "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "ugasnjen"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " je povezan "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " z "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Skupno prejetega: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", poslanega: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "To sejo prejetega: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Prejemanje: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Pošiljanje: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Deljenih: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " datotek, Odjemalcev v vrsti: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Čas: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " na "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Povprečna obremenitev sistema (1-5-15 min.):"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Neprekinjeno delovanje: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Mapa, ki vsebuje datoteko amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Sem vnesite mapo, ki vsebuje datoteko amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Interval med osvežitvami v sekundah"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Ustvari statistično sliko ob vsaki osvežitvi"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Sem vnesite mapo, v katero želite ustvariti statistično sliko"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Periodično pošiljaj sliko s statistiko na strežnik FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "URL FTP-ja"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Pot na FTP-ju"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Sem vnesite URL vašega strežnika FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Sem vnesite mapo na strežniku FTP, v katero se naj shrani statistična slika"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Uporabnik"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Sem vnesite uporabniško ime za prijavo na vaš strežnik FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Sem vnesite geslo za prijavo na vaš strežnik FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Interval med osvežitvami FTP-ja v minutah"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Preveri veljavnost"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Mapa, ki vsebuje vašo datoteko s podpisom"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Mapa, v katerem je ustvarjena statistična slika"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Naloži predlogo <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Vrata HTTP spletnega strežnika"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Uporabi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Vrata UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Geslo za polni dostop do spletnega strežnika"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Geslo za goste na spletnem strežniku"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Dovoli dostop gostom"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Zavrni dostop gostom"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Naloži/shrani nastavitve spletnega strežnika od/na oddaljeni aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Pot do nastavitvene datoteke. NE UPORABITE NEPOSREDNO."
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Onemogoči tolmača PHP-ja (opuščeno)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Ponovno prevedi strani PHP ob vsaki zahtevi"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Spletni strežnik aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "povezava spletnega odjemalca sprejeta\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "NAPAKA: ni moč sprejeti povezave spletnega odjemalca\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Zahteve ni bilo mogoče izvesti zaradi napake: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indeksne datoteke ni mogoče najti: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Seja potekla – zahtevek za prijavo\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Seja v redu, prijavljen\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Seja v redu, ni prijave\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ni odprte seje – zahtevek za prijavo\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Seja ustvarjena – zahtevek za prijavo\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Obdelovanje zahteve [izvorno]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Geslo ni nastavljeno, prijava ne bo dovoljena."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Preverjanje gesla\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Koda gesla ni veljavna\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Geslo v redu\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Napačno geslo\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Niste navedli gesla. Prazno geslo ni dovoljeno.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Zahtevana odjava\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Obdelovanje zahteve [preusmerjeno]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Povezovanje ni uspelo "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -20,26 +20,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Trego aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Kontrolli remote i aMule "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -48,79 +48,79 @@ msgstr ""
 "Copyright (C) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing i bazuar ne metriken XOR.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Kerko per versione te reja sapo te filloje"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Duke u lidhur me Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Shto nje shoke"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Ju duhet te futni nje IP dhe nje porte te vlefshem!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Informacion"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Userhash-i i specifikuar nuk eshte i vlefshem!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -129,48 +129,47 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Lidhja deshtoi "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -179,181 +178,174 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 #, fuzzy
 msgid "Failed to open ED2KLinks file."
 msgstr "Deshtoi ne hapjen %s (%s)"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 #, fuzzy
 msgid "Now, exiting main app..."
 msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "E Deshtuar"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 #, fuzzy
 msgid "aMule shutdown completed."
 msgstr "Shkarkimi Perfundoi"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Vendndodhja juaj eshte ndryshuar tek System Default i pershtatur per nje nderrim konfigurimi. Me vjen keq."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Informacion"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 #, fuzzy
 msgid ""
 "\n"
 "EC configuration"
 msgstr "Konfirmimi i daljes"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 #, fuzzy
 msgid "Password set and external connections enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "KUJDES"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "aMule eshte duke punuar"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Nuk mund te lidh portat tek adresa e dhene: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Porta %u nuk eshte me vlere. Ju do te keni ID te ulet\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +360,48 @@ msgstr ""
 "\n"
 "KOntrolloni rrjetin tuaj per tu siguruar qe porta eshte hapur per hyrje dhe dalje."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Deshtoi te krijoje failin per Firmen Online te aMule-s"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Vendi i zgjedur duket se nuk do te instalohet ne kutine tuaj. (Shenim: Une do te mundohem ta vendos ate)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Kjo eshte hera e pare qe ju po persorni aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Ky eshte nje version per testim,i azhornuar per dite, dhe\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ne nuk japim siguri per te ai nuk do te thyej asgje,nuk do te djegi shtepine tuaj,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "ose te vrasi qenin tuaj. Por ai *do te* behet i sigurte per tu perdorur.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Me shume informacion,mbeshtetje dhe leshime te reja do ti gjeni tek faqet tona,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "tek amule-org.github.io ose ne kanalin tone IRC #amule tek irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Raportoni cdo gabim tek https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,225 +409,221 @@ msgstr ""
 "Kartela e faileve per Firmen Online qe ju specifikuat eshte e PAVLERE!\n"
 " Firma Online do te C'AKTIVIZOHET deri sa ju ta rregulloni tek Preferencat."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "GABIM: nuk mund te hapet logfile"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "KUJDES: faili i log-ve eshte bosh. Dicka nuk shkon."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Faili i Log eshte risetuar"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Mesazhe nga Serveri: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Deshtoi ne shkarkimin e listave nod."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Deshtoi te hapi failin per kontrollin e versionit qe sapo shkarkuat"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Fili per kontrollin e versionit eshte i demtuar"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Ju po perdorni nje version te vjeter te aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Versioni juaj i amUle eshte %i.%i-%i dhe versioni i fundit eshte %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "KUJDES: Versioni juaj i aMule-s eshte i vjeteruar: %i.%i-%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Kopja juaj e aMule eshte azhornuar."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Deshtoi ne shkarkimin e failit per kontrollin e versionit"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "me ID te ulet"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "me ID te larte"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "I lidhur tek %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Duke u lidhur tek %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad filloi."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad u ndalua."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "I lidhur ne Kad (Ne rregull)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Rrjeti Kad nuk mund te perdoret nqs porta UDP eshte c'aktivizuar tek Preferencat, nuk po filloj."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Rrjeti Kad eshte c'aktivizuar tek Preferencat,nuk eshte duke u lidhur."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "GABIM: demoni i aMule-s nuk mund te perdoret kur lidhjet e jashtme kan te c'aktivizuara. Per te aktivizuar Lidhjet e Jashtme mund te perdorni dhe nje aMule normale, filloje aMule me kete opsion --ec-config ose vendosni celesin\"AcceptExternalConnections\" tek 1 ne failin ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "GABIM: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Preferencat"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -645,195 +633,188 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Gabim Fatal: Deshtoi te krijoje Timerin"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Lidhu me Remote te amule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "LIdhja humbi"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Pyet kur del"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -842,1192 +823,1165 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Gabim Fatal: Deshtoi te krijoje Timerin"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Going to event loop..."
 msgstr "Tentative per rekuperimin e informacionit te failit..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Connecting..."
 msgstr "Duke u lòidhur"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Lidhja tek %s (%s:%i) nuk u vendos per time-out."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Lidhu me rrjetin."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Te gjithe"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Nuk eshte aktive"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Faili nuk u gjete."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "E panjohur"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (eMule e falsifikuar versioni %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (eMule e falsifikuar)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule e falsifikuar)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (e bazuar ne eMule v0 %u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Emri: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Kerkuar: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistikat e failit per kete sesion: U pranua %d nga %d kerkesa, %s te transferuara\n"
 msgstr[1] "Statistikat e failit per kete sesion: U pranuan %d nga %d kerkesat, %s te transferuara\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistikat e failit per te gjitha sesionet: U pranua %d nga %d kerkesa, %s te transferuar\n"
 msgstr[1] "Statistikat e faileve per te gjitha sesionet: U pranua %d nga %d kerkesat, %s te transferuara\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Po kerkoni nje faili te panjohur"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtrim mesazhi nga '%s' (IP: %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Mesazh i ri nga '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara per kartelen %s -> nuk u lejua"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "Kujdes: known.met nuk mund te hapet."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "Kujdes: Lista e faileve te njohur eshte e demtuar, permban nje header te pavlere."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Gabim IO duke lexuar failin known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Gabim duke shpetuar failin known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Kategori e re"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Zgjidh nje kartele per failet ne hyrje"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Ju duhet te specifikoni nje emer per kategorine!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Ju duhet te specifikoni nje rruge per kategorine!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "E pamundur te krijoje nje kartele per failet ne hyrje per kete kategori.Ju lutem specifikoni nje rruge te vlefshme!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sesioni i chatit filloi: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** I lidhur me klientin ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** DUke u lidhur me klientin ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Deshtoi te lidhet me klientin / Lidhja humbi ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Mbyll tabelen"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Mbylli te gjitha tabelat"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Mbyll tabelat e tjera"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Shto tek shoket"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Faili i kreditit u ngarkua, %u klienti eshte njohur"
 msgstr[1] "Faili i kreditit u ngarkua, %u klientet u njohen"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Kreditet mbaruan per %u klientin!"
 msgstr[1] " - Kreditet mbaruan per %u klientet!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "NUk u gjet faili cryptkey.dat,duke e krijuar."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Detajet e klientit"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID i ulet"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID i larte"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "I lidhur"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "I shkeputur"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Nuk eshte e kompletuar"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Djale i keq"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "E verifikuar - Ne rregull"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Nuk eshte aktive"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara -> U lejua"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara -> Nuk u lejua"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Perdoruesi %s (%u) kerkoi listen e kartelave tuaja te ndara -> U lejua"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Perdoruesi %s (%u) kerkoi listen e kartelave tuaja te ndara -> Nuk u lejua"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara per kartelen %s -> u lejua"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara per kartelen %s -> nuk u lejua"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Perdoruesi %s (%u) ndan kartelen %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Perdoruesi %s (%u) dergoi nje liste te kartelave te ndara qe nuk u kerkua."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Perdoruesi %s (%u) derrgoi listen e faileve te ndara per direktorine %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Perdoruesi %s (%u) mbaroi dergimin e listes se faileve te ndara"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Perdoruesi %s (%u) dergoi listen e faileve te ndara te padeshiruara"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Perdoruesi %s (%u) nuk lejoi hyrjen ne listen e kartelave/faileve te ndara"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Komentet e faileve"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Emri i perdorimit"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Emri i failit"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Vleresimi"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Komenti"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kerkimi i Kad nuk mund te behet nqs Kad nuk eshte duke punuar"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Nuk ka komente"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u koment"
 msgstr[1] "%u komente"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Deshtoi te shkarkoje listen e serverave nga %s"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Automatike [Ulet]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Automatike [Normale]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Automatike [Larte]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "E larte"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Shume e larte"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Leshim"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Duke pyetur"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Lidhje nepermjet serverit"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Radha ne pritje eshte plote"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ne radhe"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Duke shkarkuar"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Hashsete te ardhura"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Pjese qe nuk nevojiten"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Nuk mund te lidh nje ID te ulet me nje ID te ulet"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Shume lidhje"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Lidhje nepermjet Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Shume lidhje Kad"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Te larguar"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Gabim ne lidhje"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Radha e plote"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "MLDonkey i vjeter"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "MLDonkey i ri"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Pershtatet me eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Server Lokal"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Shkembim burimesh"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasiv"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Link"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Burime te shpetuara"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Te kompletuara"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Ne vazhdim"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "Jashte nga hapesira"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Ne radhe"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Jam duke e shkarkuar"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Formati i failit temp i panjohur ose i gabuar."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Te transferuara"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Shpejtesia"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Avancimi"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Burime"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Perparesia"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Gjendja"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Koha e mbetur"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Hera e fundit qe u pa e kompletuar"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Marrja e fundit"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Jeni te sigurte qe deshironi te fshini failin e zgjedhur?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Jeni te sigurte qe deshironi te fshini failet e zgjedhura?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Automatike"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Ndal"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pushim"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Rimerr"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "&Pastro te kompletuarit"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Sposto cdo A4AF ne kete fail tani"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Sposto cdo A4F4 ne kete fail (Automatikisht)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Sposto cdo A4F4 ne cdo fail tjeter tani"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Opsione te Avancuara"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Parashikim"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Trego &detajet e faileve"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Trego te gjithe komentet"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopjo magnetin URI ne shenimet"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopjo feedback ne shenimet"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "hiq"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Vendos tek kategoria"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Hap failin"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Futni nje emer te ti per kete fail:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Riemertim i failit"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Shkarkimet (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Parashikimi i failit"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "GABIM: Deshtoi te luaj media-player te jashtem! Komanda: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading temp files from %s."
 msgstr "Duke ngarkuar failin e server.met: %s"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Duke ngarkuar te dhena nga nje fail i shkarkuar i vjeter (%u te %u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Nuk u gjenden part-files"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "U gjend %u part file"
 msgstr[1] "U gjenden %u part files"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Duke shkarkuar %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Jeni duke e shkarkuar kete fail ne nje vend tjeter '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Ju e keni kete fail '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Ju e keni kete fail '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Protokoll i panjohur i linut: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "LIdhjet e jashtme u c'aktivizuan sepse fjalekalimi ishte bosh|"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Lidhjet e jashtme u c'aktivizuan ne failin e konfigurimeve"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Lidhja e jashtme nuk u pranua sepse fjalekalimi tek preferencat ishte bosh!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Duke lidhur klientin: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Version i panjohur"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "ID-ja i versionit EC jo korrekt,duhet te kete mospershtatje binaresh. Perdor Core dhe Remote nga i njejti Snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "NUk mund te lidheni me nje version SVN tek nje version i perfunduar ne menyre arbitrare| *sigh* crash i mundshem u evitua"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Version protokoli jo i rregullt."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Munfon tag-u i versionit te protokolit."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Autentifikimi deshtoi."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Kerkese jo e rregullt, fillimisht duhet te identifikoheni."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Hyrja lejohet."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Tentative per hyrje e paautorizuar. Lidhja u mbyll."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Komanda e Remote per pjeset e faileve deshtoi: Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Nuk u gjet FileHash: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OOPS! Gabim ne procesimin e OpCode|"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Serveri nuk u shtua"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "Serveri nuk u gjend: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "nevojitet percaktimi i serverit qe do te levizet"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Kerkimi WebSearch nga Remote eshte i kote."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Kerkimi vazhdon. Rezultate ne ardhje!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "NUk ka pika per grafike."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Klienti juaj nuk eshte i konfiguruar per kete nivel detaji."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Jam duke dalur."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Lidhje e jashtme: Duke shtuar linkun '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Link i pavlere ose qe eshte ne liste."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Faili nuk u gjete."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Emri i failit i pavlere."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "E pamundur te riemeroje failin."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad-i eshte c'aktivizuar tek Preferencat."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Jam i lidhur ne Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Duke u lidhur me Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "I shkeputur nga Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "OpCode e pavlere (version protokoli i gabuar?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Shtim i panjohur '%s' per komanden '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "KOmande e panjohur '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2035,7 +1989,7 @@ msgstr ""
 "\n"
 "Kjo komande nuk mund te kete nje argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2043,7 +1997,7 @@ msgstr ""
 "\n"
 "Kjo komande duhet te kete nje argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2051,7 +2005,7 @@ msgstr ""
 "\n"
 "Kjo komande nuk eshte komplete, ju duhet te perdorni nje nga shtimet me poshte.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2059,11 +2013,11 @@ msgstr ""
 "\n"
 "Shtime ne dispozicion:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Komanda ne dispozicion:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2074,17 +2028,17 @@ msgstr ""
 "Te gjitha komandat mund te shkruhen me shkronja te medha ose te vogla.\n"
 "Shtyp '%s <command>' per te marre informacion te detajuar ne <command>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Del nga aplikimi."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Trego ndihme."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2092,7 +2046,7 @@ msgstr ""
 "Per te marre ndihme per nje komande shtyp help <command> .\n"
 "Per te marre listen e plote te komandave shtyp help .\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2103,46 +2057,46 @@ msgstr ""
 "Perdor '%s' per listen e komandave\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Gabim Sintakse!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Gabim ne punimin e komandes - nuk duhet qe te ndodhi me! Raportoni Bug-un ju lutem\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Kjo komande nuk duhet te kete parametra."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Kjo komande duhet te kete nje parameter."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Argument i pavlere."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Kjo eshte nje komande jo komplete."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Shtyp '%s' per te marre me shume ndihme.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Ky eshte %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Ky eshte %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2150,7 +2104,7 @@ msgstr ""
 "\n"
 "Duke krijuar klientin...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2159,7 +2113,7 @@ msgstr ""
 "\n"
 "Ne rregull, duke dalur %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2172,331 +2126,326 @@ msgstr ""
 "ose ne nje linje-komande, ose futni nje kur kerkohet.\n"
 "Duke dalur.\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Trego kete tekstin ndihmues."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Host ne te cilin aMule vepron. (default: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Porta e aMule per Lidhjet e Jashtme. (default: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Lexo rregullimin nga faili."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Mos printo asnje output tek stdout"
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Behu fjaleshume - trego dhe mesazhet e Debug-ut."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Vendos Locale-n e programit (gjuha)"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Shkruaj opsionet e lenjes se komandave tek faili i konfigurimeve(rregullimeve)"
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Krijo nje fail per konfigurimin te bazuar ne ate te aMule-s."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Printo versioni ne programit."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Detajet e failit"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% te mbaruara"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Miresevini!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "I lidhur me shokun"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Gjendja e lidhjes"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Rrjetet"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Shkoket"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Trego &Detaje"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Shto nje shoke"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Fshi nje shoke"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Dergo &Mesazh"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Shiko failet"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Vendos slotin per shoket"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Jeni te sigurt qe deshironi te fshini shokun e zgjedhur?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Jeni te sigurt qe deshironi te fshini shoket e zgjedhur?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2504,11 +2453,11 @@ msgstr ""
 "Ju nuk lejoheni qe te vendosni me shume se nje slot per shoket.\n"
 " Vetem nje slot i vetem u vendos."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Perzgjedhje e shumte"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2517,210 +2466,209 @@ msgstr ""
 "Ju nuk lejoheni qe te vendosni me shume se nje slot per shoket.\n"
 " Vetem nje slot i vetem u vendos."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Dergo nje mesash perdoruesit"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mesazhi qe do te dergohet:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Hiqe nga shoket"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Dergo mesazh"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposto tek ky fail"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Nje tjeter fail i kerkuar"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Ngarkime ne pritje: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "Ne radhe"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Ngarkim"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Asnjeri"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Jo"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Po"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Duke shkarkuar..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Duke shkarkuar %s"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "Shkarkimet (%i)"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Deshtoi te shkarkoje listen e serverave nga %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Deshtoi te shkarkoje listen e serverave nga %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Duke ngarkuar filtrat e IP nga 'ipfilter.dat' dhe 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Deshtoi ne ngarkimin e failit ipfilter.dat '%s', rastisem ne nje format te panjohur."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Deshtoi ne ngarkimin e failit ipfilter.dat '%s', nuk mund te hapet faili."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "U ngarkua %u intervali i adreses se IP nga '%s'."
 msgstr[1] "U ngarkuan %u intervale te adresave IP nga '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u linja e deformuar u skarcua."
 msgstr[1] "%u linjat e deformuara u skarcuan."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2728,2148 +2676,2112 @@ msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nyjet (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "IP i pavlefshem per bootstrap"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Porte e pavlefshme per bootstrap"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Ju lutem plotesoni te gjitha fushat e kerkuara"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Mesazh"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Jeni te sigurte qe deshironi te shkarkoni nje fail te ri nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Duke bere keshtu te gjitha nyjet aktuale do te hiqen dhe do te rifillohet lidhja ne Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Te vazhdoj?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: fjala qe u kerkua eshte shume e shkurter"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Po lexoj %u kontakt Kad"
 msgstr[1] "Po lexoj %u kontakte Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "U shkruajt %d kontakt Kadi"
 msgstr[1] "U shkruajten %d kontakte Kadi"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Rrjeti Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Emri i failit"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Version i panjohur"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Kujdes: E pamundur te lexohet skin nga faili '%s'"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Duke perfunduar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "E kompletuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Ne pritje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "E gabuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Duke pritur"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Ju duhet te specifikoni nje fjalekalim jo bosh "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Fjalekalim i gabuar, nuk eshte nje hash MD5 "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Lidhja deshtoi"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Lidje e jashtme: Pergjigje e keqe nga serveri. Lidhja u mbyll."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Sukses! Lidhja u vendos ne aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Sukses! Lidhja u vendos."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Mbylle"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Ndaj"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopjo"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Ngjit"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pastro"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Zgjidhi te gjitha"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "I lidhur"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "I lidhur"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "I lidhur ne Kad (Me firewall)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP-ja e Serverit: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "IP-ja e Serverit:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Nuk jam i lidhur"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Informacion mbi klientin"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Trego aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Fshih aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Dlje"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "E pakufijshme"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "Menuja e sherbimeve te aMule"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Ngarkim: Asnje"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Ngarkim: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Shkarkim: Asnje"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Shkarkim: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Shpejtesia-Ngarkimit"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Nickname: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Nuk eshte perzgjedhur asnje Nickname"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID-ja e klientit: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Emri i Serverit: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP-ja e Serverit: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "I palidhur"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Firma Online: E aktivizuar"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Firma Online: E c'aktivizuar"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Uptime: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Totali i shkarkimit: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totali i ngarkimit: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Shton nje link magnet ose ed2k tek Core."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Shto tek shoket"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Ngjarjet jane te treguara ketu. Per nje liste komplete te ngjarjeve, referohuni log-ut ne skeden e Serverave."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Duke ngarkuar ..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Numeri i perdoruesve ne serverin qe jeni lidhur edhe ju ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Perdorues: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Perdoruesit e lidhur tek serveri aktual dhe nje vleresim i numrit te te gjithe perdoruesve."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Larte: 0.0 | Poshte: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Mesatarja aktuale e ngarkimeve dhe shkarkimeve. Nese aktivizohet numrat ne thonjeza tregojne overhead-in nga komunikimi me klientin."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Tregon gjendjen e lidhjes dhe transferimet aktive. Shigjetat e kuqe tregojne qe ju aktualisht nuk jeni lidhur, shigjetat e verdha tregojne qe ju keni nje ID te ulet (me firewall) dhe shigjetat e jeshile tregojne qe ju keni ID te larte (Tipi i lidhjes optimale)"
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Nuk eshte i lidhur ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Serveri aktualisht i lidhur."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Kerko"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Emri:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokale"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Globale"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Parametra te zgjeruara"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrim"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Lloji i failit"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Kushdo"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arkive"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Imazhet-CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Figurat"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programe"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Tekste"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Video"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Zgjerimi"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Madhesia Minimale"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Madhesia Maksimale"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Te disponueshem"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filteri:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Rezultatet e filterit"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Nderro pozicionin e rezultateve"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Fshi failet e njohura"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Fillo"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Me shume"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Ndalo"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Shkarkime"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Reseto fushat"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultatet"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Pastro shkarkimet e perfunduara"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Burime te gjetura :"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Te pergjithshme"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Emri i plote :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "Faili-met :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Madhesia e failit :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferimi"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Gjendja e pjeseve te failit :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Hera e fundit qe u pa i perfunduar :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Burime te gjetura :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Burime ne transferim :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Numerimi i pjeseve te failit :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Te disponueshem :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Koha Aktive e Shkarkimit : "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Te transferuara :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Te kompletuara :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Corruption Handling"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Humbje per pjese te prishura :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Fitimi nga kompresimi :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paketa te rekuperuara nga I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Te ndara: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Kerkesa"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Kerkesa te pranuara"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Te dhena te transferuara"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Raporti i ndarjeve"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Burime te kompletuara"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "File te ndara"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Ngarkimi: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "E pavotuar"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titulli :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Emrat e Faileve"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Mbishkruaj"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Pastro"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Zbato"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Komento/Gjyko failin (Teksti do te shikohet nga perdoruesit e tjere)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Cilesia e failit"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "E pavotuar"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Pa vlere / E prishur / Falso"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "I varfer"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Mjaftueshem"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Mire"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "E perkryer"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Gjyko failin ose lajmero perdoruesit nese faili eshte i pavlefshem ..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "I shkeputur nga Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Rifreskim"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Duke shkarkuar, ju lutem prisni ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Madhesi e panjohur"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Informacion i Kerkuar"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "Adresa IP :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Porta :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informacion i Shtuar"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Emri i Perdoruesit :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Shto"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Shpejtesia-Ngarkimit"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Pema e statistikave"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Emri i perdoruesit:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Software i klientit:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Versioni i klientit:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "Adresa IP:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID-ja e Perdoruesit:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "IP-ja e Serverit:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Emri i Serverit:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferime tek klienti"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Kerkesa aktuale:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Shpejtesia mesatare e ngarkimeve:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Shpejtesia mesatare e shkarkimeve:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Te ngarkuara (sesione):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Te shkarkuara (sesione):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Ngarkimet (total):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Shkarkimet (total):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Piket"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Modifikuesi DL/UP:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Identifikim i sigurte:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "Ne radhe"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Piket e pritjes:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Nick"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Ky eshte emri qe te tjeret do te shohin kur te lidhen tek ju."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Interval kohor para se te tregohen sugjerimet."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Kjo specifikon gjuhen e perzgjedhur."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Kerko per versione te reja sapo te filloje"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Duke aktivizuar kete beni qe aMule te kerkoje per versione te reja sapo te filloje"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Fillo te minimizuar"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Duke aktivizuar kete opsion beni qe aMule te minimizohet vetevetiu sapo te filloje."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Pyet kur del"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Aktivizo Ikonen Tray"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Aktivizon ose C'aktivizon ikonen e System Tray (ose taskbar-in)"
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimizoje ne ikonen Tray"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Duke aktivizuar kete opsion do te beni qe te minimizoni aMule-n ne System Tray sesa ne taskbar."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Zgjedhesi i shfletuesit"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Hape ne nje faqe te re nqs eshte e mundur"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Nqs eshte e mundur hape faqen e re te web-it ne nje faqe tjeter te re"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Video Player"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Ngarkim"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Vendndodhja e slotit"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Lidje automatike sapo programi te hapet"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Rilidhu mbas humbjes se lidhjes"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Largo serverat e papune mbas"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "tentativa"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Perdor sistemin e prioritetit"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Perdor kontrollin e zgjuar per ID e ulet kur lidhesh"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Lidhje e sigurte"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Lidhu automatikisht vetem me serverat e qendrueshem"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Vendosni ne menyre manuale serverat e shtuar ne Prioritet te Larte"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Shto failet tek shkarkimi duke i vene ne pushim"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Shto failet tek shkarkimi me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Mundohu te shkarkosh pjesen e pare dhe te fundit te failit"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Nga e njejta kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Futni ketu hapesiren minimale qe deshironi per diskun."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Shpeto 10 burime per failet e rralla (< 20 burime)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Ngarkimi"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Shto faile te reja te ndara me prioritet automatik"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Hiq"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "( Klikoni me butonin e djathte ne ikonene e karteles per te ndare ne menyre rekursive)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Nda failet e fshehur"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafiket"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Intervali i azhornimit : 5 sek"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Intervali grafik i vlerave mesatare: 100 minuta"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Shkalla grafike e lidhjeve: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Sfondi"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Zgara"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Shkarkimi aktual"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Mesatarja e shkarkimeve ne punim"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Mesatarja e sesioneve te shkarkimit"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Ngarkimi aktual"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Mesatarja e ngarkimit ne punim"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Ikona e Speedbar-it ne Systray"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Nyjet e Kad aktuale"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Nyjet e Kad jane duke punuar"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Zgjidh"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Numera te treguar te versioneve te klienteve (0= pa kufij)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! KUJDES !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Lidhe maksimale te reja / 5 sek"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Madhesia e Buffer-it te failit: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Madhesia e Radhes ne Ngarkim: 5000 klienta"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Interval i azhornimit te lidhjes se serverit: C'aktivizuar"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Trego informacion te zgjeruar ne tabelat e kategorive"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Trego shpejtesine e transferimit ne titull"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Orientim Vertikal i toolbar-it"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "E sheshte"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Ndalo hyrjen e guest-ve"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4877,11 +4789,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4891,854 +4803,854 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "File te ndara"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Jo aktive [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/sec"
 msgstr[1] "bytes/sec"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sekonda"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minuta"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "ore"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dite"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "te gjithe"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "te gjithe te tjeret"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "E pakompletuar"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "E ndalur"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arkivi"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Tekst"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktive"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Duke importuar %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Rekuperim informacioni themelor nga informacioni i failit ne shkarkim"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Duke krijuar destinacionin e failit"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Duke ngarkuar te dhena nga nje fail i shkarkuar i vjeter (%u te %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Shpetimi i blloqeve te dhenave ne nje fail shkarkimi te vetem (%u te %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Rekuperim informacioni mbi burimet e failit ne shkarkim"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Shtim shkarkimi dhe duke shpetuar partfile-n e re"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importo pjeset e faileve"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Gjendja"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Filehash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disku: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Ju lutem zgjdhni nje kartele per te kerkuar per shkarkimet e perkohshme! (bejne pjese edhe nenkartelat)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Deshironi qe burimet e faileve te importuara ne menyre te suksesshme te fshihen?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Te heq burimet?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "GABIM: Deshtoi te krijoje partfile)"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Ngarkimi i backup-it te failit met nga %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Gabim: %s (%s) eshte e pavlere (tagcount i gabuar), e pamundur te ngarkoj failin."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Tentative per rekuperimin e informacionit te failit..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Rekuperim i failit pa emer - tentativa e rekuperimit si RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Te gjitha informacionet e mundshme jane rekuperuar :D - duke u munduar ti perdor..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "E pamundur te merren informacione mbi failin :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Deshtoi ne hapjen %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "GABIM duke shpetuar partfile: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 #, fuzzy
 msgid "IO failure while saving partfile: "
 msgstr "GABIM duke shpetuar partfile: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "E pamundur te shpetohet faili part.met seeds per %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Te shpetuar %i burimi seed per partfile: %s (%s)"
 msgstr[1] "Te shpetuar %i burimet seeds per partfile: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Te shpetuar %i burimi seed per partfile: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Gabim ne leximin e failit seeds tek partfile-t (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "U gjend pjese e prishur (%d) ne %d pjesen e failit %s - Rezultati Hash i Failit |%s| Hash i Failit |%s|"
 msgstr[1] "U gjend pjese e prishur (%d) ne %d pjeset e failit %s - Rezultati Hash i Failit !%s| Hash i Failit |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "U gjend pjese e kompletuar (%i) ne %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Hashing i ri i kompletuar %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Shkarkim i perfunduar: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Shkarkim i perfunduar: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Duke fshire failin: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "KUJDES: Nuk ka hapesire te mjaftueshme ne disk! Duke vene ne pushim failet: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Pjesa e shkarkuar %i eshte e prishur ne failin: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Rekuperohet pjesa e demtuar %i per %s -> Bytes te kursyera: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Lidhje"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktorite"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servera"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Failet"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Sigurimi"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proksi"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Kontrollet e remote"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Ngjarje"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Debug"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5754,35 +5666,35 @@ msgstr ""
 "aMule do te punoje ne rregull pa modifikuarr asnje nga\n"
 "keto rregullime"
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Lloji i Proksit(Proxy) qe ju po lidheni"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5790,51 +5702,51 @@ msgstr ""
 "aMule duhet qe te ristartohet qe keto ndryshime te aplikohen:\n"
 " \n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "Porta TCP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "Porta UDP eshte ndryshuar.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Lidhja e jashtme u mbyll."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Protokolli i Turbullimit"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5842,40 +5754,40 @@ msgstr ""
 "Ju keni lejuar lidhjet e jashtme por nuk keni specifikuar nje fjalekalim.\n"
 "Lidhjet e jashtme nuk mund te lejohen derisa te specifikohet nje fjalekalim."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Gjuha ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "Kartela Temp ndryshoi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Te gjithe rrjetet jane c'aktivizuar."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Version protokoli jo i rregullt."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5883,7 +5795,7 @@ msgstr ""
 "Kad nuk mund te filloje nqs porta juaj UDP eshte c'aktivizuar.\n"
 "Aktivizoni porten UDP ose c'aktivizoni Kad-in."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5893,69 +5805,69 @@ msgstr ""
 "Ju duhet te ristartoni aMule-n tani.\n"
 "Nqs nuk e ristartoni tani mos u anko nqs te ndodh dicka e keqe.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "U pranua nje lidhje e jashtme e re"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5965,66 +5877,66 @@ msgstr ""
 "Ju lutem mbushni te pakten nje URL te vlefshme ne failin e server.met.\n"
 "Klikoni ne butonin \"List\" per te futur nje URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Failet e perkohshme"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Failet e shkarkuara"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Firma online"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Zgjidhni nje kartele per %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Shfletoni per nje videoplayer"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Perzgjidhni shfletuesin"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Te ekzekutueshme%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6032,1225 +5944,1224 @@ msgstr ""
 "Futni ketu URL-te per te shkarkuar failet server.met.\n"
 "Vetem nga nje URL per c'do linje."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Burime te kompletuara"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Statusi:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Intervali i azhornimit: %d sekonde"
 msgstr[1] "Intervali i azhornimit: %d sekonda"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Koha per mesataren grafike: %d minute"
 msgstr[1] "Koha per mesataren grafike: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Shkalla grafike e lidhjeve: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Madhesia buffer e failit: %d byte"
 msgstr[1] "Madesia Buffer e failit: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Madhesia e radhes se ngarkimit: %d klienti"
 msgstr[1] "Madhesia e radhes se ngarkimit: %d klientet"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Intervali i rifreskimit te lidhjeve te serverit: %d minute"
 msgstr[1] "Intervali i rifreskimit te lidhjeve te serverit: %d minuta"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Intervali i rifreskimit te lidhjeve te serverit: I c'aktivizuar"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "disabled"
 msgstr "c'aktivizo"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Ekzekuto komanden ne kete ngjarje `%s' "
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Lejo ekzekutimin e komandes ne core"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "KOmanda Core:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Lejo ekzekutimin e komandes ne GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Komanda GUI:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Variacionet qe vijojne do te rivendosen:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Duke lexuar kartelen temp"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "File te ndara"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Masen Maksimale.."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "PoParalajmerim per kerkim"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Kryesore"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Gabim i paparashikuar duke kerkuar Kad: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "E pavotuar"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Shkarko ne kategori"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Shtoni URLs opsionale per kete fail"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Shenoje si fail te njohur"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ju jeni i lidhur tek serveri qe deshironi te fshini. ju lutem ne fillim shkeputuni prej tij."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Fshij"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "E pamundur te lidhet tek lista e serverave me protokollin e turbullimit. Po provoj pa turbullim."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "E pamundur te lidhet tek lista e serverave me protokollin e turbullimit. Po provoj pa turbullim."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "E pamundur te lidhem tek serverat qe jane ne liste. Po provoj perseri."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "E pamundur te lidhem tek serverat qe jane ne liste. Po provoj perseri."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "I lidhur tek %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Lidhja u vendos ne: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Gabim i Rende gjate tentatives per tu lidhur. Lidhja e Internetit mund te jete shkeputur"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Humbi lidhja tek %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) duket sikur nuk ka shenja jete."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) duket sikur eshte plote."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Rilidhje automatike tek serveri do te behet ne %d sekonde"
 msgstr[1] "Rilidhje automatike tek serveri do te behet ne %d sekonda"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Lidhja tek %s (%s:%i) deshtoi."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Lidhja tek %s (%s:%i) nuk u vendos per time-out."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Duke ngarkuar failin e server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Faili i server.met nuk u gjete!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Deshtoi te ngarkoje failin e server.met '%s' u ndeshem ne nje format te panjohur."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Deshtoi per te hapur server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Faili i server.met nuk eshte i vlefshem, u gjet nje TAG i versionit i pavlere: 0x%x, madhesia %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i u gjet server ne server.met"
 msgstr[1] "%i u gjeten servera ne server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d serveri i shtua"
 msgstr[1] "%d serverat u shtuan"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Gabim IO duke lexuar failin known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Serveri nuk u shtua: [%s:%d] nuk specifikon nje porte te vlefshme."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Serveri nuk u shtua: Ip-ja e [%s:%d] eshte e filtruar ose e pavlere."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Serveri nuk u shtua: Servera me Ip qe mungon:Porta [%s:%d] u gjet ne liste."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Serveri u shtua: Server tek é%s.%d* duke perdorur emrin '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Ju jeni i lidhur tek serveri qe deshironi te fshini. ju lutem ne fillim shkeputuni prej tij."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Deshtoi te hapi '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Deshtoi te shpetoje server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "URL e pavlere"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Mbaroi se shkarkuari listen e serverave nga %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Duke filluar shkarkimin e listes se serverave nga %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Nuk eshte gjetur nje url per auto-shkarkimin e server.met ne adresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Deshtoi te shkarkoje listen e serverave nga %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Serverat lokale jane te filtruara nga IPFilters, duke u rilidhur ne nje server tjeter!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Emri i serverit"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adresa"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Porta"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Pershkrimi"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping-u"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Perdoruesit"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "E qendrueshme"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioni"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Ju jeni lidhur tek nje serveri qe po perpiqeni te fshini. Ju lutem mbylleni lidhjen ne fillim. Serveri NUK u fshi."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Emer i panjohur)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Jeni te sigurte qe doni te fshini kete server te qendrueshem %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Serverat (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Serveri"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Lidhu ne Server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Shenoje Serverin si te qendrueshem"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Shenoje Serverin si te Jo-Qendrueshem"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Shenoji Serverat si te qendrueshem"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Shenoji Serverat si te Jo-Qendrueshem"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Hiq Server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Hiq Serverat"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Hiq te gjithe Serverat"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Rilidhu ne Server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Jeni te sigurte qe deshironi te fshini te gjithe serverat?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Jeni te sigurte qe deshironi te fshini te gjithe serverin e perzgjedhur?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Jeni te sigurte qe deshironi te fshini serverat e zgjedhur?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Klienti i ri eshte %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "KUJDES: Ju keni marre nje ID te ulet!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tMbase ngaqe ju jeni mbas nje firewalli ose routeri."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "U moren Informacione serveri te panjohura! - shume e shkurter"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "U mor %d server i ri"
 msgstr[1] "U moren %d servera te rinj"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Shpetimi i listes se serverit u perfundua."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Serveri nuk pranoi komanden e fundit"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Paketa Bogus te marra nga serveri: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Gabim qe nuk mund te menaxhohet derisa punohet me paketat nga serveri: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Nuk eshte e mundur te krijohet nje thread per te zgjidhur DNS per tu lidhur tek %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP-ja e Serverit %s ( %s) eshte e filtruar.  Nuk po lidhet."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "duke perdorur protokollin e turbullimit."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Duke u lidhur tek %s ( %s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "NUk eshte e mundur te zgjidhet DNS per serverin %s: E pamundur te lidhem!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Log i aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Serveri nuk u shtua: Nuk ka Hostname ose IP per specifikuar."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Serveri nuk u shtua: Porta e serverit te specifkuar eshte e pavlere."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Gjendja e lidhjes"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "I lidhur"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Statusi i Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Duke punuar ne %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Aktive"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Statusi i Kademlia"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Statusi:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Gjendja e lidhjes"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "UDP Connection State:"
 msgstr "Gjendja e lidhjes"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Gjendja e firewall-it: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Nuk ka Shoke"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connecting to buddy"
 msgstr "I lidhur me shokun"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "I lidhur me shokun"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed sources:"
 msgstr "Burime te gjetura :"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Indexed notes:"
 msgstr "Indeksi i failit nuk u gjet:  "
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Perdorues mesatare:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Mesatarja e faileve:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Nuk eshte aktive"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "U gjenden %i faile te njohur te ndare, %i te panjohura"
 msgstr[1] "U gjenden %i faile te njohura te ndara,%i te panjohura"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, fuzzy, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Serveri nuk u gjend: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Emri i Perdoruesit"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Shpejtesia-Ngarkimit"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Te disponueshem :"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Gjendja e ngarkimit"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Gjendja e shkarkimit"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Emri i failit"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "File te ndara"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Pjese te marra"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Direktoria Path"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Shti Komento/Klasifiko"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Redakto Koment/Klasifiko"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Riemerto"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Shto failet ne koleksionin e listes per transferim"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopjo magnetin &URI ne shenime"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopjo linkun ED2k ne shenime (&AICH informacion)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Ju keni nevoje per nje ID te larte per te krijuar nje sourcelink te vlefshem"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Emri i failit"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Vlera te ngarkuara (Sesioni (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Overhead-i Total (Paketa): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Overhead-i i faileve te kerkuara (Paketa): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Overhead-i i nderrimit te burimit (Paketa): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Overhead-i i Serverit (Paketa): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Overhead i Kad (Paketa): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Ngarkime Aktive: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Ngarkime ne pritje: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Sesione totale ngarkimi me sukses: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Sesione totale ngarkimi te deshtuara: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Mesatarja kohore e ngarkimeve: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Te dhenat e shkarkimeve (Sesioni(Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Burime te gjetura: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Shkarkime Aktive (pjeset): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Raporti NG:SHK i sesionit (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Rilidhjet: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Koha qe nga transferimi i pare: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "I lidhur ne server qe prej: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Lidhje Aktive (vleresimi): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Kufiri maksimal i lidhjeve u arrit: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Mesatarja e lidhjeve (vleresim): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Kulmi i lidhjeve (vleresim): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Kliente"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Madhesi e panjohur"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Te filtruar"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "Te larguar"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Totale: %i Te njohur: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Servera qe punojne: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Servera te deshtuar: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Totale: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Servera te fshire: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Servera te filtruar: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Perdorues ne serverat qe punojne: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Faile ne serverat qe punojne: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Perdorues Total: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Totali i Faileve: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Zenia e Serverit: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numeri i faileve te ndara: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Totali i madhesise se faileve te ndara: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Sistemi Operativ"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Jo te marra"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Lidhjet Aktive (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Asnjehere"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Komanda `%s' me pid `%d' mbaroi me kodin e statusit `%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Shtyp <str> dhe dil."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Format IP e pavlere. Perdor xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Kjo komanda kerkon nje argument, Argumente te vlefshme: all , emri i failit, ose nje numer.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Perpunim nga Hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Perpunim nga emri i failit: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Kjo komanda kerkon nje argumet. Argumente te vlefshem jane: nje fail hash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Nuk eshte numer i vlefshem\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Nuk eshte hash i vlefshem (gjatesia duhet te jete ekzaktesisht 32 shkronja)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7259,7 +7170,7 @@ msgstr "Shtyp '%s' per te marre me shume ndihme.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7268,89 +7179,87 @@ msgstr "Shtyp '%s' per te marre me shume ndihme.\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Shtyp '%s' per te marre me shume ndihme.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Shkarkimet (%i)"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Kerkesa deshtoi me nje gabim te panjohur."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operacioni u mbyll me sukses."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Kerkesa deshtoi me kete gabim: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Filtrimi i IP per klientet eshte %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Fikur"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Ndezur"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Filtrimi i IP per serverat eshte %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Niveli aktual i filtrimit te IP eshte %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "I lidhur tek %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Tani po lidhem"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "firewalled"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7359,7 +7268,7 @@ msgstr ""
 "\n"
 "Shkarkim:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7368,7 +7277,7 @@ msgstr ""
 "\n"
 "Ngarkim:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7377,7 +7286,7 @@ msgstr ""
 "\n"
 "Kliente ne radhe:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7386,46 +7295,46 @@ msgstr ""
 "\n"
 "Burime Totale:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[File ne shkarkim]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Numri i rezultateve te kerkimeve: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Erdhi nje pergjigje e panjohur nga serveri, OpCode = %#x"
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Trego informacione mbi gjendjen."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Trego gjendjen e lidhjes, ngarkim/shkarkim shpejtesi aktuale, etj.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Trego pemen e te gjitha statistikave."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7438,51 +7347,51 @@ msgstr ""
 ". Asnje numer nuk tregon 'infinit'.\n"
 "Shembull: 'statitistics 5' do te tregoje vetem 5 versionet eme te perhapura per cdo lloj klienti.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Ringarko objektet e dhena."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Ringarko tabelen e Filterit te Ip nga faili."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Zgjidh nivelin e filtrimit te IP."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Ringarko tabelen e Filterit te Ip nga faili."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Lidhu me rrjetin."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7493,36 +7402,36 @@ msgstr ""
 "Ju gjithashtu mund te specifikoni adresen IP ne formen IP:Port, te nje serveri dhe\n"
 "te lidhesh vetem tek ai. Mund te perdoret nje adrese IPv4 ose nje emer i zgjidhshem DNS."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Lidhu vetem tek Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Shkeputu nga rrjeti."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Kjo do te shkepusi aMulen nga te gjithe rrjetet qe eshte e lidhur.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Shkeputu vetem nga Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Shton nje link magnet ose ed2k tek Core."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7533,52 +7442,52 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Vendos nje vlere te preferuar."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Vendos preferimet per filtrin e IP."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Ndize filtrin e IP si per kliente dhe per serverat."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Fike filterin e IP si per klientet si per serverat."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Aktivizo/C'aktivizo filtrimin e IP per klientat."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Ndiz filtrimin e IP per klientet."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Fike filtrimin e IP per klientet."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Aktivizo/C'aktivizo filtrimin e IP per serverat."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Ndize filtrimin e IP per serverat."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Fike filtrimin e IP per serverat."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Zgjidh nivelin e filtrimit te IP."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7586,80 +7495,80 @@ msgstr ""
 "Niveled e duhura per filtrimin jane nga 0-255, dhe eshte e dhene (fillimisht)\n"
 "vlera eshte 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Vendos kufijte e rrjetit."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Vlera e dhene e ketyre komandave duhet te jete ne kilobytes/sec.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Vendos kufijte ngarkues te rrjetit."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Vlera e dhene e ketyre komandave duhet te jete ne kilobytes/sec.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Vendos kufijte shkarkues per rrjetin."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Vlera e dhene e ketyre komandave duhet te jete ne kilobytes/sec.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Merr dhe trego nje vlere te preferencave."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Merr preferencat e filtrit te IP."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Merr gjendjen e filterit te IP per klientet dhe per serverat."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Merr gjendjen e filterit te IP vetem per kliente."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Merr gjendjen e filterit IP vetem per servera."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Zgjidh nivelin e filtrimit te IP."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Merrni kufijte e bandwdith."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Fillon nje kerkim Kad"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7678,48 +7587,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Fillon nje kerkim global."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Fillon nje kerkim lokal"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Fillon nje kerkim Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Tregon rezultatet e kerkimit te fundit."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Tregon ecurine e nje kerkimi."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Shkarko nje fail"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7727,82 +7636,82 @@ msgstr ""
 "Duhet te jepet numri i nje faili nga kerkimi i fundit.\n"
 "Shembull: 'shkarkimi 12' do te filloje te shkarkoje failin me numer 12 te kerkimit te meparshem.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pusho shkarkimin."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Rimerr shkarkimin."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Fshij shkarkimin."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Vendos prioritetin e shkarkimit."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Vendos prioritetin e nje shkarkimi tek Ulet, Normale, Larte ose Auto,\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Vendos prioritetin tek Ulet,"
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Vendos prioritetin tek Normale."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Vendos prioritetin tek Larte."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Vendos prioritetin tek auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Trego radhet/listat."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Tregon radhen e ngarkim/shkarkimit, listen e serverave ose listen e faileve te ndara.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Trego radhen e ngarkimeve."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Trego radhen e shkarkimeve."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Trego log."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Trego listen e serverave."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Ringarko listen e faileve te ndara."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Fshi log-un."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7811,262 +7720,259 @@ msgstr ""
 "Kjo eshte nje komande e pavlere dhe mund te largohet ne te ardhmen.\n"
 "Perdor '%s' ne vendin e saj.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Teksti i klientit aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Duke kembyer hashsetet e vjetra AICH ne '%s' 64b ne '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "KUJDES: Emri i failit '%s' eshte i pavlere dhe eshte riemeruar ne '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "KUJDES: Faili '%s' ekziston,faili i ri i riemertuar ne '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Jeni te sigurte qe deshironi te fshini te gjithe failet nga kjo kategori?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Konfirmo kerkesen"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Shume lidhje"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Te gjithe te tjeret"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Shto kategorine"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Redakto kategorine"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Zhvendos kategorine"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Kerkohet Hashset-i per failin e panjohur: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Rimarrja e ngarkimeve te failit: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Duke pezulluar ngarkimin e failit: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Deshtoi te ekzekutoje komanden `%s' ne `%s' ngjarjet."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Shkarkimi Perfundoi"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Path-i i plote per tek faili"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Emri i failit pa perberesit e Path-it."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Madhesia e failit ne bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "KOha permbledhese e shkarkimeve."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Sesion i ri chati filloi"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Derguesi i mesazheve."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Jashte nga hapesira"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Particioni i diskut."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Gabim ne perfundim"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Numeri i failit ne proces %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ju kerkuat hashin e pjeseve (Vetem per failet e perdorur > 9.5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fail qe nuk ekziston !\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Miresevini!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Parametrat e hyrjes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Faili per ekzaminim"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Shtoni URLs opsionale per kete fail"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Krijo lidhje me pjeset-hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Ndihmo te shperndash sa me shpejte failet e reja dhe te vyera, ne kembim te nje lidhjeje me te gjate"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "Hash MD4"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Shpeto"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopjo ne shenime"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Rreth aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Asgje per te kopjuar tani !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "E pamundur te hapet "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Ju lutem, futni nje emer faili jo boshe"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Asgje per te shpetuar tani !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8078,167 +7984,159 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hashing..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "i anulluar !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "I perfunduar ne %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ju e keni futur edhe me pare kete URL !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Ju lutem, futni nje URL jo boshe"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "I paafte per te hapur %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dita(et) %i ora(et) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uo %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, Statistikat Online te aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Shpejtesia maksimale e DL qe kur eshte aktive wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Shpejtesia maksimale e DL ne aktivizimet e meparshme"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Rivendos"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Ndalo Rifreskimin Automatik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Shpeto imazhet e statistikave online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Printo imazhet e statistikave online"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Rregullimet e preferencave"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Rreth wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Fillo Rifreskimin Automatik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Rifreskimi Automatik u ndalua"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Rifreskimi Automatik filloi"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Shpeto imazhet e statistikave"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Statistikat Online te aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8246,11 +8144,11 @@ msgstr ""
 "Kishte nje problem duke printuar.\n"
 " Mos valle printeri juaj nuk eshte instaluar ne menyre korrekte?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Duke printuar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8268,403 +8166,392 @@ msgstr ""
 "\n"
 "Shperndare nga GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh Oh, aMule nuk eshte duke punuar..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule eshte duke punuar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule eshte duke punuar,por e shkeputur"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule po lidhet..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh Oh, Statusi i aMule eshte i panjohur..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr "ka punuar per "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " ka ndaluar !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " nuk eshte lidhur !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " po lidhet..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " eshte duke bere dicka te cuditshme, kontrolloje !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " eshte lidhur me "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "Fikur"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr "  Eshte ndezur "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " me "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Shkarkimi Total: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Ngarkimi: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Sesioni i Shkarkimit: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Shkarkim: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Ngarkim: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Te ndara: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " faili(et), Klientet ne pritje: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Koha: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " Ndezur "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Ngarikimi mesatar i sistemit (1-5-15 minuta): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Uptime i Sistemit: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Direktoria permban failin amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Futni ketu direktorine se ku keni vendosur failin e amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Intervali i rifreskimit ne sekonda"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Prodho nje imazh te statistikave ne c'do rifreskim ngjarje"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Futni ketu direktorine se ku deshironi te prodhoni nje imazh te statistikave"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Ngarko periodikisht imazhin tuaj te statistikave ne serverin FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "Url e FTP-se"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "Rruga e FTP-se"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Futni ketu URL e serverit tuaj FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Futni ketu direktorine e serverit FTP ne te cilen doni te kopjoni imazhin tuaj te statistikave"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Perdorues"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Futni ketu emrin e Perdoruesit per te hyre ne serverin FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Futni ketu fjalekalimin e Perdoruesit per te hyre ne serverin FTP"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Intervali i rifreskimit te FTP-se ne minuta"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Konvalido"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Kartela qe mban failoin e firmes"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Kartela ku prodhohet imazhi i statistikave"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Duke ngarkuar modelin <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "Porta UPnP"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Lejo hyrjen e guest-ve"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Ndalo hyrjen e guest-ve"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Rruga per konfigurimin e failit te aMule. MOS E PERDORNI DIREKT!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "C'aktivizo interpretuesin e PHP (nuk aprovohet)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Rimbush faqet PHP ne c'do kerkese"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Web Server i aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Kerkesa deshtoi me kete gabim: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indeksi i failit nuk u gjet:  "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Sesioni mbaroi - kerkohet hyrja\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Sesioni ne rregull, u futet ne\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Sesioni ne rregul,nuk u futet ne\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Nuk ka sesion te hapur - kerkese per hyrje\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Sesioni u krijua - kerkohet hyrja\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Perpunim i kerkeses [origjinale]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Hash-i i fjalekalimit nuk eshte i rregullt\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Fjalekalimi ne rregull\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Fjalekalim i gabuar\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Ju nuk futet asnje fjalekalim: Vendi bosh nuk lejohet.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Dalja e kerkuar\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Perpunimi i kerkeses [e ridrejtuar]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Lidhja deshtoi "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Visa aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule fjärrkontroll"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "'Alla-Platformar' p2p-klient basserad på eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,79 +50,79 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Delar av aMule är baserad på \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing baserad på XOR metric.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Webbsida:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Sök efter ny version vid start"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Ansluter till Kad..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Inte tillgänglig"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Lägg till en vän"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Du måste ange en giltig IP-adress och port!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Information"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Angiven userhash är inte giltig!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -131,49 +131,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Efter programnamn"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "Anslutningen misslyckades "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,103 +181,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Kunde inte öppna ED2KLinks-filen"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-länk när du har lowid."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Nu, avslutar huvudapplikationen..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Avslutar  amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Dödar amuleweb-instansen med pid '%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule VidAvslut: Avslutar huvudprogrammet."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMules avslutning slutförd"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Minnes-debug-resultat för aMules avslut"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Din plats har ändrats till systemets standard på grund av en konfigurationsändring. Ledsen."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Info"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +282,70 @@ msgstr ""
 "\n"
 "EC-konfiguration"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "FEL"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "webbservern kör på pid %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Kunde inte binda portarna till specificerad adress: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port %u är inte tillgänglig. Du kommer att bli LOWID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +360,48 @@ msgstr ""
 "\n"
 "Kontrollera ditt nätverk för att se att porten är öppen för ut och in-trafik."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Misslyckades med att skapa OnlineSig-fil"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Misslyckades med att skapa aMule OnlineSig-fil"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Den valda platsen verkar inte vara installerad på din burk. (OBS: Jag försöker ändå)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Det här är första gången du kör aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Den här versionen är en testversion, uppdateras dagligen, och\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "vi ger inga garantier att den inte förstör allt, bränner ner huset,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "eller dödar din hund. Men den *bör* vara säker att använda.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Mer information, support och nya versioner kan hittas på vår hemsida,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io, eller i vår IRC-kanal #aMule på irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Rapportera gärna eventuella fel på https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,224 +409,220 @@ msgstr ""
 "Katalogen för Online Signaturefiler som du angav är OGILTIG!\n"
 " OnlineSignatur kommer vara INAKTIVERAD tills du ändrar inställningarna."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Förallokerad diskutrymme för filen '%s' misslyckades: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "FEL: kan inte öppna loggfilen"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "VARNING: loggfilen är tom. Någonting är fel."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Loggen har nollställts"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Servermeddelande: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "Avslutade nerladdningen av %s eftersom begärd fil inte är nyare."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Misslyckades med att hämta nodlistan."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Misslyckades med att öppna den hämtade versionskontrollfilen"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Korrupt versionskontrollfil"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Du använder en gammal version av aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Din aMuleversion är %i.%i.%i och den senaste versionen är %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "VARNING: Din version av aMuled är gammal: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Din version av aMule är den senaste."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Misslyckades med att hämta versionskontrollfilen"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Användare: %s | Filer: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Användare: E: %s K: %s | Filer: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Inga nätverk valda"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "med LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "med HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Ansluten till %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Ansluter till %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Frånkopplad från eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad startad."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad stoppad."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Ansluten till Kad (ok)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kadnätverket kan inte användas om UDP-porten är inaktiverad i inställningarna, startar inte."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kadnätverket är inaktiverad i inställningarna, ansluter inte."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "FEL: aMule-deamon kan inte användas när externa anslutningar är inaktiverade. För att aktivera Externa Anslutningar, använd en normal aMule, starta amuled med optionen --ec-config eller sätt nyckeln \"AcceptExternalConnections\" till 1 i filen ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "FEL: Ett giltigt lösenord krävs för att använda externa anslutningar och aMule daemon kan inte användas utan externa anslutningar. För att köra aMule deamon måste du ställa in \"ECPassword\"-fältet i filen  ~/.aMule/amule.conf med ett lämpligt värde. Kör amuled med flaggan --ec-config för att ställa in lösenordet. Mer info finns på https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - startar timern"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Kan inte skapa Pid-fil"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "FEL: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Det här är aMule %s baserad på eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,193 +632,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Inget nätverk"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule fjärrkontroll"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Allvarligt fel: Kunde inte skapa Core Timer"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Anslut till fjärr-aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Anslutningen förlorades"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Fråga vid avslut"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -839,727 +820,704 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Allvarligt Fel: Kunde inte skapa Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Går till händelse-loop..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Ansluter..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Fjärr-GUI EC händelse-hanterare"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Anslutning misslyckades. Kan inte ansluta till %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Stänger ner"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Anslutningsförsöket till %s (%s:%i) tog för lång tid."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "Anslut till nätverket."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Anslutning misslyckades. Kan inte ansluta till %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Färdig"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Alla"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Inte tillgänglig"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Filen hittades inte."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Felaktig länk eller redan i listan."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Okänd"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Letar efter en kompis för lowid-anslutning"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMule-version %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Falsk eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baserad på eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Smeknamn: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Begärd: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistik för den här gången: Accepterat %d av %d begäran, %s överfört\n"
 msgstr[1] "Filstatistik för den här gången: Accepterat %d av %d begäran, %s överfört\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistik sedan början: Accepterat %d av %d begäran, %s överfört\n"
 msgstr[1] "Filstatistik sedan början: Accepterat %d av %d begäran, %s överfört\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Begärde okänd fil"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Meddelande filtrerat från '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nytt meddelande från '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Användare %s (%u) begärde sharedfiles-list för icke exiterade mapp '%s' -> Ignorerad"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "VARNING: %s kan inte öppnas."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "VARNING: Avbruten fillista korrupt, har inkorrekt header."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "IO-fel vid läsning av %s fil: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Fel vid sparandet av %s fil: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Ny kategori"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Välj en mapp för inkommande filer"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Du måste ange ett namn för kategorin!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Du måste ange en sökväg för kategorin!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Kunde inte skapa inkommande-mapp för kategorin. Ange giltig sökväg!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Chat startad: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Ansluten till klient ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Ansluter till klient ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Kunde inte ansluta till klient / anslutningen bröts ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Du klarade captcha-testet och användaren har fått ditt meddelande ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Ditt svar på captcha var fel och ditt meddelande har ignoretats. Du kan begära ett nytt captcha genom att skicka ett nytt meddelande. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Chat"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Stäng flik"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Stäng alla flikar"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Stäng andra flikar"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Lägg till i vänner"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Kreditfilen laddad, %u klient är känd"
 msgstr[1] "Kreditfilen laddad, %u klienter är kända"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - Krediten utgått för %u klient!"
 msgstr[1] " - Krediten utgått för %u klienter!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Ingen 'cryptkey.dat'-fil funnen, skapar."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Klientdetaljer"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Stöds"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Stöds inte"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Inaktiverad"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ansluten"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Inte färdig"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Bad Guy"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verifierad - OK"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Inte tillgänglig"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Användare %s (%u) begärde din sharedfiles-lista -> Accepterad"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Användare %s (%u) begärde din sharedfiles-lista -> Nekad"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Användare %s (%u) begärde lista på utdelade mappar -> Accepterad"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Användare %s (%u) begärde lista på utdelade mappar -> Nekad"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Användare %s (%u) begärde din sharedfiles-lista för mapp '%s'  -> Accepterad"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Användare %s (%u) begärde din sharedfiles-lista för mapp '%s'  -> Nekad"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Användare %s (%u) delar mapp '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Användare %s (%u) skickade obegärda delade mappar."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Användare %s (%u) skickade sharedfiles-list för mappen '%s'"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Användare %s (%u) färdig med sändningen av sharedfiles-listan"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Användare %s (%u) skickade oönskad sharedfiles-lista"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Användare %s (%u) nekade tillgång till listan för delade mappar/filer"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Filkommentarer"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Användarnamn"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Rankning"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad-sökning kan inte göras om Kad inte är igång"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Letar efter en kompis för lowid-anslutning"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Inga kommentarer"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u kommentar"
 msgstr[1] "%u kommentarer"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "Bannlyser klient %s för skickandet av %s korrupt data av totalt %s för filen '%s'"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Kunde inte hämta lands-data för '%s'."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Auto [Lå]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Auto [Nej]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Auto [Hö]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hög"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Mycket hög"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Version"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Frågar"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Ansluter via server"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Kö full"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kö"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Hämtar"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Tar emot hashset"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Inga behövda delar"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Kan inte ansluta LowID till LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "För många anslutningar"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Ansluter via Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "För många Kad-anslutningar"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Bannlyst"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Anslutningsfel"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Fjärrkö full"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Gammal MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Ny MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule-kompatibel"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Lokal server"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Källutbyte"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Passiv"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Länk"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Käll-frön"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Sökresultat"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Färdig"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "Pågår"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "FEL: Slut på diskutrymme"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "FEL: Hittade inte Partmet"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "FEL: IO-fel"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "FEL: Mysslyckades!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Lagd i kö"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Laddar redan ner"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Okänd eller trasig temp-fil-format"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Överfört"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighet"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Förlopp"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Källor"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Status"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Återstående tid"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Senast sedd komplett"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Senast mottagen"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Är du säker på att du vill ta bort vald fil?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Är du säker på att du vill ta bort alla valda filer?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1568,109 +1526,106 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Stoppa"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Fortsätt"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Ta bort färdiga"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Byt alla A4AF till denna fil nu"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Byt alla A4AF till denna fil (Auto)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Byt alla A4AF till någon annan fil nu"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Utökade inställningar"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Förhandsgranska"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Visa fil &details"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Visa alla kommentarer"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Kopiera magnet URI till urklipp"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Kopiera eD2k &link till urklipp"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiera återkoppling till urklipp"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "Otilldela"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Koppla till kategori"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "&Öppna filen"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Ange nytt namn för den här filen:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Byt namn på fil"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H.%M.%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Hämtningar (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1679,348 +1634,347 @@ msgstr ""
 "För att slippa den här varningen i varje förhandsvisning,\n"
 "Ställ in önskad videospelare i inställningar (standard är %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Förhandsvisning av fil"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEL: Kunde inte starta externa mediaspelaren! Kommado: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Sparar PartFile %u av %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Alla PartFiles sparade."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Laddar temp-filer från %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Laddar PartFile %u av %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "Fel: Kunde inte ladda backupfilen. Sök i https://github.com/amule-org/amule/discussions efter .part.met recovery solutions."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Alla PartFiles laddade."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Inga PartFiles hittade"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "Hittade %u part file"
 msgstr[1] "Hittade %u part filer"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Filsystemet för Temp-mappen kan inte hantera stora filer."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Filsystemet för inkommande filer kan inte hantera stora filer."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Hämtar %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Du försöker redan hämta filen '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Du har redan filen '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Du har redan filen '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du försöker redan hämta filen %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Kan inte konvertera magnetlänk till eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Ökänd protokoll för filen: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Felaktig eD2k-länk! FEL: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Klienten skickade paket efter att autentisering misslyckades. "
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Extern anslutning stängd."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Externa anslutningar inaktiverade pga. tomt lösenord!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Externa anslutningar inaktiverade i konfigfilen"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Ny extern anslutning accepterad"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "FEL: Kunde inte acceptera ny extern anslutning"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Extern anslutning nekad pga. tomt lösenord i inställningarna!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Ansluter klient: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Okänd version"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Fel EC-versions-ID, kanske är det inkompatibla binärfiler. Använd core och remote från samma snapshot."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Du kan inte ansluta en release-version från en godtycklig utvecklings-snapshot! *suck* Trolig krasch förhindrad "
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Fel protokoll-version"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Saknar tag för protokoll-version"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Autentisering misslyckades: fel hash specificerad som EC-lösenord"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Autentisering misslyckades: fel lösenord"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Autentisering misslyckades: saknar lösenord"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Felaktig begäran, vänligen autentisera först."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Tillgång beviljad."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Skickade felmeddelandet \"%s\" till klienten."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Obehörigt åtkomstförsök från %s. Anslutning stängd."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Extern PartFile kommando misslyckades: FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "FileHash hittades inte: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "HOPPSAN!  OpCode-bearbetningsfel!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Server inte inlaggd"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "server inte hittad: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "måste definiera server som ska tas bort"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k är inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websök från fjärrgränssnitt är meningslöst."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Sök pågår. Visar snart svaren!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Inga poäng för graf."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Din klient är inte konfigurerad för denna detaljnivå."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Extern Anslutning: avstängning begärd"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Håller redan på att stänga ner."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "ExternalConn: lägger till länk '%s'."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Felaktig länk eller redan i listan."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Filen hittades inte."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Ogiltigt filnamn."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Kunde inte byta namn på fil."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad inaktiverad i inställningarna."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Redan ansluten till eD2k."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "Ansluter till eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Redan ansluten till Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Ansluter till Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Alla nätverk är inaktiverade."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Koppla ifrån eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Frånkopplad från Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Extern anlutning: Felaktig opcode mottagen: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Felaktig opcode (fel protokollversion?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Okänd tillägg '%s' för kommandot '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Okänd kommando '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2028,7 +1982,7 @@ msgstr ""
 "\n"
 "Det här kommandot har inga argument.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2036,7 +1990,7 @@ msgstr ""
 "\n"
 "Det här kommandot måste ha ett argument.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Det här kommandot är inte komplett, du måste använda ett av tilläggen nedan.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2052,11 +2006,11 @@ msgstr ""
 "\n"
 "Tillgängliga tillägg:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Tillgängliga kommandon:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2067,17 +2021,17 @@ msgstr ""
 "Kommandon är inte skiftlägeskänsliga.\n"
 "Skriv '%s <command>' för att få detaljerad info om <command>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Avslutar programmet."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Visa hjälp."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2085,7 +2039,7 @@ msgstr ""
 "För att få hjälp om ett kommando, skriv 'help <command>'.\n"
 "För att se en lista över alla kommandon, skriv 'help'.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2096,46 +2050,46 @@ msgstr ""
 "Använd '%s' för kommandolista\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Syntaxfel!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Fel när kommandot skulle utföras - ska aldrig hända! Vänligen rapportera buggen\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Det här kommandot ska inte ha några parametrar."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Det här kommandot måste ha parametrar."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Ogiltigt argument."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Det här är inte ett komplett kommando."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Skriv '%s' för att få mer hjälp.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Det här är %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Det här är %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2143,7 +2097,7 @@ msgstr ""
 "\n"
 "Skapar klient...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2152,7 +2106,7 @@ msgstr ""
 "\n"
 "Ok, avslutar %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2166,331 +2120,326 @@ msgstr ""
 "\n"
 "Avslutar...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Visa den här hjälptexten."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Värd där aMule körs. (standard: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMules port for extern anslutning. (standard: 4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Lösenord för extern anslutning"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Läs in konfiguration från fil."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Skriv inte någon output till stout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Använd verbose - visa även debug-meddelanden."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Ställer in program locale (språk)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Skriv kommandon för inställningar till configfilen."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Skapar config-fil baserad på aMules configfil."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Skriv ut programversion."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Fildetaljer"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% färdig"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Välkommen!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Ansluter till vän"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Anslutningstillstånd:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Nätverk"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standard TCP-port "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Utökad UDP-port (Kad / global sökning) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Aktivera UPnP för vidarebefordring av routerport"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Bootstrap"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Du försöker redan hämta filen %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Auto-uppdatera serverlistan vid start"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för läsning!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Vänner"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Visa &Details"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Lägg till en vän"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Ta bort vän"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Skicka &Message"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Visa filer"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Skapa vän-spår"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Är du säker på att du vill ta bort vald vän?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Är du säker på att du vill ta bort valda vänner?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2498,11 +2447,11 @@ msgstr ""
 "Du kan endast ha ett vän-spår.\n"
 " Endast ett spår tilldelades. "
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Flerval"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2511,206 +2460,205 @@ msgstr ""
 "Du kan endast ha ett vän-spår.\n"
 " Endast ett spår tilldelades. "
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Skicka meddelande till användare"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Meddelande att skicka:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Ta bort från vänner"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Skicka meddelande"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Växla till den här filen"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "På kö: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Frågade om en annan fil"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Väntar på ett uppladdningsspår"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "På kö: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Skickar"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Ja"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Hämtar..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP-hämtning avbryten"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "URLen för hämtningen kan inte vara tom"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Hämtat %d bytes"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "URLen %s returnerade: %i - Fel (%i)!"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP-hämtning avbryten"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Hämta ny GeoIP.dat från %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Hämtning av GeoIP.dat-fil misslyckades, avbryter updateringen."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Kunde inte ta bort %s filen, avbryter uppdateringen."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Kunde inte byta namn på %s filen, avbryter uppdateringen."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "Lyckad uppdatering av %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Fel vid uppdatering av GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "Kunde inte hämta %s från %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Laddar IP filter 'ipfilter.dat' och 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Kunde inte ladda ipfilter.dat-fil '%s', okänt format upptäcktes."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Kunde inte ladda ipfilter.dat-fil '%s', kunde inte öppna filen."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "Laddade %u IP-range från '%s'."
 msgstr[1] "Laddade %u IP-ranges från '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u felaktigt linje kastades."
 msgstr[1] "%u felaktiga linjer kastades."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Det gick inte att byta namn på ny %s fil, avbryter uppdateringen."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP-filter är redo"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2718,876 +2666,844 @@ msgstr ""
 "Bootstrap från \n"
 "kända klienter"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noder (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ogiltig ip till bootstrap"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Ogiltig port till bootstrap"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Fyll i alla fält som krävs"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Meddelande"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Är du säker på att du vill hämta en ny nodes.dat-fil?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Om du gör det tas dina nuvarande noder bort och Kademlias anslutning startas om."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Fortsätt?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: sökord för kort"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: sökord är redan på söklistan: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Det gick inte att läsa nodes.dat fil - för gammal. Denna version (0) stöds inte längre."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "Läs %u Kad-kontakt"
 msgstr[1] "Läs %u Kad-kontakter"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Inga kontakter hittades, vänligen bootstrappa, eller ladda ner en nodes.dat fil."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Endast %d Kad-kontakt tillgänglig, nodes.dat inte skriven"
 msgstr[1] "Endast %d Kad-kontakter tillgängliga, nodes.dat inte skriven"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "Skrev %d Kad kontakt"
 msgstr[1] "Skrev %d Kad kontakter"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Kad-nätverk"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Filnamn"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Filstorlek"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Dela-förhållande"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Begärda"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Accepterad"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Kompletta källor"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "VARNING: listan med kända filer skadad, innehåller ogiltig header."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Det gick inte att läsa posten i filen med kända filer, filen kan vara skadad"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ogiltig post i filen med kända filer, filen kan vara skadad: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Okänd version %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Det går inte att få felbeskrivning för fel %d"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Hashing"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Färdigställer"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Färdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Felaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Väntar"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Du måste ange ett icke-tomt lösenord."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Ogiltigt lösenord, inte en MD5-hash!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Anslutningsfel"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Extern anslutning stängd."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC-anslutningen misslyckades. Tomt svar."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Extern Anslutning: Fel svar, handskakning misslyckades. Anslutning stängd."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Lyckades! Anslutning etablerad till aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Lyckades! Anslutning etablerad."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Extern Anslutning: Åtkomst nekad på grund av: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Extern anslutning: Handskakning misslyckades."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "FEL: Det gick inte att lyssna på TCP-port."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "FEL: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "VARNING: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Stäng"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiera"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Klistra in"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Töm"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Markera alla"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "Ansluten"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "Ansluten"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "Ansluten till Kad (brandvägg)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Server-IP:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Inte ansluten"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP-port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP-port: Inte klar"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP-port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP-port: Inte klar"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Klientinformation"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Uppladdningsbegränsning"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Nerladdningsbegränsning"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Visa aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Dölj aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Avsluta"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Obegränsad"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule Fackmeny"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Hastighetsbegränsningar:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "UL: Inga"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "UL: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "DL: Inga"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "DL: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Nedladdningshastighet: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Uppladdningshastighet: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Smeknamn: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Inget smeknamn vald!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "Klient-ID "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Servernamn: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "ServerIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Inte ansluten"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online Signatur: Aktiverad"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online Signatur: Inaktiverad"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Upptid: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Delade filer: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Kö klienter: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Totalt DL: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totalt UL: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Lägg till en ed2k- eller magnetlänk till kärnan."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Lägg till i vänner"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Klicka här för att lägga till eD2k-länken i textkontrollen till hämtningskön."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Händelser visas här. För en fullständig lista över händelser, se i loggen i Serverfliken.."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Läser in..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Antal användare på servern du är ansluten till ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Användare: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Användare som är anslutna till den aktuella servern och en uppskattning av det totala antalet användare."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Upp: 0.0 | Ner: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Nuvarande genomsnittliga uppladdnings- och nedladdningsnivåer. Om aktiverat visar siffrorna även overhead från klientkommunikationen."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Visar anslutningsstatus och aktiva överföringar. Röda pilar innebär att du för tillfället inte är ansluten, gula pilar betyder att du har låg ID (brandvägg) och gröna pilarna betyder att du har högt ID (Den optimala anslutningstypen)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Inte ansluten ..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Just nu ansluten server."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Sök"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Namn:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Lokal"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Global"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Utökade Parametrar"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Filtrering"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Filtyp"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Arkiv"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Audio"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-avbildningar"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Bilder"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Program"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Texter"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videoklipp"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Filändelse"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Min storlek"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Max storlek"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Filtrerresultat"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Invertera resultat"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Dölj kända filer"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Starta"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Mer"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Stoppa"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Hämta"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Återställ fält"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultat"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Rensar färdiga nedladdningar"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Filkällor:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Allmänt"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Hela namnet :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-fil :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Hash :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Filstorlek :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Överför"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Partfilestatus :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Senast sedd komplett :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Hittade Källor :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Källor som överför :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Filepart-antal :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Tillgänglig :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Hämta Aktiv Tid: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Överförd :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Färdig storlek :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent korruptionshantering"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Förlorat till korruption :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Vunnits genom komprimering :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Paket sparad av I.C.H. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Delningar: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Förfrågningar"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Godkända förfrågningar"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Överförd data"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Delningsförhållande"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "kompletta Källor"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Delade filer"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", Ladda upp: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Inte betygsatt"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Titel :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Filnamn"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Övertagande"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Städa"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Verkställ"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Ok"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Kommentera/Betygsätt fil (Text kommer att vara synlig för alla användare)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3595,1269 +3511,1265 @@ msgstr ""
 "För en film kan du berätta om dess längd, innehåll, språk ... \n"
 "och om det är en bluff, kan du berätta det till andra användare av aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Filkvalitet"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Inte betygsatt"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Ogiltig / Korrupt / Bluff"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Dålig"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Duglig"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Bra"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Utmärkt"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Välj filbetyg eller berätta om filen är felaktig..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Frånkopplad från Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Hämtar, vänta ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Okänd storlek"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Nödvändig information"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-adress :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Ytterligare information"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Användarnamn :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Lägg till"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Uppladdningshastighet"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Statistikträd"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Användarnamn:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Klientprogramvara:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Klientversion:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-adress:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Användar-ID"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Server-IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Servernamn:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Fördunkling:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Överföringar till klienten"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Aktuella begäran:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Genomsnittlig uppladdningshastighet:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Genomsnittliga nedladdningshastighet:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Skickat (session):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Hämtat (session):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Skickat (totalt):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Hämtat (totalt):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Poäng"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "DL/UP-modifierare:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Säker ident:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Kö-rang:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Kö-poäng:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Smeknamn"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - multiplattforms Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Detta är det namn som andra användare ser när du ansluter till dig."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Språk: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Fördröjningen innan visning av verktygstips."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Detta anger det språk som används på kontroller."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Sök efter ny version vid start"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Aktivering av detta kommer att få aMule att leta efter en ny version vid start"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Starta minimerad."
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Vid aktivering av detta startar aMule minimerad vid start."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Fråga vid avslut"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Gör så att aMule frågar innan du avslutar programmet."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Aktivera fack-Ikon"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Detta Aktiverar/Inaktiverar systemfält- (eller aktivitetsfält-) ikonen."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Dölj programfönstret när stängningsknapp trycks"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Minimera till Ikonen"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Aktivering av detta gör så att aMule minimeras till systemfältet, snarare än aktivitetsfältet."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Tooltip fördröjningstid: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "sekunder"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Webbläsarval"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Öppna i ny flik om möjligt"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Öppna webbsidan i en ny flik istället för ett nytt fönster när det är möjligt"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Videouppspelare"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Bandbreddsbegränsningar"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Spårallokering"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portar"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Detta är standard ed2k-port och kan inte avaktiveras."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "UDP-port för serverförfrågningar (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Denna UDP-port används under utökade ed2k-förfrågningar och Kadnätverk"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP-port (tillval):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Max källor per hämtad fil:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Autoanslut vid start"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Återanslut vid nedkoppling"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Ta bort död server efter"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "försök"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Lista"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Uppdatera serverlistan vid anslutning till en server"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Uppdatera serverlistan när en klient ansluter"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Använd prioriteringssystem"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Använda smart LowID kontroll vid anslutning"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Säker anslutning"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Autoanslut endast till servrar i statisk-listan"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Ställ in hög prioritet på manuellt tillagda servrar"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Lägg till filer för nerladdning i pausläge"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Lägg till filer för nerladdning med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Försök att hämta första och sista bitarna först"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Börja nästa pausade fil när en fil är klar"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Från samma kategori"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "I alfabetisk ordning"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Förallokera diskutrymme för nya filer"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "För nya filer förallokeras diskutrymme för hela filen, detta minskar fragmentering"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Stoppa nedladdningar när ledigt diskutrymme når "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Välj detta om du vill aMule att kontrollera diskutrymmet"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Ange här min diskutrymme."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Spara 10 källor för sällsynta filer (<20 källor)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Uppladdningar"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Lägg till nya delade filer med automatisk prioritet"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Intelligent Corruption Handling (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Aktivera"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Avancerad I.C.H. litar på varje hash (rekommenderas inte)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Delade mappar"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Högerklicka på mappikonen för rekursiv delning)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Dela ut dolda filer"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Diagram"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Uppdateringsfördröjning: 5 sekunder"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Tid för genomsnittlig graf: 100 minuter"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Anslutningar Diagramskala: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Hämtningsgrafskala:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Uppladdningsgraf-skala:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Färger: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Bakgrund"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Rutnät"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Hämtning nu"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Hämtningar session, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Hämtningar nu"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Hämtningar nu, medelvärde"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Systray Ikon Speedbar"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Kad-noder nuvarande"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Kad-noder körs"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Välj"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Träd"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Antal klientversioner visas (0 = obegränsat)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! VARNING !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Max nya anslutningar / 5 sek"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Filbuffertstorlek: 240000 bytes"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Uppladdningsköstorlek: 5000 klienter"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktivera"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Inaktivera datorns inställda standby-läge"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Skin att använda: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Visa \"Snabb eD2k-Länkhanterare\" i varje fönster."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Visa utökad information på kategoriflikar"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Visa programversionen på titel"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Visa överföringshastigheter på titel"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Före programnamn"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Efter programnamn"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Visa overheadsbandbredd"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Vertikal verktygsfältsorientering"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Nedladdningsköfiler"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Visa framsteg i procent"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Visa förloppsindikator"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Platt"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Neka gäståtkomst"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Gästlösenord för webbservern"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4865,11 +4777,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4879,826 +4791,826 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Inaktiverad [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "byte"
 msgstr[1] "bytes"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "byte/sek"
 msgstr[1] "bytes/sek"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sekunder"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "minuter"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "timmar"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagar"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "alla"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "alla andra"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Ofullständig"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Stoppad"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Video"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Arkiv"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Text"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Använder config dir: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Väntar på att partfile-konverterings-tråd ska dö..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Importerar %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Läsa temp-mappen"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Hämta grundläggande information från nedladdnings-infofil"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Skapa målfilen"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Ladda data från gamla hämtade filen (%u av %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Spara datablock till ny enskilld nerladdningsfil (%u av %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Hämtar källor nerladningasfilsinformation"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Lägger till nerladdning och sparar ny partfile"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Importera partfiles"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Tillstånd"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Filehash"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disk: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Välj en mapp för att söka efter temporära hämtningar! (Undermappar kommer att ingå)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Vill du radera källfilerna för framgångsrikt importerade nedladdningar?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Ta bort källor?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "FEL: Misslyckades med att skapa partfile"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Försöker ladda backup av met-fil från %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "FEL: Det gick inte att öppna part.met-fil: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "FEL: part.met fil är 0 i storlek: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "FEL: Ogiltig part.met-fil-version: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "Fel: %s ( %s ) är korrupt (dåliga taggar: %s ), kan inte läsa in filen."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "FEL: %s ( %s ) är skadad (fel tagcount), oförmögen att läsa in filen."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Försöker återhämta sig filinformation ..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Återstället icke namngiven fil - kommer att försöka återställa det som RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Återvann all tillgängliga filinformation :D - Försöker att använda filen..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Det går inte att återställa filinformation :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Misslyckades med att öppna %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "VARNING: %s kan vara skadad (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "FEL vid sparning av partfile: %s ( %s ==> %s )"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "IO-fel vid sparandet av partfile: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Det gick inte att spara part.met-frö-fil för %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "Sparade %i käll-frö för partfile: %s (%s)"
 msgstr[1] "Sparade %i käll-frön för partfile: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Kan inte läsa frö-filen för Partfile %s ( %s )"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Fel vid läsning partfile frö-fil ( %s - %s ): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Hittade skadade delen (%d) i %d del fil %s - FileResultHash |%s| FileHash |%s|"
 msgstr[1] "Hittade skadade delen (%d) i %d dels fil %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Hittade avslutande del (%i) i %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Klar med återhashning av %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Oväntat fel vid färdigställande %s . Fil pausad"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Hämtat färdigt: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Hämtat färdigt: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Tar bort fil: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "VARNING: Det går inte att hasha nedladdade delen - hashset ofullständig för '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "FEL: Det går inte att hasha nedladdade delen - hashset ofullständig (%s). Detta bör aldrig hända"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "EOF medan hashning av hämtade del %u med längd %u (max %u) av partfile %s med längd %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "VARNING: Inte tillräckligt med ledigt diskutrymme! Pausa fil: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Nedladdade del %i är skadad i fil: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Återvunnen skadad del %i för %s -> Sparade bytes: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Allokera"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Otillräckligt diskutrymme"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Nedladdad"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Anslutning"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kataloger"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servrar"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Filer"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Säkerhet"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Filter"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Fjärrkontroller"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Onlinesignatur"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Avancerad"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Händelser"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Felsökning"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5708,15 +5620,15 @@ msgstr ""
 "    %PARTFILE - hela sökvägen till filen\n"
 "    %PARTNAME - endast filnamnet"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5732,35 +5644,35 @@ msgstr ""
 "aMule kommer fungera bra utan att justera några av\n"
 "dessa inställningar."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Det gick inte att ansluta Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från Cfg till widget med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Den typen av proxy du ansluter till"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Det gick inte att överföra data från widget till Cfg med ID %d och nyckel %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Kontrollerar lösenord\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5768,41 +5680,41 @@ msgstr ""
 "aMule måste startas om för att aktivera dessa ändringar:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP-port ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Extern anslutningsport ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Extern anslutningsacceptans ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Extern anslutningsgränssnitt ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Stöd för fördunkling av protokoll ändrad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5810,7 +5722,7 @@ msgstr ""
 "Din automatiska uppdateringsserverlista är tom.\n"
 "'Auto-uppdateringsserverlista vid start' inaktiveras."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5818,33 +5730,33 @@ msgstr ""
 "Du har aktiverat externa anslutningar men har inte angett ett lösenord.\n"
 "External anslutningar kan inte aktiveras om inte ett giltigt lösenord anges."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Språk ändrat.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Mappen Temp ändrades.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K-nätverk aktiverad.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Fel protokoll-version"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5852,7 +5764,7 @@ msgstr ""
 "Både eD2k- och Kad-nätverk är inaktiverade.\n"
 "Du kommer inte att kunna ansluta förrän du aktiverar åtminstone en av dem."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5860,7 +5772,7 @@ msgstr ""
 "Kad startar inte om din UDP-port är inaktiverad.\n"
 "Aktivra UDP-port eller inaktivera Kad."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5870,69 +5782,69 @@ msgstr ""
 "Du MÅSTE starta om aMule nu.\n"
 "Om du inte startar nu, klaga inte om något dåligt händer.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Auto Refresh startad"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Mapp för temporära nerladdningsfiler"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Lösenord sparad och extern anslutning aktiverad."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5942,66 +5854,66 @@ msgstr ""
 "Vänligen fylla i åtminstone en URL för att peka på en giltig server.met-fil.\n"
 "Klicka på knappen \"lista\" i denna kryssruta för att ange en URL."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Temporära filer"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Inkommande filer"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Online-signaturer"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Välj en mapp för %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Bläddra efter videospelare"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Välj webbläsare"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Körbar %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Systemets standard"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Redigera serverlista"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6009,1208 +5921,1207 @@ msgstr ""
 "Lägg här URL för att hämta server.met filer.\n"
 "Endast en webbadress på varje rad."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Kompletta källor"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Status:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Uppdateringsfördröjning: %d sekund"
 msgstr[1] "Uppdateringsfördröjning: %d sekunder"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Tid för genomsnittlig graf: %d minut"
 msgstr[1] "Tid för genomsnittlig graf: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Anslutningsdiagramskala: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Filbuffertstorlek: %d byte"
 msgstr[1] "Filbuffertstorlek: %d bytes"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Uppladdningsköstorlek: %d klient"
 msgstr[1] "Uppladdningsköstorlek: %d klienter"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Serveranslutninguppdateringsintervall: %d minut"
 msgstr[1] "Serveranslutninguppdateringsintervall: %d minuter"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Serveranslutningsuppdateringsintervall: Inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "inaktiverad"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "Exekvera kommando på '%s' händelse"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Aktivera kommandokörning på kärnan"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Kommando till kärnan:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Aktivera kommandokörning via GUI"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "GUI kommando:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Följande variabler kommer att ersättas:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delade mappar"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Sökvarning"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Huvud"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k-sökning kan inte göras om eD2k inte är ansluten"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Sökord för sökning: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Oväntat fel vid försöket med Kadsökningen: "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Inte betygsatt"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Nedladdning i kategori"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hämta %s för den här filen:"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Sök relaterade filer (eD2k, lokal server)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Markera som känd fil"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiera eD2k-länken till urklipp"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du är ansluten till den server som du försöker ta bort. Vänligen koppla ifrån först."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "Avbryten"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Ny"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Det gick inte att ansluta till några fördunkliade servrar i listan. Gör ett nytt försök utan obfuscation."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Det gick inte att ansluta till några fördunkliade servrar i listan. Gör ett nytt försök utan obfuscation."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Misslyckades med att ansluta till alla listade servrar. Gör ett nytt försök."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Misslyckades med att ansluta till alla listade servrar. Gör ett nytt försök."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-nätverket inaktiverad i inställnigarna, ansluter inte."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Inga giltiga servrar att ansluta till finns i serverlista"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "Ansluten till %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "Anslutning etablerad med: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Allvarligt fel vid försök att ansluta. Internet-anslutningen kan vara nere"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Förlorade anslutningen till %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) verkar vara död."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) verkar vara full."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Automatisk anslutning till servern testas igen om %d sekund"
 msgstr[1] "Automatisk anslutning till servern testas igen om %d sekunder"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "Anslutning till %s (%s:%i) misslyckades."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "FEL: Socket ogiltig vid timeout-kontroll"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Anslutningsförsöket till %s (%s:%i) tog för lång tid."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Mottog sent resultat av DNS-sökning, förkastar."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Laddar server.met fil: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met filen hittades inte!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Det gick inte att läsa in server.met filen '%s', okänt format påträffades."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Det gick inte att öppna server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met filen är korrupt, hittade ogiltig versiontag: 0x%x , storlek %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i server hittad i server.met"
 msgstr[1] "%i servrar hittade i server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d server tillagd"
 msgstr[1] "%d servrar tillagda"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Fel: filen 'server.met' är skadad: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "IO fel vid läsning av 'server.met': "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Server inte tillagd: [%s:%d] anger inte en giltig port."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Server inte tillagd: IP på [%s:%d] filtrerades eller är ogiltig."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Server inte tilllagt: Server med matchande IP:Port [%s:%d] hittades i listan."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Server tillagd: server på [%s:%d] med namnet '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Du är ansluten till den server som du försöker ta bort. Vänligen koppla ifrån först."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Misslyckades med att öppna '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Det gick inte att spara server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Ogiltig URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Färdig med hämtningen av serverlistan från %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Ingen serverlistadresspost i 'addresses.dat' hittades. Klistra in en giltig serverlista adressen i denna fil för att auto-uppdatera din serverlista"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Börja ladda ner serverlista från %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "VARNING: ogiltig URL som angavs för auto-uppdatering av servrar: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Ingen giltig server.met auto-nedladdnings-url i addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Det gick inte att hämta serverlistan från %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Lokal server filtreras av IPFilters, återansluter till en annan server!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernamn"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adress"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Beskrivning"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Användare"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statisk"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Du är ansluten till en server som du försöker ta bort. Koppla ifrån först. Servern togs INTE bort."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Okänt namn)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Är du säker på att du vill ta bort den statiska servern %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Servrar (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Server"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Anslut till server"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Markera servern som statisk"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Markera servern som icke-statisk"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markera servrar som statiska"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markera servrar som icke-statiska"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Ta bort server"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ta bort servrar"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Ta bort alla servrar"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Kopiera eD2k länkar till Urklipp"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Återanslut till server"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Är du säker på att du vill ta bort alla servrar?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Är du säker på att du vill ta bort vald server?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Är du säker på att du vill ta bort valda servrar?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "FEL: %s ( %s ) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "VARNING: %s ( %s ) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Ny clientid är %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "VARNING: Du har fått low-ID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tMest sannolikt är det på grund av att du är bakom en brandvägg eller router."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tFör mer information, referera till https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Okänd server info mottagen! - för kort"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "Tagit emot %d ny server"
 msgstr[1] "Tagit emot %d nya servrar"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Lagring av serverlista klar."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Servern avvisade senaste kommandot"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Boguspaket/skräppaket mottagen från servern: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Ohanterat fel vid bearbetning av paket från servern: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Det går inte att skapa DNS tråd för anslutning till %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Server IP %s (%s) är filtrerad. Ansluter inte."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "med hjälp av protokollfördunkling."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Ansluter till %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Det gick inte att hitta dns för server %s: Kan inte ansluta!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule-logg"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Server inte tilllagd: Ingen IP eller värdnamn angiven."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Server inte tilllagd: Ogiltig serverport angiven."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k Status:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Anslutningstillstånd:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Ansluten"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia-status:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "Kör på LAN-läge"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Kör"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia klient-ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Status:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Anslutningstillstånd:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Bakom brandvägg - öppna TCP-port %d i din router eller brandvägg"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP anslutningstillstånd:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Bakom brandvägg - öppna UDP-port %d i din router eller brandvägg"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Brandväggstillstånd: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Ingen kompis krävs - TCP-port öppen"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Ingen kompis krävs - UDP-port öppen"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Ingen kompis"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Ansluter till vän"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ansluten till vän på %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Indexerade källor:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Indexerade nyckelord:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Indexerade anteckningar:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Indexerad belastning:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Genomsnittliga Användare:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Genomsnittliga Filer:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Kör inte"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Lägga fil %s till utdelning"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Hittade %i känd delad fil, %i okänd"
 msgstr[1] "Hittade %i kända delade filer, %i okänd"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "FEL: Försökte dela %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Delad mapp hittades inte, hoppar över: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Inga delbara filer hittade i mappen: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Användarnamn"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hämtningshastighet"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uppladdningshastighet"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Tillgängliga delar"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Uppladdningsstatus"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Hämtningsstatus"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Lokalt filnamn"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Lista på delade filer"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Erhållna delar"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Mappsökväg"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Lägg till Kommentar/Betyg"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Redigera Kommentar/Betyg"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Byt namn"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lägg till filer i samlingen för att överföringslistan"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Kopiera magnet &URI till urklipp"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Kopiera eD2k-länk till urklipp (&Source)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Kopiera eD2k-länk till urklipp (Source) (&With Crypt alternativ)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Kopiera eD2k-länk till urklipp (&Hostname)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Kopiera eD2k-länk till Urklipp (värdnamn) (Med &Crypt alternativ)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopiera eD2k-länken till urklipp (&AICH info)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Kopiera eD2k-länk till urklipp (&AICH info + källa)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Du behöver en HighID att skapa en giltig sourcelink"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Fjärrfilnamn"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Överförd data (Session (Total)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Totalt Overhead (paket): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Filbegäran Overhead (paket): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Source Exchange Overhead (paket): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Server Overhead (paket): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad Overhead (paket): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Crypt overhead (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktiva uppladdningar: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Väntande uppladdningar: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Totalt framgångsrika uppladdningssessioner: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Totalt misslyckade uppladdningssessioner: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Genomsnittlig uppladdningstid: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Nedladdad data (Session (Total)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Hittade Källor: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktiva nedladdningar (chunks): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Session UL: DL förhållande (Total): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Genomsnittliga nedladdningshastighet (Session): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Genomsnittlig uppladdningshastighet (Session): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Max nedladdningshastighet (Session): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Max uppladdningshastighet (Session): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Återansluter: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Tid sedan första överföringen: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "Ansluten till server sedan: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktiva anslutningar (uppskattning): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Max anslutningsgräns har uppnåtts: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Genomsnittliga anslutningar (uppskattning): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Toppar anslutningar (uppskattning): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Klienter"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Okänd: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Filtrerade: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Bannlysta: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Totalt: %i Kända: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Fungerande servrar: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Inte fungerande servrar: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Totalt: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Borttagna servrar: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Filtrerade servrar: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Användare på fungerande servrar: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Filer på fungerande servrar: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Totalt antal användare: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Totalt antal filer: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Serveranvändade: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Antal Delade filer: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Total storlek på Delade filer: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Genomsnittlig filstorlek: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Operativsystem"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Inte mottagen"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktiva anslutningar (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Inte tillgänglig"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Aldrig"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Kommando '%s' med pid '%d' är klar med statuskoden '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Kör <str> och avsluta."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Ogiltigt IP-format. Använd xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Detta kommando kräver ett argument. Giltiga argument. 'all', filename, eller ett nummer.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Bearbetning efter hash: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Bearbetning efter filnamn: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Detta kommando kräver ett argument. Giltiga argument: a file hash.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Inte ett giltigt nummer\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Inte ett giltigt hash (längd ska vara exakt 32 tecken)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7221,7 +7132,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7232,7 +7143,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7240,82 +7151,80 @@ msgstr ""
 "Ingen söktyp vald.\n"
 "Skriv 'help search' för att få mer hjälp.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Hämta fil: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Begäran misslyckades med ett okänt fel."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Operationen var lyckad."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Begäran misslyckades med följande fel: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "IP-filtrering för klienterna är %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "AV"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "PÅ"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "IP-filtrering för servrar är %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Aktuell IPFilternivå är %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Bandbreddsgränser: Upp: %u kB/s, Ner: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Ansluten till %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Ansluter nu"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "via brandvägg"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7324,7 +7233,7 @@ msgstr ""
 "\n"
 "Hämtningar:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7333,7 +7242,7 @@ msgstr ""
 "\n"
 "Uppladdningar:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7342,7 +7251,7 @@ msgstr ""
 "\n"
 "Klienter i kö:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7351,46 +7260,46 @@ msgstr ""
 "\n"
 "Totalt källor:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[PartFile]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Antal sökresultat: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Sökets framstigande: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Framskridandet för söket är inte tillgänglig"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Fick ett okänt svar från servern, Opcode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Visa kort statusinformation."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Visa anslutningsstatus, nuvarande upp/nedladdningshastigheter, etc.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Visa fullständigt statistikträd."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7404,11 +7313,11 @@ msgstr ""
 "\n"
 "Exempel: 'statistics 5' kommer att visa endast de översta 5 versionerna för varje klienttyp.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Stäng ner aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7418,35 +7327,35 @@ msgstr ""
 "Detta kommer också stänga av textklienten, eftersom det är oanvändbar utan en\n"
 "körande kärna.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Ladda om det givna objektet."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Ladda om listan med delade filer."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Ladda om IP-filtreringtabell."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "Ladda om nuvarande IP-filtreringstabell."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Uppdatera IP-filtreringstabell från URL."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Om URL utelämnas används URLen från inställningarna."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Anslut till nätverket."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7458,35 +7367,35 @@ msgstr ""
 "endast den servern. IP måste vara en punktad decimal-IPv4-adress,\n"
 "eller ett fungerande DNS-namn."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Anslut endast till eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Anslut endast till Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Koppla ifrån nätverket."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Detta kommer att koppla ifrån alla nätverk som nu är anslutna.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Koppla endast ifrån eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Koppla endast ifrån Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Lägg till en ed2k- eller magnetlänk till kärnan."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7504,51 +7413,51 @@ msgstr ""
 "\n"
 "Magnetlänken måste innehålla eD2k-hash och fillängd.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Ange ett inställningvärde."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "Ange IP-filtreringsinställningar."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Slå på IP-filtrering för både klienter och servrar."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Stäng av IP-filtrering för både klienter och servrar."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Aktivera/inaktivera IP-filtrering för klienter."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Slå på IP-filtrering för klienter."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Stäng av IP-filtrering för klienter."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Aktivera/inaktivera IP-filtrering för servrar."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Slå på IP-filtrering för servrar."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Stäng av IP-filtrering för servrar."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Välj IP-filtreringsnivå."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7556,73 +7465,73 @@ msgstr ""
 "Giltiga filtreringsnivåer är i intervallet 0-255, och dess standard (initialt)\n"
 "värde är 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Sätt bandbreddsgränser."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Det värde som ges till dessa kommandon måste vara i kilobyte/s.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Sätt gräns för bandbredd."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Det givna värdet måste vara i kilobyte/sekund.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Sätt gräns för nedladdningsbandbredd."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Det givna värdet måste vara i kilobyte/sekund.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Hämta och visa ett inställningsvärde."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "Hämta IP-filtreringsinställningar."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hämta IP-filtreringstillstånd för både klienter och servrar."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Hämta IP-filtreringstillstånd endast för klienter."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Hämta IP-filtreringstillstånd endast för servrar."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "Hämta IP-filtreringsnivå."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Hämta bandbreddbegränsningar."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Utför en sökning."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7641,44 +7550,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Utför en global sökning."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Utför en lokal sökning"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Utför en kadsökning"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Visar resultaten av den senaste sökningen."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Visa sökförloppet."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Börja ladda ner en fil"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7686,80 +7595,80 @@ msgstr ""
 "Numret på en fil från den senaste sökningen måste anges\n"
 "Exempel.. 'download 12' kommer att börja ladda ner filen med nummer 12 i den föregående sökningen.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Pausa hämtning."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Fortsätt hämtning."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Avbryt hämtning."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Ställ in hämtningsprioritet."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Sätt prioritet för en nedladdning till Låg, Normal, Hög eller Auto.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Sätt prioritet till låg."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Sätt prioritet till det normala."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Sätt prioritet till högt."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Sätt prioritet till auto."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Visa köer/listor."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Visa upp-/ner-laddningskö, serverlistan eller listan över delade filer.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Visa sändningskö."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Visa hämtningskö."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Visa logg."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Visa serverlista."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Visa listan med delade filer."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Nollställ logg."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Utfasad kommando, använda '%s' i stället."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7768,261 +7677,258 @@ msgstr ""
 "Detta är ett föråldrat kommando, och kan tas bort i framtiden.\n"
 "Använd '%s' istället.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule textklient"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konvertera gamla AICH-hashsets i '%s' till 64b i '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "VARNING: filnamn '%s' är ogiltig och har döpts om till '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "VARNING: Filen '%s' finns redan, ny fil omdöpt till '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Är du säker på att du vill avbryta och ta bort alla filer i denna kategori?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Konfirmation Krävs"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Endast 99 kategorier stöds."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "För många kategorier!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Alla andra"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Välj vyfiltret"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Lägg till kategori"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Redigera kategori"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Ta bort kategori"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "HashSet begärd för okänd fil: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Återupptar uppladdning av filen: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Uppskjuter uppladdning av filen: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Det gick inte att köra kommandot '%s' på '%s' händelsen."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Nedladdning avslutad"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Den fullständiga sökvägen till filen."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Namnet på filen utan sökvägskomponent."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "eD2k-hash av filen."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Storleken på filen i bytes."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Ackumulerad nedladdningsaktivitetstid."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Ny chatt startad"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Meddelandeavsändare."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Slut på utrymme"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Diskpartition."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Fel vid slutföring"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Bearbetar filnummer %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Du har bett om en del-hashar (används endast för filer> 9,5 MB)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> icke existerande fil!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, aMule-eD2k-länk-skapare"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Välkommen!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Inparametrar"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Fil att Hash:a"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Lägg till valfria URLer för den här filen"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Skriv in filen du vill beräkna eD2k-länk för"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Skriv in URLen som du vill lägga till eD2k-länken: Lägg till / i slutet för att låta aLinkCreator bifoga det aktuella filnamnet"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Skapa länk med part-hashes"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Hjälpa till att sprida nya och ovanliga filer snabbare, på bekostnad av en ökad länk storlek"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 Fil-hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k-fil-hash"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k-länk"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Spara"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Kopiera till urklipp"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Öppna"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Öppna en fil för att beräkna dess ed2k-länk"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Kopiera beräknad ED2K-adress till urklipp"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Spara som"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Spara beräknad ED2K-länk till fil"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Om aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Välj den fil du vill beräkna ED2K-länk för"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Det går inte att öppna urklipp"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Inget att kopiera just nu!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Välj filen för din beräknade ED2K-länk"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Kunde inte öppna "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Vänligen ange en icke tom filnamn"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Inget att spara just nu!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8042,167 +7948,159 @@ msgstr ""
 "\n"
 "Distribuerad under GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Hashar..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator fungerar för dig"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Räknar ut MD4-Hash ..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Räknar ut ED2K-Hashar ..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Avbruten!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Klar om %.2f s"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Du har redan lagt till denna URL!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Vänligen ange en icke tom URL"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Kunde inte öppna %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "Slut på minne vid beräkning ed2k hash!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i dag(ar) %i timme(ar) %i min %i s"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02umin %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule Onlinestatistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Maximal DL takt sedan wxCas körts"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Absolut Maximal DL takt under wxCas tidigare körningar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Nollställ"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "System"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Stoppa Auto Refresh"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Spara Onlinestatistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Skriv ut Onlinestatistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Preferensinställningar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Om wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Starta Auto Refresh"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Auto Refresh stoppad"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Auto Refresh startad"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Spara Statistikbild"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule Online-statistik"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8210,11 +8108,11 @@ msgstr ""
 "Det fanns ett problem med utskriften.\n"
 "Är kanske den aktuella skrivaren inte korrekt inställd?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Utskrift"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8232,403 +8130,392 @@ msgstr ""
 "\n"
 "Distribuerad under GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Oh nej, aMule körs inte..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule körs"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule kör, men är frånkopplad"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule ansluter..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Oh nej, status för aMule är okänd..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " har kört i "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " är stoppad !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " är inte ansluten!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " ansluter..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " gör någonting konstigt, kontrollera det!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " är ansluten till "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "av"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " är på "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " med "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Totalt Laddat ner: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Ladda upp: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Session nerladdning: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Hämta: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Upp: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Delningar: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " fil(er), klienter i kö: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Tid: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " på "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Genomsnittlig systembelastning (1-5-15 min): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Drifttid: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Mapp som innehåller amulesig.dat-fil"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Skriv in den mapp där din amulesig.dat-fil finns"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Uppdateringsfrekvens intervall i sekunder"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Generera en stat-bild vid varje uppdateringshändelse"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Skriv in den mapp där du vill generera statistikbilden"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Ladda periodiskt din stat-bild till FTP-servern"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP URL"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP sökväg"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Skriv in URL-adressen till din FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Ange här katalogen var du vill spara din stat-bild på FTP-servern"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Användare"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Här anger du användarnamn för att logga in på din FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Skriv in användarens lösenord för att logga in på din FTP-server"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP-uppdateringshastighetsintervall i minuter"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Validera"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Mapp som innehåller din signaturfil"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Mapp för skapande av statistikbild"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Laddar mall <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Webbserverns HTTP-port"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Använd UPnP port forwarding på webbserverport"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP-port"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Lösenord för full tillgång till webbservern"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Gästlösenord för webbservern"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Tillåt gäståtkomst"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Neka gäståtkomst"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Ladda/spara webbserverinställningar från / till fjärr-aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule konfigurationsfilssökväg. ANVÄND INTE DIREKT!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Inaktivera PHP-tolk (föråldrat)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Återkompilera PHP-sidor vid varje begäran"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule webbserver"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "webbklientanslutning accepterad\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "FEL: kan inte acceptera webbklientanslutning\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Begäran misslyckades med följande fel: %s ."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Indexfil hittades inte: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Session löpt ut - begär inloggning\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Session ok, loggade in\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Session ok, inte inloggad\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Ingen session öppnades - kommer att begära inloggning\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Session skapad - begär inloggning\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Bearbetar begäran [original]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Inget lösenord angiven, inloggning kommer inte att tillåtas."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Lösenords-hash ogiltig\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Lösenord OK\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Lösenord dålig\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Du har inte anget något lösenord. Tomt lösenord är inte tillåtet.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Utloggning begärd\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Bearbetar begäran [omdirigerad]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "Anslutningen misslyckades "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,100 +17,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "நண்பரைச் சேர்"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "நீங்கள் சரியான ஐபி மற்றும் துறைமுகம் உள்ளிட வேண்டும்!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "தகவல்"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "குறிப்பிட்ட பயனர்கொத்து தவறானது!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -119,47 +119,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -168,172 +167,165 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,269 +335,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "பிழை: வெளிப்புற இணைப்புகள் முடக்கப்பட்டிருக்கும் போது aMule deemon ஐப் பயன்படுத்த முடியாது. வெளிப்புற இணைப்புகளை இயக்க, ஒரு சாதாரண aMule ஐப் பயன்படுத்தவும், --ec-config விருப்பத்துடன் அமல் செய்யத் தொடங்கவும் அல்லது ~/.aMule/amule.conf கோப்பில் \"AcceptExternalConnections\" விசையை 1 ஆக அமை"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,191 +603,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -808,1204 +789,1177 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "பயனர் %s (%u) உங்கள் பகிரப்பட்ட கோப்பகங்கள்-பட்டியல் -> ஏற்கப்பட்டது"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "பயனர் %s (%u) உங்கள் பகிரப்பட்ட கோப்பகங்கள்-பட்டியலைக் கோரினார் -> மறுக்கப்பட்டது"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "பயனர் %s (%u) உங்கள் பகிரப்பட்ட கோப்புகளின் பட்டியலை '%s' கோப்பகத்திற்காக கோரினார் -> மறுக்கப்பட்டது"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "பயனர் %s (%u) பகிர்ந்த கோப்பகம் '%s'"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "பயனர் %s (%u பகிரப்பட்ட கோப்பகம்/கோப்புகள் பட்டியலுக்கான அணுகலை மறுத்தனர்"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr ""
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr ""
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr ""
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "காட்"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr ""
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2013,23 +1967,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2037,59 +1991,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2098,2647 +2052,2605 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "அகோவேறுகழுதை இயங்கும் புரவலன். (இயல்புநிலை: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 msgid "Connection & bandwidth"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 msgid "Connection speed:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u ஐபி-வரம்பு ஏற்றப்பட்டது '%s' இலிருந்து."
 msgstr[1] "%u ஐபி-வரம்புகள் ஏற்றப்பட்டது '%s' இலிருந்து."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "அகோவேறுகழுதையை மறை"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr ""
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr ""
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr ""
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr ""
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr ""
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr ""
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr ""
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr ""
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr ""
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4746,11 +4658,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4760,836 +4672,836 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr ""
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr ""
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "முடிக்கப்பட்ட பகுதி (%i) கண்டறியப்பட்டது %s இல்"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "முடிந்ததாக %u பகுதி '%s' இன் குறிக்கப்பட்டது, ஆனால் பார்ட்ஃபைல் எதிர்பார்த்ததை விடக் குறைவாக உள்ளது (%llu பைட்டுகள் உள்ளன, %llu தேவை); மீண்டும் பதிவிறக்குவதற்கான இடைவெளியை மீண்டும் திறக்கிறது."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "%u பகுதி %u (அதிகஅளவு %u) நீளம் கொண்ட கொத்து செய்யும் போது கோப்புமுடிவு ஆனது நீளம் கொண்ட '%s' பகுதி கோப்பு %u: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: சிதைந்த பகுதி %i %s க்காக மீட்கப்பட்டது -> சேமிக்கப்பட்ட பைட்டுகள்: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5599,1444 +5511,1443 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr ""
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "சேவையகம் சேர்க்கப்பட்டது: [%s:%d] இல் உள்ள சேவையகம் '%s' என்ற பெயரைப் பயன்படுத்தி."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "%s சேவையகங்களுக்கான dns ஐத் தீர்க்க முடியவில்லை: இணைக்க முடியவில்லை!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 msgid "Connected since:"
 msgstr ""
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr ""
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr ""
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "கட்டளை '%s' pid '%d' உடன் '%d' நிலைக் குறியீட்டுடன் முடிந்தது."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7044,7 +6955,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7052,155 +6963,153 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7209,46 +7118,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "அகோவேறுகழுதை ஐ மூடவும்."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7256,35 +7165,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7295,121 +7204,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7428,383 +7337,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr ""
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr ""
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr ""
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7816,177 +7722,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f மெபை"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -7997,400 +7895,389 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "தொலைநிலை aMule இலிருந்து/வரை வலை சேவையக அமைப்புகளை ஏற்றவும்/சேமிக்கவும்"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -20,19 +20,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.9\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "aMule Hakkında"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule uzak denetimi "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Bilgileri:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -40,7 +40,7 @@ msgstr ""
 "eMule üzerine kurulu 'Sistem-Üstü' p2p yazılımı \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -48,76 +48,76 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Ekibi \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "aMule'nin üzerinde kurulduğu parçalar: \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: XOR matrisi üzerine kurulu eşten eşe iletişim.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Web Sitesi:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Forum:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "Belgelendirme:"
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "Hata raporları:"
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "Yeni sürümü denetlemek için tıklayın."
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "Güncellemeleri kontrol et"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "Güncellemeler kontrol ediliyor…"
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "En yeni sürümü kullanıyorsunuz."
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "Yeni bir sürüm (%s) mevcuttur:"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "Güncellemeler kontrol edilemedi. Lütfen daha sonra tekrar deneyin."
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Arkadaş Ekle"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Geçerli bir IP ve port girmelisiniz!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Bilgi"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Belirlenen kullanıcı adreslemesi geçersiz!"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -131,47 +131,46 @@ msgstr ""
 "\n"
 "Masaüstü birleşimi şimdi kurulsun mu?"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "aMule uygulama menünüze eklensin mi?"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "Kur"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "Şimdi değil"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "Tekrar sorma"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "Masaüstü birleşimi kurulamaz: APPDIR ortam değişkeni tanımlı değil. Bu, genelde AppImage başlatılmasının standart olmayan bir yolla yapıldığı manasına gelir."
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "aMule birleşimi başarısız"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "Masaüstü birleşimi kurulamaz: %s oluşturulması başarısız oldu. Ev dizininizin yazılabilir olduğundan emin olun."
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "Masaüstü birleşimi kurulamaz: %s yazması başarısız oldu. Ev dizininizin yazılabilir olduğundan emin olun."
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage birleşimi: aMule uygulama menünüze ilave edildi (~/.local/bin konumunda %d kabuk kısayolu)."
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -185,103 +184,100 @@ msgstr ""
 "\n"
 "aMule şimdi tekrar başlatılsın mı?"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule kuruldu"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "Şimdi tekrar başlat"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "Daha sonra"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "ED2KBağlantı dosyası açılamadı."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k bağlantılarına ekleyemezsiniz."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Ana uygulamadan çıkılıyor…"
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Amuleweb oturumu pid `%d' ile sonlandırılıyor… "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleweb oturumu öldürülüyor… "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "'%d' pid'sine sahip amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "pid `%d' ile ilişkili amuleapi oturumu sonlandırılıyor… "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule Çıkışında: Çekirdek imha ediliyor."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule kapatılma işlemi tamamlandı."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "aMule çıkışı için hafıza hata raporlama sonuçları:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "aMule eşten eşe trafiği şu arayüze bağlanıyor: %s (HTTP güncellemeleri varsayılan yolu kullanır)"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "Tüm ağ trafiği şu arayüze bağlanıyor: %s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "İKAZ: yapılandırılmış ağ arayüzü '%s' bulunamadı - trafik ona bağlı DEĞİL ve varsayılan yol ile dışarı çıkabilir. Arayüz ismini Tercihler'de kontrol edin."
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlamak yüksek izinler gerektirmektedir ve UYGULANMAMIŞTIR - trafik varsayılan yol ile dışarı çıkabilir. Gerekli yeteneği tanıyın (mesela aMule ikili dosyası üzerinde 'sudo setcap cap_net_raw+ep' komutunu kullanarak) veya yeterli imtiyazlarla çalıştırın."
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "İKAZ: '%s' ağ arayüzüne bağlama yapılamadı - trafik varsayılan yoldan dışarı çıkabilir."
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Bir yapılandırma değişikliği nedeniyle dil ayarınız 'Sistem Varsayılanı'na çevrildi. Üzgünüm. Vallahi…"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Bilgi"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -289,20 +285,19 @@ msgstr ""
 "\n"
 "EC yapılandırması"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Parola ayarlandı ve dış bağlantılar etkinleştirildi."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "UYARI"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -310,51 +305,48 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web sunucusu pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "HATA"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi pid %d üzerinde çalışıyor"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "amuleapi'nın başlangıçta çalışmasını istediniz, fakat amuleapi ikilisi çalıştırılamıyor. Lütfen aMule REST API sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_AMULEAPI=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Belirtilen şu adrese portlar bağlanamıyor: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Port. %u kullanılamıyor. DÜŞÜKID alacaksınız.\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -369,48 +361,48 @@ msgstr ""
 "\n"
 "Ağ ayarlarınıza göz atarak portun giriş ve çıkışlar için açık olup olmadığını denetleyiniz."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "aMule Çevrim içi İmza dosyası oluşturma başarısız."
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Seçilen yerelleştirme görünüşe göre bilgisayarınızda yüklü değil. (Not: Bunu yine de yapmaya çalışacağım)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Hoş geldiniz! aMule %s sürümünü ilk kez kullanıyorsunuz."
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Bu sürüm bir deneme sürümü, her gün güncellenir ve\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "bir şeyleri bozmayacağını veya evinizi yakmayacağını \n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "yahut da köpeğinizi öldürmeyeceğini garanti edemeyiz. Fakat bir *sorun* yaratmayacağını da umuyoruz.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Daha fazla bilgi, destek ve yeni sürümler ana sayfamızda bulunabilir\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io veya IRC kanalımız: irc.libera.chat sunucusunda #aMule \n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Her türlü hatayı bize bildirmekten çekinmeyin https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -418,222 +410,218 @@ msgstr ""
 "Belirlediğiniz Çevrim içi İmza dosyaları dizini GEÇERSİZ!\n"
 " Çevrim içi İmza, ayarlarınızda düzeltene kadar DEVRE DIŞI bırakıldı."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "%s dosyası için diskte yer ayırma başarısız oldu: %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "HATA: Günlük dosyası açılamıyor."
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "UYARI: Günlük dosyası boş, bir şeyler yanlış."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Günlük kaydı silindi"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Sunucu İletisi: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "%s indirilmeyecek; çünkü istenen dosya yeni değil."
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Nod listesini indirme başarısız."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "İndirilen sürüm denetleme dosyasını açma başarısız oldu."
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Bozuk sürüm denetleme dosyası"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "aMule'nin eski bir sürümünü kullanıyorsunuz!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "aMule sürümünüz %i.%i.%i ve en güncel sürüm %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "En güncel sürüm her zaman https://github.com/amule-org/amule/releases/latest adresinde bulunabilir."
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "UYARI: aMuled sürümünüz eski: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "aMule sürümünüz güncel."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Sürüm denetleme dosyasını indirme başarısız oldu."
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Kullanıcılar: %s | Dosyalar: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Kullanıcılar: E: %s K: %s | Dosyalar: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Hiç bir ağ seçilmedi"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "DüşükID ile"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "YüksekID ile"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "Bağlandı: %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "Bağlanıyor: %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "eD2k Bağlantısı kesildi"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kademlia başladı."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kademlia durdu."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "Kademlia ağına bağlanıldı (tamam)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "Kademlia ağına bağlanıldı (Güvenlik duvarı arkasında)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Kademlia bağlantısı kesildi."
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "UDP portu ayarlarda devre dışı bırakılmışsa Kad ağı kullanılamaz. Başlatılmıyor."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "HATA: aMule daemon dış bağlantılar devre dışı bırakıldığında kullanılamaz. Dış Bağlantıları etkinleştirmek için ya aMule'yi, --ec-config seçeneği ile birlikte amuledi başlatarak ya da ~/.aMule/amule.conf dosyasındaki \"AcceptExternalConnections\" seçeneğini 1 olarak ayarlayın."
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "HATA: Dış bağlantıların kullanılabilmesi için geçerli bir parola gerekilidir ve aMule uygulamacığı dış bağlantılar olmadan kullanılamaz. aMule uygulamacığını çalıştırmak için ~/.aMule/amule.conf dosyasında \"ECPassword\" kısmını uygun bir değerle doldurmalısınız. amuled' i --ec-config seçeneği ile çalıştırın ve parolanızı ayarlayın. Daha fazla bilgi https://amule-org.github.io/docs adresinde bulunabilir."
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - zamanlayıcı başlatılıyor"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "Pid dosyası oluşturulamıyor"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "HATA: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "Yeni bir sürüm mevcuttur"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -648,191 +636,184 @@ msgstr ""
 "\n"
 "İndirme sayfasını açmak ister misiniz?"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Ağ yok"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule Uzak Denetimi"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Önemli Hata: Çekirdek Zamanlayıcı oluşturulamadı"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "Uzak aMule'ye bağlan"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Bağlantı Koptu"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "İptal et ve çık"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "Tekrar bağlanılıyor… (teşebbüs %d)"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "Bir sonraki teşebbüs %d saniye sonra…"
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -845,40 +826,40 @@ msgstr ""
 "\n"
 "Arayüz, bağlantı geri gelinceye dek duraklatıldı."
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Önemli Hata: Havuz Zamanlayıcı oluşturulamadı"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Olay döngüsüne gidiliyor…"
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "Bağlanıyor…"
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "Bağlantı başarısız oldu. Lütfen makine ismini, bağlantı noktasını ve parolayı kontrol edin."
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Uzak ARAYÜZ EC olay yakalayıcı"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "Bağlantı Başarısız Oldu. %s:%d bağlanılamıyor\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "İniyor"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Tekrar bağlanma teşebbüsü zaman aşımına uğradı; yeniden deneniyor."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -887,681 +868,658 @@ msgstr ""
 "Bağlantı zaman aşımına uğradı. Ayrılan vakit zarfında %s:%d ile irtibat kurulamadı.\n"
 "Lütfen adresi, bağlantı noktasını ve aMule'ün Harici Bağlantılar etkinleştirilmiş olarak çalıştırılıp çalıştırılmadığını kontrol edin."
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Uzaktaki çekirdekle kurulan bağlantı koptu. Tekrar bağlanma deneniyor…"
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "Uzaktaki çekirdeğe tekrar bağlanıldı."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tekrar bağlanma teşebbüsü %d: %s:%d unsuruna bağlanılıyor"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "Tekrar bağlanma başlatılamadı; kısa zamanda yeniden denenecek."
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Hazır"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Tümü"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "okunabilir değil"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "bulunamadı"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "Çekirdek şu paylaşılan dizinleri reddetti: %s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Geçersiz bağlantı veya zaten listede mevcut."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanılıyor."
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "DüşükID bağlantı için bir eş aranıyor"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Sahte eMule sürümü %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Sahte eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Sahte eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule s.0.%u üzerine kurulu)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Rumuz: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "İstek: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bu oturum için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 msgstr[1] "Bu oturum için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tüm oturumlar için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 msgstr[1] "Tüm oturumlar için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Bilinmeyen dosya istendi"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s' kullanıcısından gelen ileti engellendi. (IP: %s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s' kullanıcısından yeni ileti geldi (IP: %s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kullanıcı %s (%u), var olmayan '%s' dizini için paylaşılmış dosya listenizi istedi. -> Görmezden gelindi."
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "UYARI: %s açılamıyor."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "UYARI: İptal edilen dosya listesi bozuk. Geçersiz başlık içeriyor."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "%s dosyası okumada IO hatası: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "%s dosyası kaydedilirken hata: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Sınıf"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Yeni Sınıf"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Gelen dosyalar için bir dizin seçin"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Sınıf için bir isim girmelisiniz!"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Sınıf için bir yol girmelisiniz!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Sınıf için gelen dizini oluşturma başarısız. Lütfen geçerli bir yol giriniz!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Sohbet Oturumu Başladı: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** Kullanıcıya Bağlandı. ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** Kullanıcıya Bağlanıyor.***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Kullanıcıya bağlantı başarısız. / Bağlantı koptu.***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** Captcha denetiminden geçtiniz ve kullanıcı iletinizi aldı. ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** Captcha' ya cevabınız yanlıştı ve iletiniz yok sayıldı. Yeni bir ileti göndererek yeni bir captcha isteyebilirsiniz. ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "Sohbet"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Sekmeyi Kapat"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Tüm sekmeleri kapat"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Diğer sekmeleri kapat"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Arkadaşlara Ekle"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "Kredi dosyası yüklendi. %u adet kullanıcı biliniyor"
 msgstr[1] "Kredi dosyası yüklendi. %u adet kullanıcı biliniyor"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u adet kullanıcı için krediler bitti!"
 msgstr[1] " - %u adet kullanıcı için krediler bitti!"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "'cryptkey.dat' dosyası bulunamadı. Oluşturuluyor…"
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Kullanıcı Ayrıntıları"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "DüşükID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "YüksekID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Etkinleştirildi"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Destekleniyor"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Desteklenmiyor"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Bağlandı"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Eksik"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Kötü Çocuk"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "İncelendi - Tamam"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Uygun değil"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Kullanıcı %s (%u), paylaşılmış dosya listenizi istedi. -> Kabul edildi"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Kullanıcı %s (%u), paylaşılmış dosya listenizi istedi. -> Reddedildi"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Kullanıcı %s (%u), paylaşılmış dizin listenizi istedi. -> Kabul edildi"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Kullanıcı %s (%u), paylaşılmış dizin listenizi istedi. -> Reddedildi"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Kullanıcı %s (%u), '%s' dizini için paylaşılmış dosya listenizi istedi. -> kabul edildi"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Kullanıcı %s (%u), '%s' dizini için paylaşılmış dosya listenizi istedi. -> reddedildi."
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Kullanıcı %s (%u), %s dizinini paylaşıyor"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Kullanıcı %s (%u) istenmeyen paylaşılmış dosya listesi gönderdi."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Kullanıcı %s (%u) '%s' dizini için paylaşılmış dosya listesini gönderdi"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Kullanıcı %s (%u) paylaşılmış dosya listesini göndermeyi tamamladı"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Kullanıcı %s (%u) istenmeyen paylaşılmış dosya listesi gönderdi"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Kullanıcı %s (%u)nın paylaşılmış dizin/dosyalara erişimi reddedildi."
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Dosya Yorumları"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Puanlama"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Yorum"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "Kad araması başlatılamadı"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad çalışmıyorsa, Kad. araması yapılamaz."
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "Yorumlar için Kad üzerinde arama yapılıyor…"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Yorum yok"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u adet yorum"
 msgstr[1] "%u adet yorum"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "%s istemcisi %s kadar veriyi %s toplamda '%s' dosyasında gönderdiği için yasaklandı."
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "'%s' için ülke verisi yüklenemedi."
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Oto (Düş)"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Oto [Nor]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Oto (Yük)"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Yüksek"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Çok Yüksek"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Yayım"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Soruyor"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "Sunucu yoluyla bağlanıyor"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Sıra dolu"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Sırada"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Aktarılıyor"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Adresleme seti alınıyor"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Gereksiz parçalar"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "DüşükID'den DüşükID'ye bağlanılamaz"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Çok fazla bağlantı"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "Kad yoluyla bağlanıyor"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Çok fazla Kad bağlantısı"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "Engellendi"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Bağlantı Hatası"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Uzaktaki Sıra Dolu"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Eski MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Yeni MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Sunucu"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Kaynak Değişimi"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Pasif"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Bağlantı"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Kaynak Girdileri"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Arama Sonucu"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Tamamlandı"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "İşlem yapılıyor"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "HATA: disk alanı yetersiz"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "HATA: Partmet bulunamadı"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "HATA: Girdi-çıktı hatası!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "HATA: Başarısız!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "Sıraya girdi"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Zaten aktarılıyor"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Bilinmeyen yada bozuk geçici dosya formatı."
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Parça"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Aktarıldı"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hız"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "İşlem"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kaynaklar"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Öncelik"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Durum"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Kalan Süre"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Son Tamamlanmış Görülme"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Son Alım"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Seçili dosyayı silmek istediğinizden emin misiniz?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Seçili dosyaları silmek istediğinizden emin misiniz?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1570,109 +1528,106 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Otomatik"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "&Dur"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "&Durakla"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "&Başlat"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Tamamlananları T&emizle"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Tüm A4Afleri derhal bu dosyaya geçir"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Tüm A4Afleri bu dosyaya geçir (Otomatik)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Tüm A4Afleri derhal bir başka dosyaya geçir"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Genişletilmiş Seçenekler"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Ön İzleme"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Dosya &ayrıntılarını göster"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Tüm yorumları göster"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Magnet bağlantısını panoya kopyala"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "eD2k bağlantısını panoya kopya&la"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Geri beslemeyi panoya kopyala"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "atamayı kaldır"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Sınıfa Ekle"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Dosyayı &Aç"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Bu dosya için yeni bir isim girin:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Dosya yeniden adlandır"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "İndirmeler (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "varsayılan Windows kabuk işleyicisi"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1681,346 +1636,345 @@ msgstr ""
 "Her önizlemede bu uyarının gösterilmesini önlemek için,\n"
 "seçeneklerden tercih ettiğiniz video oynatıcısını ayarlayın (varsayılan %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Dosya ön izlemesi"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "Hata: Ortam oynatıcısını çalıştırma başarısız! Komut : `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "ParçaDosyası %u, %u'da kaydediliyor"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Tüm ParçaDosyaları Kaydedildi."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "%s konumundan geçici dosyalar yükleniyor."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "ParçaDosyası %u %u'dan yükleniyor"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "HATA: Yedekleme dosyası yüklenemedi. .part.met kurtarma çözümleri için https://github.com/amule-org/amule/discussions adresini ziyaret edin."
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Tüm ParçaDosyaları Yüklendi."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Hiç part dosyası bulunamadı"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "%u adet parça dosyası bulundu"
 msgstr[1] "%u adet parça dosyası bulundu"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Geçici dizininin dosya sistemi büyük dosyaları kullanamaz."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Gelen dizininin dosya sistemi büyük dosyaları kullanamaz."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Aktarılıyor %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Zaten %s dosyasını indirmeye çalışıyorsunuz."
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Zaten '%s' dosyasına sahipsiniz ('%s' olarak talep edilmiş)"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Zaten %s dosyası var."
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Magnet bağlantısı eD2k' ya çevrilemez: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Bağlantı için bilinmeyen protokol: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "%u bağlantı eklenemedi (teferruatlar için kütüğe bakın)."
 msgstr[1] "%u bağlantı eklenemedi (teferruatlar için kütüğe bakın)."
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Geçersiz eD2k bağlantısı! HATA: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "Kimlik kanıtlamadan sonra istemci tarafından gönderilen paket başarısız."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Dışarıdan bağlantı kesildi."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Boş şifre sebebiyle dışarıdan bağlantı devre dışı!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Yapılandırma dosyasında dışarıdan bağlantılar devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Yeni dışarıdan bağlantı kabul edildi"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "HATA: yeni bir dış bağlantı kabul edilemiyor"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Ayarlardaki boş şifre sebebiyle dışarıdan bağlantılar reddedildi!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "Kullanıcıya bağlanılıyor: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Bilinmeyen sürüm"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Yanlış EC sürüm ID, bir çift uyumsuzluğu olabilir. Aynı görüntüden çekirdek ve uzak kullanınız."
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Bir geliştirme sürümünden dengeli bir sürüme bağlanamazsınız! *muhtemel* bir çökme önlendi"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Geçersiz protokol sürümü."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Kayıp protokol sürüm eki."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "Kimlik doğrulama başarısız oldu: EC parolası olarak geçersiz adresleme girildi."
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "Kimlik doğrulama başarısız oldu: yanlış parola."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "Kimlik doğrulama başarısız oldu: kayıp parola."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "Geçersiz istem, öncelikle doğrulatmanız lazım."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Giriş izni verildi."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "\"%s\" hata iletisi istemciye gönderildi."
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s üzerinden yetkilendirilmemiş giriş denemesi. Bağlantı kesildi."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Uzak Parça Dosyası komutu başarısız: Dosya Adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Dosya adreslemesi bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Aman aman! OpCode işleme hatası!"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Sunucu eklenmedi."
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "sunucu bulunamadı: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "çıkarılacak sunucunun tanımlanması gerekli"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "Arkadaş bulunamadı."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "İstemci bulunamadı."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED, EC_TAG_FRIEND veya EC_TAG_CLIENT gerektirir."
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Uzak arayüzden Web araması yapmak anlamsız."
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Arama sürüyor. Bir dakikaya sonuçlanır!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Grafik için hiç nokta yok."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Yazılımınız bu ayrıntı düzeyi için yapılandırılmamış."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Bağlantı kapat"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Zaten kapatılıyor."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Dışarıdan Bağ.:'%s' bağlantısı ekleniyor."
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d bağlantı, ki toplam %d üzerinden, başarısız oldu (geçersiz veya zaten listede)."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "Sürüm kontrolü sınırlandırıldı; kısa bir süre sonra tekrar deneyin."
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "Bu daemon üzerinde sürüm kontrolü mevcut değildir."
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Dosya bulunamadı."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Geçersiz dosya adı."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Dosya yeniden adlandırılamıyor."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad ayarlarda devre dışı bırakılmış."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "eD2k ağına zaten bağlandı."
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "eD2k ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Kad zaten bağlı."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kad ağına bağlanıyor…"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Bütün ağlar devre dışı."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "eD2k ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Kad ağından bağlantı kesildi."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Dış Bağlantı: geçersiz opcode alındı: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Geçersiz opcode (yanlış protokol sürümü mü?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Bilinmeyen %s uzantısı, %s komutu için.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Bilinmeyen komut '%s' .\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2028,7 +1982,7 @@ msgstr ""
 "\n"
 "Bu komut bir argüman içeremez.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2036,7 +1990,7 @@ msgstr ""
 "\n"
 "Bu komut bir argüman içermelidir.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2044,7 +1998,7 @@ msgstr ""
 "\n"
 "Bu komut eksik. Aşağıdaki uzantılardan birini girmelisiniz.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2052,11 +2006,11 @@ msgstr ""
 "\n"
 "Uygun uzantılar:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Uygun komutlar:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2067,17 +2021,17 @@ msgstr ""
 "Tüm komutlar büyük-küçük harf duyarlıdır.\n"
 "'%s <komut>' tuşlayarak <komut> hakkında detaylı bilgi alabilirsiniz.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Uygulamadan çıkar."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Yardımı göster."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2085,7 +2039,7 @@ msgstr ""
 "Bir komut hakkında yardım çağırmak için 'help <komut>' yazınız.\n"
 "Tüm komutları görmek için 'help' yazınız.\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2096,46 +2050,46 @@ msgstr ""
 "Komut listesi için '%s' kullanınız.\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Söz dizimi hatası!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Komut çalıştırmada hata.- Bu hiç olmamalıydı! Lütfen hatayı bildiriniz.\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Bu komut herhangi bir parametre içermemeli."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Bu komut bir parametre içermeli."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Geçersiz argüman."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Bu eksik bir komut."
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Daha fazla yardım için '%s' yazınız.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Bu bir %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Bu bir %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2143,7 +2097,7 @@ msgstr ""
 "\n"
 "Yazılım oluşturuluyor…\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2152,7 +2106,7 @@ msgstr ""
 "\n"
 "Tamam, çıkılıyor %s…\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2166,331 +2120,326 @@ msgstr ""
 "\n"
 "Çıkılıyor…\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Bu yardım dosyasını göster."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule'nin çalıştığı makine. (varsayılan: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Dışarıdan bağlantı için aMule portu. (Varsayılan:4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Dışarıdan bağlantı şifresi."
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Yapılandırmayı dosyadan oku."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "stdout' a herhangi bir çıktı yazdırma."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Geveze ol - hata iletilerini de göster."
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Yazılım yerelini ayarla (dil)"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Komut satırı seçeneklerini yapılandırma dosyasına yaz."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "aMule'nin yapılandırma dosyasını temel alan yapılandırma dosyası oluşturur."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Yazılım sürümünü yazdır."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "Seçilen IP adresinin konumuna bakılmaksızın ZLIB sıkıştırmasını zorla (sunucuya, bir LAN IP adresine çözümlenen VPN tüneli üzerinden erişilebildiğinde kullanışlıdır)."
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "Tüm konsol çıktısının bir kopyasını bu kütük dosyasına ilave et (varsayılan: <ayar-dizini>/amuleapi.log)."
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "Kütük dosyası yazma; sadece konsolda görüntüle."
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Dosya Ayrıntıları"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% tamamlandı"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Hoş geldiniz!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "Eşe Bağlanıyor"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Bağlantı Türü:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Ağlar"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Standart TCP Portu "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Genişletilmiş UDP portu (Kad / Genel arama) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Yönlendirici port iletimi için UPnP'yi etkinleştir"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Ön Yükleme"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Otomatik başlangıç"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "aMule'ü oturum açtığımda otomatik olarak başlat"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "aMule'ü ed2k:// bağlantıları için kaydet"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "aMule'ü magnet: bağlantıları için kaydet"
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Geçici dosyalar için dizin"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Arkadaş listesi 'emfriends.met' dosyası okunamıyor!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Arkadaşlar"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "&Ayrıntıları Göster"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Arkadaş ekle"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Arkadaş sil"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "&İleti Gönder"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Paylaşılmış Dosyalara bak"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Arkadaş Slotu Kur"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Seçili arkadaşı silmek istediğinizden emin misiniz?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Seçili arkadaşları silmek istediğinizden emin misiniz?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2498,11 +2447,11 @@ msgstr ""
 "Birden fazla arkadaş slotu kuramazsınız.\n"
 "Sadece bir slot kuruldu."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Çoklu seçim"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2510,206 +2459,205 @@ msgstr ""
 "Birden fazla arkadaş oluğu kurmanıza izin verilmez.\n"
 "Sadece bir oluk atandı."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Kullanıcıya ileti gönder"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Gönderilecek ileti:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Arkadaşlardan Çıkar"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "İleti Gönder"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Bu dosyaya geçir"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Sırada: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Başka dosya için soruldu"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "Gönderme slotu için bekleniyor"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "Sırada: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "Gönderiliyor"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Yok"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Hayır"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Evet"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Aktarılıyor…"
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP aktarımı iptal edildi"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "İndirme bağlantısı boş olamaz."
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "'%s' için HTTP talebi oluşturulması başarısız oldu"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP indirmesi: %s için boş cevap gövdesi"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "İndirilen dosyanın %s konumuna taşınması başarısız oldu."
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "%s (%llu bayt) indirildi."
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "%s bağlantısı şunu geri gönderdi: %i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "%s için HTTP indirmesi başarısız oldu: %s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "%s için HTTP 401 Yetkisiz"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "Mevcut GeoLite2-Country.mmdb dosyası %s unsuruna taşındı"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country: MaxMind, GeoIP kaynağı olarak seçilmiştir fakat hiçbir Lisans Anahtarı yapılandırılmamıştır. Ayarlar -> IP2Country menülerine gidin, ücretsiz MaxMind Lisans Anahtarınızı yapıştırın ve 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country: kişiselleştirilmiş bir URL (bağlantı) GeoIP kaynağı olarak seçilmiştir fakat hiçbir URL yapılandırılmamıştır. Ayarlar -> IP2Country menülerine gidin ve bir .mmdb dosyasına (veya onu içeren bir .gz / .tar.gz dosyasına) işaret eden bir URL girin."
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country: bir GeoIP indirme bağlantısının çözümlenmesi başarısız oldu."
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "Yeni %s unsurunu %s konumundan indir"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "%s dosyasının indirilmesi başarısız oldu, güncelleme iptal ediliyor."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "%s dosyası silinemedi. Güncelleme iptal edildi."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "%s dosyası yeniden adlandırılamadı. Güncelleme iptal edildi."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "%s başarıyla güncellendi."
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "%s unsurunun güncellemesinde hata oluştu"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "DB-IP indirmesi güncel ay için başarısız oldu - önceki ayın bağlantısıyla tekrar deneniyor."
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "%s, %s kaynağından indirilemedi."
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "IP süzgeçleri 'ipfilter.dat' ve 'ipfilter_static.dat' yükleniyor."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "ipfilter.dat dosyasını '%s' yükleme başarısız. bilinmeyen format algılandı."
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "ipfilter.dat dosyasını '%s' yükleme başarısız. Dosya açılamıyor."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "%u adet IP-aralığı '%s' unsurundan yüklendi."
 msgstr[1] "%u adet IP-aralığı '%s' unsurundan yüklendi."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "%u adet bozuk satır göz ardı edildi."
 msgstr[1] "%u adet bozuk satır göz ardı edildi."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Yeni %s dosyası yeniden adlandırılamadı. Güncelleme iptal edildi."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP süzgeci hazır"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2717,860 +2665,828 @@ msgstr ""
 "Bilinen kullanıcılardan\n"
 "Ön Yükleme"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Düğümler (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Ön yükleme için geçersiz ip"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Ön yükleme için geçersiz port"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "İstenilen tüm alanları doldurunuz."
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "İleti"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Yeni bir nodes.dat dosyası indirmek istediğinizden emin misiniz?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Bunu yapmanız şu anki düğümleri silecek ve Kademlia bağlantısını baştan başlatacaktır."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Devam mı?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: Arama sözcüğü çok kısa"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: Arama anahtar sözcüğü zaten arama listesinde var. "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "Nodes.dat dosyası okunamadı- dosya çok eski. Bu sürüm (0) artık desteklenmiyor."
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "%u adet Kademlia bağlantısı okundu"
 msgstr[1] "%u adet Kademlia bağlantısı okundu"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Hiç bağlantı bulunamadı. Lütfen, ön yükleme veya nodes.dat dosyası indirmeyi deneyin."
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "Sadece %d Kad bağlantısı var. Nodes.dat yazılmadı"
 msgstr[1] "Sadece %d Kad bağlantısı var. Nodes.dat yazılmadı"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "%d Kademlia bağlantısı yazıldı"
 msgstr[1] "%d Kademlia bağlantısı yazıldı"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Kad kullanıcısı"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "'%s' için Kad not araması başlatılmadı: Kad bağlı değil"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "'%s' için Kad not araması başlatılmadı: bu dosya için bir not araması zaten çalışıyor"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "'%s' için Kad not araması başlatılmadı: dosya paylaşım listesinde, indirme kuyruğunda veya arama sonuçlarında mevcut değil"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "'%s' için Kad not araması başlatılmadı: başka bir Kad araması (mesela bir kaynak araması) zaten bu dosyanın karma değeri kullanılarak çalışıyor - kısa bir süre sonra tekrar deneyin"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "'%s' için Kad not araması başlatılmadı: PrepareLookup başarısız oldu"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Dosya adı"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Dosya"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Paylaşım oranı"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "İstenen"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Kabul edilen"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Tamamlandı"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "UYARI: Bilinen dosya listesi bozuk. Geçersiz başlık içeriyor."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "Bilinen dosyalar listesinden girdi yüklenemedi. Dosya bozuk olabilir"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Bilinen dosyalar listesinde geçersiz girdi bulundu. Dosya bozuk olabilir: "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "Bilinmeyen hata %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "%d hatası için tanımlama alınamadı!"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Adresleniyor"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Tamamlanıyor"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hatalı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Bekliyor"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Boş olmayan bir şifre girmelisiniz."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Geçersiz şifre, bir MD5 adreslemesi değil!"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "Bağlantı başarısız"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "Dış bağlantı kesildi — programdan çıkılıyor."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC bağlantısı başarısız. Boş cevap."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Dış Bağlantı: Kötü yanıt. Bağlantı kapatıldı."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Başarıldı! aMule'ye bağlantı kuruldu. "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Başarıldı! Bağlantı kuruldu."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Dış Bağlantı: Erişim engellendi çünkü: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "Dış Bağlantı: Tanılama engellendi."
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "DinlemeSoketi: Tamam."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "HATA: TCP portu dinlenemiyor."
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "HATA: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "UYARI: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Kapat"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Kes"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopyala"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "Bağlandı (DüşükID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "Bağlandı (YüksekID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "Çevrim içi (Güvenlik duvarı arkasında)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "Sunucu: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "Sunucu IP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Bağlı değil"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP port: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP port: Hazır değil"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP port: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP port: Hazır değil"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Yazılım Bilgisi"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Gönderim sınırı"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Aktarım sınırı"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "aMule'yi Göster"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "aMule'yi Gizle"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Çıkış"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "kB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Sınırsız"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule Sistem Tablası Menüsü"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Hız:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "GÖN: Yok"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "GÖN: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "İND: Yok"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "İND: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "İndirme hızı: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Gönderme hızı: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Rumuz: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Rumuz Seçilmedi!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "KullanıcıID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Sunucu Adı: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "SunucuIP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Bağlanmadı"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Çevrim içi İmza: Etkin"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Çevrim içi İmza: devre dışı"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Çalışma Süresi: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Paylaşılan dosyalar: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Sıraya giren kullanıcılar: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Toplam İND: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Toplam GÖN: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "eD2k veya magnet bağlantılarını buraya yapıştırın"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "Bağlantı ekle"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Metin denetimindeki eD2k bağlantısını indirme sırasına eklemek için burayı tıklayın."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Olaylar burada gösterilir. Olayların tam listesi için Sunucu sekmesine bakınız."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Yükleniyor…"
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Sunucu üzerinden bağlandığınız kullanıcı sayısı…"
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Kullanıcılar: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Şu anki sunucuya bağlı kullanıcılar ve kullanıcıların yaklaşık sayısı."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Gön: 0.0 | İnd: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Şu anki ortalama gönderim ve aktarım oranları. Etkinleştirilirse, ızgaralar üzerindeki rakamlar kullanıcı iletişiminden kaynaklanan ek yükü gösterir."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Bağlantı durumu ve aktif aktarımları gösterir. Kırmızı ok henüz bağlanmadığınızı, sarı ok düşük ID (güvenlik duvarı)aldığınızı ve yeşil ok ise yüksek ID (En verimli bağlantı türü) aldığınızı simgeler."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Bağlanmadı …"
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "Şu an bağlanılan sunucu."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Ara"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Ad:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tür"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Genel"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Genişletilmiş Parametreler"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Süzgeç"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Dosya Türü"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Herhangi"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Sıkıştırılmış Dosyalar"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Ses"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD-Kalıbı"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Resim"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Programlar"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Belgeler"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Videolar"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Uzantı"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "En Az Boyut"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "Bayt"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "En Fazla Boyut"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Uygunluk"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Süz:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Süzme Sonuçları"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Sonuçları tersine çevir"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Bilinen Dosyaları Gizle"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Başlat"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Daha Fazla"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "Zaten cevap vermiş Kad eşlerinden aramayı genişletmelerini iste. Aramanın ilk alfa hududunun bulamadığı ilave dosya eşleşmelerini ortaya çıkarmak için her bir tıklama bir sonraki en yakın eşten daha fazla irtibat talep eder (KADEMLIA_FIND_VALUE_MORE)."
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "İndir"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Alanları Sıfırla"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Sonuçlar"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Tamamlanan aktarımları temizler."
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dosya kaynakları:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Genel"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Tam Ad :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-Dosyası :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Adresleme:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Dosya Boyutu :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Aktarım"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Parça Dosya Durumu :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Son Görülen Tamamlama :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Bulunan Kaynaklar:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Aktarılan Kaynaklar:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Dosya Parçası-Sayısı:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Uygun:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Veri Oranı:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Aktarım Süresi: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Aktarılan:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Tamamlanmış Boyut:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Akıllı Bozulma Yakalayıcısı"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Bozulma ile kaybedilen:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Sıkıştırma ile kazanılan:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "I.C.H ile kurtarılan paketler :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "Paylaşılan"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "İstekler"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Kabul Edilen İstekler"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Aktarılan Veri"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Paylaşım Oranı"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Tam Kaynak Sayısı"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "Şu tarihten beri paylaşılıyor:"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "Son gönderme"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "Ortam Bilgileri"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "Süre:"
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "Akış hızı:"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "Kodlama:"
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "Sanatçı:"
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Başlık :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Dosya Adları"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Devral"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Temizle"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Uygula"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Dosyayı Yorumla/Puanla (İçerik tüm kullanıcılara gösterilecektir.)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3578,570 +3494,568 @@ msgstr ""
 "Bir film için süresini, öyküsünü, dilini belirtebilir …\n"
 "ve sahte bir dosya ise bunu diğer aMule kullanıcılarına bildirebilirsiniz."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Dosya Kalitesi"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Derecelendirilmemiş"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Geçersiz / Bozuk / Sahte"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Zayıf"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Doğru"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "İyi"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Mükemmel"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Dosya puanlaması seçiniz veya geçersiz ise diğer kullanıcıları uyarınız."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "Kad üzerinden al"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Yenile"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Aktarılıyor, lütfen bekleyiniz …"
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Boyut bilinmiyor"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Gerekli Bilgiler"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP Adresi:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Ek Bilgi"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Kullanıcı Adı :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Ekle"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Gönderim Hızı"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "İstatistik Ağacı"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Kullanıcı Adı:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Kullanıcı Adreslemesi:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Yazılım:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Yazılım Sürümü:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "Kullanıcı ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Sunucu IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Sunucu:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Gizleme:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kademlia:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Yapılan aktarımlar"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Şimdiki İstek:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Ortalama gönderim oranı:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Ortalama aktarım oranı:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Gönderilen (oturum):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "İndirilen (oturum):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Gönderilen (toplam):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "İndirilen (toplam):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skor"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "İND./GÖN. niteleyici:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Güvenli Kimlik:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "Kuyruk sırası:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Sıra skoru:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Rumuz"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - çok-sistemli Katır"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Bağlandığınızda diğerlerinin göreceği isminiz budur."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Dil: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "İpuçlarını göstermeden önce geçecek süreyi belirler."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Arayüzde kullanılacak dil."
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "Yeni sürümü düzenli olarak denetle"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Bunu etkinleştirmek, aMule'nin yeni sürümleri başlangıçta ve çalıştığı sürece günde bir defa aramasını sağlar"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Oturum açıldığında aMule'ün çalıştırılması için işletim sistemine kullanıcı başı bir otomatik başlatma unsuru kaydeder. Eğer aMule ikilisini taşırsanız, sonrasında onu bir kere el ile başlatın ki bu unsur güncellensin."
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "aMule'ü ed2k:// bağlantıları için varsayılan yönetici yapar, yani böyle bir bağlantıya tarayıcınızda veya dosya yöneticinizde tıklamanız onu burada açar."
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "aMule sadece eD2k uyumlu (xt=urn:ed2k: içeren) magnet'leri işler. BitTorrent magnet'leri DESTEKLENMEZ ve onlara tıklamanız sessizce başarısızlığa uğrayacaktır. Şayet bir BitTorrent istemcisi (Transmission, aBittorrent, vs.) kullanıyorsanız, bunu devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Küçültülmüş başla"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Bunu etkinleştirmek aMule'nin küçültülmüş durumda başlamasını sağlar."
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Çıkışta uyar"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "aMule'nin çıkıştan önce uyarmasını sağlar."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Sistem tablası simgesini etkinleştir."
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Bu, sistem tablası (ya da görev çubuğu) simgesini Etkinleştirir/Devre dışı bırakır."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "Kapatma butonuna tıklandığında uygulamayı sakla"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Sistem tablasına küçült."
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Bu, aMule'nin görev çubuğu yerine sistem tablasına küçülmesini sağlar."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "İndirme sona erdiğinde bildirimleri göster"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "Bu şık etkinleştirilirse, indirmeler sona erdiğinde aMule bildirimleri gösterecektir."
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "İpucu gecikme süresi: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "saniye"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Tarayıcı Seçimi"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Mümkünse yeni sekmede aç"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Web sayfasını, yeni pencere yerine mümkünse yeni sekmede açar."
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Ortam Çalıcısı"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Bağlantı sınırları"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Gönderme"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Slot Tahsis Boyutu"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Portlar"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Bu, standart eD2k bağlantı noktasıdır ve devre dışı bırakılamaz."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Sunucu istemleri için UDP Portu (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Bu UDP portu genişletilmiş eD2k istemleri ve Kad ağı için kullanılır"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP Portu (İsteğe bağlı):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "Sadece ileri seviye kullanıcılar için: tüm aMule trafiğini listeden seçilmiş veya ismi (mesela tun0, eth0, en0) ya da endeksi yazılmış tek bir ağ arayüzüne sabitle. Bir IP adresine sabitlemenin aksine bu, trafiğin varsayılan yoldan sızmasını engeller - VPN'ler ile faydalıdır. Yüksek izinlere ihtiyaç duymaz."
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Başlangıçta otomatik bağlan"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Bağlantı koptuğunda yeniden bağlan"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Ölü sunucuları"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr "Statik sunucular hiçbir zaman kaldırılmazlar, ulaşılamaz oldukları zaman dahi."
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "denemeden sonra kaldır"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Liste"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Bir sunucuya bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Bir kullanıcı bağlandığında sunucu listesini güncelle"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Öncelik sistemini kullan"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Bağlanırken akıllı DüşükID denetimi yap"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Güvenli Bağlantı"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Sadece statik listesindeki sunuculara otomatikman bağlan"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Elle eklenmiş sunuculara Yüksek Öncelik ata"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Dosyaları aktarımlara duraklatılmış kipte ekle"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Dosyaları, aktarımlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "İlk ve son parçaları en önce indirmeye çalış"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "\"Endgame\" kipi: son bloklar için hızlı kaynaklara geç"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Bir dosya tamamlandığında duraklatılan sonraki dosyaya başla"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "Aynı sınıftan"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "Alfabetik sırayla"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Yeni dosyalar için diskte yer ayır"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Yeni dosyalarda, dosyanın tamamı için sabit diskte yer ayrılarak parçalanma azaltılır"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Boş disk alanı şu kadar kaldığında aktarımları durdur "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "aMule'nin diskteki alanı denetlemesini istiyorsanız bunu seçiniz."
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Buraya istenilen en az disk alanını giriniz."
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Nadir bulunan dosyalarda 10 kaynak sakla (<20 kaynak)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Gönderilenler"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Dosyaları paylaşılanlara otomatik öncelikle ekle"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Akıllı Bozulma Yakalayıcısı (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Gelişmiş I.C.H. her adreslemeye güvensin. ( önerilmez )"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "Ortam üst verisi çıkarımı"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "Süre / bit hızı / kodlama bilgilerini paylaşılan ses ve video dosyalarından çıkar"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "Etkinleştirildiğinde, dosyayı bir aramada bulan diğer istemcilerin gördükleri Süre / Bit Akışı / Kodlama sütunlarını doldurmak için aMule her paylaşılan ortam dosyası üzerinde ffprobe çalıştırır. ffmpeg (ffprobe ikilisi) kurulumu gerektirir."
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "ffprobe yolu:"
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe ikilisi için tam yol. aMule tarafından başlangıçta otomatik olarak tespit edilmesi için boş bırakın."
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "Tespit et"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4149,684 +4063,682 @@ msgstr ""
 "Tamamlanmış indirmeler burada muhafaza edilir. Bu dizindeki tüm dosyalar otomatik olarak diğer eşler ile paylaşılır.\n"
 "Şayet bu dizin paylaşmak istemediğiniz dosyalar da içeriyorsa, aMule'e özel bir alt dizini seçin."
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Paylaşılan dizinler"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(Çekirdek tarafından paylaşılan dizinler. Bir dizin eklemek için yol ilave edin.)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "Çekirdeğin makinesinde bir dizinin mutlak yolu, mesela /home/rumuz/shared"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "Özyinelemeli"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "Bunun altındaki tüm alt dizinleri paylaş, ki buna daha sonra oluşturulacak dizinler de dahildir."
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Çıkar"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Özyinelemeli paylaşım için dizin simgesine sağ tıklayınız.)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Gizli dosyaları paylaş"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "Paylaşılan dizinleri değişiklikler için otomatik olarak tekrar tara"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "Paylaşılan dizinlerdeki simgesel bağlantıları takip et"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "Şununla eşleşen dosyaları dışla:"
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "'|' ile ayrılmış joker karakterli örüntüler (mesela .DS_Store|Thumbs.db|*.tmp). İsmi eşleşen dosyalar paylaşılmaz. Eşleştirme sırasında büyük/küçük harf ayrımı yapılmaz."
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "Örüntüler düzenli ifadelerdir"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "Etkinleştirildiğinde, tüm alan tek bir düzenli ifadedir ('|' alternatifler içindir). Devre dışı bırakıldığında, '|' ile ayrılmış jokerler listesidir."
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikler"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Güncelleme gecikmesi: 5 sn"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Ortalama grafiği için süre: 100 dk"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Bağlantı Grafik Ölçüsü: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "İndirme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Gönderme grafik ölçüsü:"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "Renkler: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Izgara"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Şu anki aktarımlar"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Aktarım çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Aktarım oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Şu anki gönderme"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Gönderme çalışma Ortalaması"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "Sistem Tepsisi İkonu Hız Göstergesi"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Şu anki Kad düğümleri"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "İşlemdeki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Seçiniz"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Ağaç"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Gösterilen Yazılım Sürümü Sayısı (0=sınırsız)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! UYARI !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "En fazla yeni bağlantı / 5 sn"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "Eşzamanlı Kad kaynak aramaları"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad kaynak tekrar arama zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "Kaynaklara tekrar sorma zaman aralığı (dakika)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Dosya Tampon Boyutu: 240000 bayt"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "MMAP kullan: \"memory-mapped file access\" yani bellek eşlemeli dosya erişimi (daha az bellek kullanır)"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "Yığın üzerinde tampona almak yerine kısmi dosyaları bellekte eşleştirir, böylece sürecin bellek ayak izini azaltır. Bazı disklerde indirme hızını düşürebilir; belleği sınırlı veya çok fazla gönderide bulunan makineler için idealdir."
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Gönderme Sıra Boyutu: 5000 kullanıcı"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Sunucu bağlantısı yenileme sıklığı: devre dışı"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "Bilgisayarın devre dışı kalma kipini etkisiz hale getir"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Kullanılacak kaplama: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "\"Hızlı eD2k Bağlantı Yakalayıcısı\"nı her pencerede göster.."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Sınıf sekmelerinde genişletilmiş bilgi göster."
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "Başlık çubuğunda uygulama sürümünü göster"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Başlık çubuğunda aktarım oranlarını göster."
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Uygulama adından önce"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Uygulama adından sonra"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Ek yük ağ genişliğini göster"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Dikey araç çubuğu yerleşimi"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "Naklen sütun düzenleme (değerleri değiştikçe satırları otomatik olarak tekrar sırala)"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Sıradaki Dosyaları İndir"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "İşlem yüzdesini göster"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "İşlem çubuğunu göster"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Düz"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Konuk girişini reddet"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Web sunucusu için konuk parolası"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4838,11 +4750,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4858,11 +4770,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4872,504 +4784,504 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Devre dışı [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "bayt"
 msgstr[1] "bayt"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "kB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "k"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "bayt/sn"
 msgstr[1] "bayt/sn"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "sn"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "dk"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "saat"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "gün"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "tümü"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "diğerleri"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Tamamlanmamış"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Durduruldu"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Görüntü"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Sıkıştırılmış"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Belge"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Etkin"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "Kullanılan yapılandırma dizini: %s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Parçadosyası dönüşümünün bitmesi bekleniyor…"
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "İçe Aktarılıyor %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Geçici dosyalar dizini okunuyor."
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Aktarım bilgisi dosyasından temel bilgiler alınıyor."
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Hedef dosya oluşturuluyor."
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Eski aktarım dosyasından veri yükleniyor (%u, %u üzerinden)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Yeni tek aktarım dosyasına veri bloku kaydediliyor (%u, %u üzerinden)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Kaynak aktarım dosyası bilgisi alınıyor."
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Aktarım ekleniyor ve yeni parça dosyası kaydediliyor."
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Parça dosyalarını içe aktar"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Durum"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Dosya adreslemesi"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (Disk: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Lütfen geçici aktarım dosyaları için bir dizin seçiniz. (Alt dizinler de taranacaktır.)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Başarılı bir şekilde içe aktarılan indirmelerin kaynak dosyalarının silinmelerini ister misiniz?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Kaynakları çıkar?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "HATA: Part dosyası oluşturma başarısız"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Met-dosyası yedeklemesi %s konumundan yüklenmeye çalışılıyor."
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "HATA: part.met dosyası açılamadı: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "HATA: part.met dosyası 0 boyuta sahip: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "HATA: Geçersiz part.met dosya sürümü: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "HATA: %s (%s) bozuk (hatalı yaftalar: %s), dosya yüklenemez."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "HATA: %s (%s) bozuk (hatalı başlık sayısı), dosya yüklenemez."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Dosya bilgisi kurtarılmaya çalışılıyor…"
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "İsimsiz dosya kurtarılmaya çalışılıyor-RecoveredFile.dat olarak kaydedilecek."
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Uygun olan tüm bilgiler kurtarıldı. :-D - bunlar kullanılacak…"
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Dosya bilgisi kurtarılamıyor :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "%s (%s) açma başarısız"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "UYARI: %s bozulmuş olabilir (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "Parça dosyası kaydedilirken HATA: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Parçadosyası kaydedilirken girdi-çıktı hatası: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "'%s' konumuna 0/bilinmeyen bayt yazıldı -- mevcut .part.met muhafaza ediliyor."
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "%s için part.met girdilerini kaydetme başarısız."
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i kaynak tohumu parça dosyası için kaydedildi: %s (%s)"
 msgstr[1] "%i kaynak tohumu parça dosyası için kaydedildi: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Kısmi dosya %s (%s) için tohum dosyası okunamadı"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Parça dosyasına ait girdi dosyası (%s - %s): %s okunamıyor."
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "Bozuk parça (%d) %d parça dosyası %s içinde bulundu -Dosya sonuç adreslemesi |%s| Dosya adreslemesi |%s|"
 msgstr[1] "Bozuk parça (%d) %d parça dosyası %s içinde bulundu -Dosya sonuç adreslemesi |%s| Dosya adreslemesi |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Tamamlanmış (%i) parçası %s içinde bulundu."
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "%s dosyasının yeniden adreslenmesi bitti"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "%s tamamlanırken beklenmeyen bir hata oluştu. Dosya duraklatıldı"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Aktarım tamamlandı: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5378,306 +5290,306 @@ msgstr ""
 "Şu indirme tamamlandı:\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Dosya siliniyor: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "UYARI: İndirilen parça adreslenemiyor - adresleme seti '%s' için eksik"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "HATA: Aktarılan parça adreslenemiyor.- adres seti tamamlanmamış (%s). Bu hiç olmamalıydı"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "%u kısmı ('%s' dosyasının) tamamlanmış olarak işaretlendi ama kısmi dosya beklenenden daha küçük (%llu bayt bulunduruyor halbuki %llu bayt gerektiriyor); yeniden indirme için boşluk tekrar açılıyor."
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "İndirilen %u bölümünün %u uzunluğunda (maksimum %u) parçasının ('%s' parça dosyasına ait (%u uzunluğunda)), adreslenmesinde EOF: %s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "UYARI: Yetersiz disk alanı! %s dosyası duraklatılıyor."
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "İndirilen %i parçası %s dosyasındaydı ve bozuk."
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH: Bozulan %i parçası %s dosyasındaydı ve kurtarıldı -> Kaydedilen miktar: %s bayt"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Ayrılıyor"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Yetersiz disk alanı"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "İndirildi"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "Letonca"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "Bağlantı"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Dizinler"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Sunucular"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Güvenlik"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Arayüz"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Vekil sunucu"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Süzgeçler"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Uzak Denetimler"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Çevrimiçi İmza"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Olaylar"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Hata Çıktısı"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5687,15 +5599,15 @@ msgstr ""
 "    %PARTFILE - dosyanın tam yolu\n"
 "    %PARTNAME - dosyanın sadece adı"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "Sistem tepsisi ikon desteği, derleme esnasında libayatana-appindicator3'e ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "Wayland ile kullanılamaz: protokol bir pencere küçültüldüğünde bunu iletmez, yani bu seçenek sistemin küçült düğmesi tıklamasını yakalayamaz. Çözüm: yerine XWayland kullanmak için aMule'ü `GDK_BACKEND=x11` ile başlatın."
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5711,35 +5623,35 @@ msgstr ""
 "Bu ayarlarla oynanmasa da\n"
 "aMule gayet iyi işleyecektir."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Cfg %d Kimliği ve %s anahtarı ile parçacığa bağlanamadı"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Cfg' den %d Kimliği ve %s anahtarı ile Parçacığa veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Bağlanacağınız vekil sunucu türü"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Parçacıktan %d Kimliği ve %s anahtarı ile Cfg' ye veri aktarılamadı"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Yönetici parolası"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5747,39 +5659,39 @@ msgstr ""
 "Değişikliklerin uygulanması için, aMule yeniden başlatılmalı\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP Portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- Ağ arayüz bağlaması değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- Dışarıdan bağlantı portu değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- Dışarıdan bağlantı kabul edilme işlemi değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- Dışarıdan bağlantı arayüzü değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- Protokol gizleme desteği değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5787,7 +5699,7 @@ msgstr ""
 "Otomatik Sunucu güncelleme listeniz boş.\n"
 "'Sunucu listesini başlangıçta otomatikman güncelle' devre dışı bırakılacak."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5795,32 +5707,32 @@ msgstr ""
 "Dışarıdan bağlantıları aktifleştirmiş ama bir şifre belirlememişsiniz.\n"
 "Geçerli bir şifre belirlenmedikçe dışarıdan bağlantılar devre dışı kalacaktır."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Dil ayarları değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Geçici Dosyalar dizini değişti.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K ağı etkinleştirildi.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "Paylaşılan dosya dışlama örüntüsü geçerli bir düzenli ifade değil. Filtre devre dışı olarak bırakıldı."
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5828,7 +5740,7 @@ msgstr ""
 "Hem eD2k hem de Kad ağları devre dışı bırakılmış.\n"
 "En az birini etkinleştirmeden bağlanamayacaksınız."
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5836,7 +5748,7 @@ msgstr ""
 "UDP portu devre dışı bırakılmışsa Kad başlamayacaktır.\n"
 "UDP portu açın veya Kademlia'yı devre dışı bırakın."
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5846,68 +5758,68 @@ msgstr ""
 "aMule' yi ŞİMDİ yeniden başlatmalısınız.\n"
 "Şimdi yeniden başlatmazsanız, kötü şeyler olabilir.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "Oturum açıldığında otomatik başlatma için aMule kaydedilemedi. Otomatik başlatma deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "Oturum açılışında otomatik başlatma unsuru kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "Otomatik başlatma"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "URL yöneticisini kaydet"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule, sadece eD2k uyumlu magnet'leri işler. Şayet güncel magnet yöneticisinin (%s) yerine onu koyarsanız, BitTorrent magnet bağlantıları artık çalışmayacaktır - aMule BitTorrent içeriği indiremez. Devam edilsin mi?"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "Başka bir uygulama güncel olarak bu bağlantıların yöneticisidir (%s). Yerine aMule konsun mu?"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "aMule, URL yöneticisi olarak kaydedilemedi. Kayıt deposu salt okunur olabilir."
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "URL yönetim kaydı kaldırılamadı."
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Web sunucusu ve aMule API, dış bağlantıların etkinleştirilmiş olmalarına ihtiyaç duyar."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web sunucusu eskimiştir. Yerine aMule API çalıştırmayı değerlendirin."
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5917,64 +5829,64 @@ msgstr ""
 "Lütfen geçerli bir server.met dosyasını gösteren en az bir adres yazınız.\n"
 "Bir adres girmek için bu kutucuğun yanındaki \"Liste\" düğmesine basınız."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Geçici dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Gelen dosya(lar)"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Çevrimiçi İmzalar"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "%s için bir dizin seçiniz."
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "%u dosya, ki %u üzerinde dışlanırdı"
 msgstr[1] "%u dosya, ki %u üzerinde dışlanırdı"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Ortam Çalıcısı için göz at"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Tarayıcı Seçiniz"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "ffprobe ikilisi seçin"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Çalıştırılabilir %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "ffprobe, PATH veya standart kurulum konumlarında bulunamadı. ffmepg kurun (ffprobe'u sağlar) veya el ile bir ikili seçmek için Tara düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "Bu sayfadaki ayarlar varsayılan değerlerine sıfırlansınlar mı?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "Varsayılanlara sıfırla"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Sunucu listesini düzenle"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5982,114 +5894,114 @@ msgstr ""
 "Server.met dosyasını indirmek için buraya bağlantı adresi girin.\n"
 "Her satıra sadece bir adres yazılmalıdır."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "IP2Country güncellemesi başarısız oldu"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "Veriler MaxMind GeoLite2 tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "Kişiselleştirilmiş kaynak"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "Veriler DB-IP.com tarafından sağlanmıştır"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "Durum: %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Durum: %s - %s yüklendi"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "Durum: yükleme başarısız oldu - güncellemek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "Durum: bulunamadı - indirmek için 'Şimdi güncelle' düğmesine tıklayın."
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "Güncelleme gecikmesi: %d saniye"
 msgstr[1] "Güncelleme gecikmesi: %d saniye"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "Ortalama grafiği için süre: %d dakika"
 msgstr[1] "Ortalama grafiği için süre: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Bağlantı Grafik Ölçüsü: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "Dosya Alım Boyutu: %d bayt"
 msgstr[1] "Dosya Alım Boyutu: %d bayt"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "Gönderme Sıra Boyutu: %d kullanıcı"
 msgstr[1] "Gönderme Sıra Boyutu: %d kullanıcı"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 msgstr[1] "Sunucu bağlantısı yenileme sıklığı: %d dakika"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Sunucu bağlantısı yenileme döngüsü: Devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "devre dışı"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "'%s' olayında komut çalıştır."
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Çekirdekte komut çalıştırmayı aktifleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Çekirdek komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Arayüzde komut çalıştırmayı etkinleştir."
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Arayüz komutu:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Şu girdiler değiştirilecek:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6097,1082 +6009,1081 @@ msgstr ""
 "Şu dizinler sistem dizinleri veya hassas konumlar gibi görünüyor:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD2k/Kad ağlarında yayınlayacaktır. Bunu hakikaten yapmak istiyor musunuz?"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "Alt dizinler taranıyor…"
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "Paylaşılan dizinler güncelleniyor"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u dizin tarandı…"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Arama hatası"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük boyut göz ardı ediliyor."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Arama uyarısı."
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Ana"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k ağına bağlanılmamışsa eD2k araması yapılamaz"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Kad araması için anahtar kelime yok - iptal ediliyor"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kad araması sırasında beklenilmeyen hata oluştu. "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Kad araması: bir eşten daha, daha geniş sonuçlar talep edildi."
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad araması: daha fazla sonucu tekrar talep edecek eş kalmadı (sınıra ulaşıldı veya henüz cevap alınamadı)."
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Dosya Adresi"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "Süre"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "Akış hızı"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Kodlama"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Sınıfa göre indir"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "Bu dosya için %s iste"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "İlgili dosyaları ara (eD2k, yerel sunucu)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Bilinen dosya olarak işaretle"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k bağlantısını panoya kopyala"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Şu anda İlgili Dosyalar arama işlevini destekleyen bir sunucuya bağlı değilsiniz"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "İptal edildi"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "Yeni"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Listelenen gizlenmiş bağlantılı tüm statik sunuculara bağlanma başarısız. Gizlenmiş bağlantı olmadan geçiş yapılacak."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Listelenen gizlenmiş bağlantılı tüm sunuculara bağlanma başarısız. Gizlenmiş bağlantı olmadan geçiş yapılacak."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Listelenen statik sunucuların hiç birine bağlanılamadı. Başka bir geçiş yapılıyor."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Listelenen sunucuların hiç birine bağlanılamadı. Başka bir geçiş yapılıyor."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Sunucu listesinde bağlanılabilecek geçerli bir sunucu yok"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "%s (%s:%i) unsuruna bağlanıldı"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "%s sunucusuna bağlanıldı"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Önemli Hata: Bağlantı sağlanamıyor. İnternet bağlantınız kopmuş olabilir."
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Bağlantı kaybedildi: %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) görünüşe göre ölü."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) görünüşe göre dolu."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
 msgstr[1] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "%s (%s:%i) adresine bağlantı başarısız."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "HATA: Zaman aşımı denetlemesinde soket geçersiz"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "%s (%s:%i) adresine bağlanma denemesi zaman aşımına uğradı."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "DNS araştırmasında geç sonuç alındı, atlanıyor."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Server.met dosyası yükleniyor: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Server.met dosyası bulunamadı!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Server.met dosyası '%s' açılamadı. Bilinmeyen format."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Server.met açılamadı!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met dosyası bozuk, geçersiz sürüm eki bulundu: 0x%x, size %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "%i adet sunucu server.met dosyasında bulundu"
 msgstr[1] "%i adet sunucu server.met dosyasında bulundu"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "%d adet sunucu eklendi"
 msgstr[1] "%d adet sunucu eklendi"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "Hata: 'server.met' dosyası bozuk: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "'server.met' dosyası okumada IO hatası: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Sunucu eklenmedi: [%s:%d] geçerli bir port içermiyor."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Sunucu eklenmedi: [%s:%d] IP'si süzüldü veya geçersiz."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Sunucu eklenmedi: Listede IP:Portu [%s:%d] eşleşen bir sunucu bulundu."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Sunucu eklendi: [%s:%d] adresindeki sunucu '%s' adını kullanıyor."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Silmeye çalıştığınız sunucuya bağlı durumdasınız. Lütfen, öncelikle bağlantıyı kesiniz."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "'%s' açma başarısız"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Server.met kaydetme işlemi başarısız!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Geçersiz adres"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "%s adresinden sunucu listesi aktarımı tamamlandı."
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "'addresses.dat' dosyasında hiç sunucu listesi adresi bulunamadı. Lütfen sunucu listenizi otomatik güncellemek için bu dosyaya sunucu listesi dosyası yapıştırın"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Sunucu listesini %s adresinden indirmeye başla."
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "UYARI: sunucuların otomatik güncellenmesi için geçersiz URL girildi: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "address.dat üzerinde, geçerli bir server.met güncelleme adresi bulunamadı."
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "%s adresinden sunucu listesi alınamadı."
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Yerel sunucu IP Süzgeci tarafından engellendi, başka bir sunucuya bağlanılıyor!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Sunucu Adı"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Adres"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Port"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Açıklama"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Kullanıcılar"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Statik Sunucu"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Sürüm"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "TCP Bayrakları"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "UDP Bayrakları"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Silmeye çalıştığınız bir sunucuya bağlısınız. Lütfen önce bağlantıyı kesiniz. Sunucu SİLİNMEDİ."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(Bilinmeyen ad)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Statik sunucu %s'i silmek istediğinizden emin misiniz"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Sunucular (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Sunucu"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Sunucuya bağlan"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Sunucuyu statik olarak işaretle"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Sunucuyu statik olmayan olarak işaretle"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Sunucuları statik olarak işaretle"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Sunucuları statik olmayan olarak işaretle"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Sunucuyu kaldır"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Sunucuları kaldır"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Bütün sunucuları kaldır"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "eD2k bağlantısını panoya kopyala"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Sunucuya yeniden bağlan"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Hepsini silmek istediğinizden emin misiniz?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Seçili sunucuyu silmek istediğinizden emin misiniz?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Seçili sunucuları silmek istediğinizden emin misiniz?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "HATA: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "UYARI: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "%s (%s) sunucusu oturum açmamızı reddetti (hiçbir istemci kimliği tahsis etmedi). Bağlantı kesiliyor."
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Yeni kullanıcı kimliğiniz %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "UYARI: Düşük ID aldınız!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tBüyük ihtimalle bir güvenlik duvarı veya yönlendirici arkasındasınız."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tDaha fazla bilgi için: https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Bilinmeyen sunucu bilgisi alındı! - çok kısa"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "%d adet yeni sunucu alındı"
 msgstr[1] "%d adet yeni sunucu alındı"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Sunucu listesinin kaydı tamamlandı."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Sunucu son komutu reddetti"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "Sunucudan bozuk paket alındı: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Sunucudan paket alınırken beklenmeyen hata: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "%s bağlantısı için DNS çözümlemesi yapılamıyor."
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "Sunucu IP. %s (%s) süzüldü.  Bağlanılmıyor."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "protokol gizleme kullanılarak."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "Şuna bağlanılıyor: %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Sunucu %s için DNS çözümlenemiyor: Bağlanmak imkansız!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "aMuleGUI Günlüğü"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Sunucu eklenmedi: Bir IP veya makine adı girilmedi."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Sunucu eklenmedi: Geçersiz sunucu portu girildi."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k Durumu:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "Bağlantı Türü:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "Bağlandı"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kademlia Durumu:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "LAN kipinde çalışıyor"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Çalışıyor"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kademlia istemci kimliği:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Durum:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Bağlantı Durumu:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Güvenlik Duvarı - yönlendirici veya güvenlik duvarınızda %d TCP portunu açın"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP Bağlantı Durumu:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Güvenlik Duvarı - yönlendirici veya güvenlik duvarınızda %d UDP portunu açın"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Güvenlik duvarı durumu: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Eşe gerek yok - TCP portu açık"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Eşe gerek yok - UDP portu açık"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Eş yok"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "Eşe Bağlanıyor"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Eşe %s üzerinde bağlandı"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Fihristlenen Kaynaklar:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Fihristlenen anahtar kelimeler:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Fihristlenen notlar:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Fihristlenen yük:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Kullanıcı Ortalaması:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Dosya Ortalaması:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Çalışmıyor"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "%s dosyası paylaşılanlara ekleniyor"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu"
 msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
 msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "Filtre tarafından %i dosya paylaşımdan dışlandı"
 msgstr[1] "Filtre tarafından %i dosya paylaşımdan dışlandı"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "HATA: %s paylaşılmak istendi"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Paylaşılan dizin bulunamadı, atlanıyor: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "Kullanıcı Adı"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "İndirme Hızı"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Gönderme Hızı"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "Erişilebilir Parçalar"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "Gönderme Durumu"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "İndirme Durumu"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Köken"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "Yerel Dosya Adı"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "Paylaşılan Dosyalar Listesi"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Alınan Parçalar"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Dizin Konumu"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Yorum/Puanlama Ekle"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Yorum/Puanlama Düzenle"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Yeniden Adlandır"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "Yerel Verileri Kontrol Et"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Koleksiyondaki dosyaları aktarım listesine ekle"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Magnet &bağlantısını panoya kopyala"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "eD2k bağlantısını panoya kopyala (&Kaynak)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "eD2k bağlantısını panoya kopyala (Kaynak) (&Şifreleme seçenekleriyle birlikte)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "eD2k bağlantısını panoya kopyala (&Makine Adı)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "eD2k bağlantısını panoya kopyala (Makine adı) (&Şifreleme seçenekleriyle birlikte)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "eD2k bağlantısını panoya kopyala (&AICH bilgisi)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "eD2k bağlantısını panoya kopyala (&AICH bilgisi + Kaynak)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "PartFile üzerinde Yerel Veri Kontrolü güncel olarak desteklenmemektedir: %s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Geçerli bir kaynak bağlantısı oluşturmak için YüksekID almanız gerekiyor"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Dosya Adı"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Gönderilen Veri (Oturum (Toplam)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Toplam Ek Yük (Paket): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Dosya İstemi Ek Yükü (Paket): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Kaynak Değişimi Ek Yükü (Paket): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Sunucu Ek Yükü (Paket):%s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad Ek Yükü (Paketler): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Şifreleme ek yükü (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Aktif Gönderimler: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Bekleyen Gönderimler: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Toplam başarılı gönderme oturumu: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Toplam başarısız gönderme oturumu: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Ortalama gönderme süresi: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Aktarılan Veri (Oturum (Toplam)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Bulunan Kaynaklar: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Aktif İndirmeler (parçalar): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Oturum GÖN:İND Oranı (Toplam): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Ortalama aktarım oranı (Oturum): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Ortalama gönderim oranı (Oturum): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "En fazla aktarım oranı (Oturum): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "En fazla gönderim oranı (Oturum): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Yeniden Bağlanma: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "İlk Aktarımdan Beri Geçen Süre: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "%s beri Sunucuya Bağlı"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Aktif Bağlantılar (yaklaşık): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Ulaşılan En Fazla Bağlantı Sınırı: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Ortalama Bağlantılar (yaklaşık): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Doruk Bağlantılar (yaklaşık): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Kullanıcılar"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "Bilinmiyor: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "Süzülen: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "Engellenen: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Toplam: %i Bilinen: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Çalışan Sunucular: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Başarısız Sunucular: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Toplam: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Silinen Sunucular: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Süzülen Sunucular: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Çalışan Sunuculardaki Kullanıcı Sayısı: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Çalışan Sunuculardaki Dosya Sayısı: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Toplam Kullanıcılar: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Toplam Dosyalar: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Sunucu Bağlantısı: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Paylaşılmış Dosya Sayısı: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Ortalama dosya boyutu: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "İşletim Sistemi"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Alınmadı"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Aktif Bağlantılar (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Devre dışı"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Hiç"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "`%s' komutu, pid `%d' içermekteydi ve durum kodu `%d' ile sona erdi."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str> çalıştır ve çık."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Geçersiz IP biçimi. xxx.xxx.xxx.xxx:xxxx kullanınız.\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Bu komut bir argüman gerektiriyor. Geçerli argümanlar: 'all', dosya adı veya bir sayı.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Adresleme ile işleniyor: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Dosya adı ile işleniyor: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Bu komut bir argüman gerektirir. Geçerli argümanlar: bir dosya adreslemesi.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Geçerli bir sayı değil\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Geçerli bir adresleme değil (uzunluğu tam olarak 32 karakter olmalı)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7182,7 +7093,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7192,7 +7103,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7200,82 +7111,80 @@ msgstr ""
 "Hiçbir arama türü tanımlanmadı.\n"
 "Daha fazla yardım için 'help search' yazınız.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Dosyayı indir: %lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "İstem bilinmeyen bir hatayla başarısız oldu."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "İşlem başarılı."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "İstek şu hata ile başarısız oldu: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Kullanıcılar için IP Süzgeci %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "KAPALI"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "AÇIK"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Sunucular için IP süzgeci %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Şu anki IP Süzgeç seviyesi %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Bağlantı sınırları: Gön: %u kb/s, İnd: %u kB/s.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "\"Endgame\" kaynak değişimi şu durumdadır: %s.\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Arama başlatıldı (id %u).\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "Bağlandı: %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Şimdi bağlanıyor"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "güvenlik duvarı"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "tamam"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7284,7 +7193,7 @@ msgstr ""
 "\n"
 "İndirme:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7293,7 +7202,7 @@ msgstr ""
 "\n"
 "Gönderme:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7302,7 +7211,7 @@ msgstr ""
 "\n"
 "Sıradaki Kullanıcılar:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7311,46 +7220,46 @@ msgstr ""
 "\n"
 "Toplam Kaynak:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[Parça Dosyası]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "Arama süresi dolmuş veya bilinmeyen kimlik. Yeni bir arama başlatın.\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Arama sonuçları sayısı:%i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "Arama süreci: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "Arama süreci görüntülenemiyor"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Sunucudan bilinmeyen bir cevap alındı.: OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Kısa durum bilgisi göster."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Bağlantı durumunu, o anki gönderim/aktarım hızını v.b. göster.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Tüm istatistik ağacını göster."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7364,11 +7273,11 @@ msgstr ""
 "\n"
 "Örnek: 'istatistik 5 sadece her yazılım türünün en üstteki 5 sürümünü gösterecektir.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "aMule' yi kapat."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7378,35 +7287,35 @@ msgstr ""
 "Bu ayrıca sonraki aracı da kapatacaktır; çünkü çalışan bir çekirdek olmadan\n"
 "bir işe yaramayacaktır.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "Verilen nesne yeniden yükleniyor."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "Paylaşılmış dosya listesini yeniden yükler."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "Dosyadan IP süzgeci tablosunu yeniden yükler."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "IP süzme seviyesini seçiniz."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "Dosyadan IP süzgeci tablosunu yeniden yükler."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "Bir URL verilmediyse ayarlarda belirlenen URL kullanılır."
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "Ağa bağlan."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7418,35 +7327,35 @@ msgstr ""
 "IP onluk IPv4 adresi biçiminde veya çözümlenebilir\n"
 "bir DNS adı olmalıdır."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "Sadece eD2k ağına bağlan."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "Sadece Kad'a bağlan."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Ağ bağlantısını kes."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Bu, şu anda bağlı olduğunuz tüm ağlarla bağlantıyı kesecektir.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Sadece eD2k bağlantısını kes."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Sadece Kad'dan bağlantıyı kes."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "Çekirdeğe bir eD2k veya magnet bağlantısı ekler."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7464,51 +7373,51 @@ msgstr ""
 "\n"
 "Magnet bağlantısı eD2k adreslemesi ve dosya boyutunu içermelidir.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Bir ayar değeri girin."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "IP Süzgeci ayarları girin."
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "IP süzgecini hem kullanıcılar hem de sunucular için aç."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "IP süzgecini hem kullanıcılar hem de sunucular için kapat."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "IP süzgecini kullanıcılar için Aç/Kapat."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "IP süzgecini kullanıcılar için aç."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "IP süzgecini kullanıcılar için kapat."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "IP süzgecini sunucular için Aç/Kapa."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "IP süzgecini sunucular için aç."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "IP süzgecini sunucular için kapat."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "IP süzme seviyesini seçiniz."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7516,71 +7425,71 @@ msgstr ""
 "Geçerli süzme seviyeleri 0-255 aralığındadır. Varsayılan\n"
 "değer 127'dir.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Bağlantı sınırlarını girin."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Bu komutlar için girdiler kilobayt/saniye cinsinden olmalıdır.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Gönderme sınırını girin."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Girilen değer kilobayt/saniye cinsinden olmalıdır.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "İndirme sınırını girin."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "\"Endgame\" kaynak değişimini etkinleştir veya devre dışı bırak."
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Girilen değer 1/ON (etkinleştir) veya 0/OFF (devre dışı bırak) olmalıdır.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Bir ayar değerini al ve göster"
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "IP Süzgeci ayarlarını al."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Hem kullanıcılar hem de sunucular için IP süzgeci durumunu al."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "Sadece kullanıcılar için IP süzgeci durumunu al."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "Sadece sunucular için IP süzgeci durumunu al."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "IP süzme seviyesini seçiniz."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Bağlantı sınırlarını al."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "\"Endgame\" kaynak değişim durumunu al."
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "Kad araması yapar."
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7614,23 +7523,23 @@ msgstr ""
 "Örnek: 'search global linux iso --type Iso --min-size 100M' şunu geri gönderir:\n"
 "\"linux iso\" için Iso dosya türünde asgari 100 MiB boyutunda sonuçlar.\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "Genel arama yapar."
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "Sunucuda arama yapar."
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "Kad araması yapar."
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "Bir arama sonuçlarını göster."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7638,11 +7547,11 @@ msgstr ""
 "Bir aramanın sonuçlarını gösterir.\n"
 "Seçime dayalı olarak bir arama kimliği alır ('search …' unsurundan); kimlik yoksa en son başlatılan aramanın sonuçlarını gösterir.\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "Bir aramanın işleyişini göster."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7650,11 +7559,11 @@ msgstr ""
 "Bir aramanın ilerleyişini göster.\n"
 "Seçime dayalı olarak bir kimlik alır; kimlik yoksa en son başlatılan aramanın ilerleyişini gösterir.\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Dosyayı indirmeye başla."
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7662,80 +7571,80 @@ msgstr ""
 "Son arama sonucunda elde edilen dosya numarası verilmelidir.\n"
 "Örnek: '12 İndir' bir önceki aramadaki 12 numaralı dosyayı indirmeye başlayacaktır.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Aktarımı duraklat."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Aktarıma devam et."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Aktarım İptal."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "İndirme önceliği ayarla."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Bir aktarımın önceliğini Düşük, Normal, Yüksek veya OTO. ayarla.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Önceliği Düşük ayarla."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Önceliği Normal ayarla."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Önceliği Yüksek ayarla."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Önceliği Otomatik ayarla."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Sıra/liste göster."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Gönderme/indirme sırasını,sunucu listesini veya paylaşılmış dosya listesini gösterir.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Gönderim sırasını göster."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "İndirme sırasını göster."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Günlük kayıtlarını göster."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Sunucu listesini göster."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "Paylaşılan dosyalar listesini göster."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Günlük kayıtlarını sıfırla."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Geçersiz komut, yerine '%s' kullanın."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7744,261 +7653,258 @@ msgstr ""
 "Bu geçersiz bir komut, ve gelecekte belki çıkartılabilir.\n"
 "Bunun yerine '%s' kullanın.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule metin aracı"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s' içindeki eski AICH adresleme setleri '%s' içindeki 64 b'ye çevriliyor."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "Yerel Veri Kontrolü (%s): %s için Sonuç Tamam"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "Yerel Veri Kontrolü (%s): HATA TESPİT EDİLDİ! %s başarısız blok: MD4: %s. %s%s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "UYARI: '%s' dosya adı geçersiz ve '%s' olarak yeniden adlandırıldı."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "UYARI: '%s' dosyası zaten var ve '%s' olarak yeniden adlandırıldı."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Bu sınıf içindeki bütün dosyaları iptal edip silmek istediğinizden emin misiniz?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Onaylama Gerekiyor"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "Sadece 99 kategori desteklenir."
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "Çok fazla kategori!"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Tüm Diğerleri"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Görünüm Süzgeci Seç"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Sınıf Ekle"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Sınıfı Düzenle"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Sınıfı Kaldır"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Bilinmeyen dosya için adresleme seti istendi: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Şu dosya için gönderimler sürdürülüyor: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Şu dosya için gönderimler bekletiliyor: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "%s komutunun %s olayında çalıştırılması başarısız oldu."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "İndirme tamamlandı"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Dosyanın tam konumu."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Konum eki olmaksızın dosyanın tam adı."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "Dosyanın eD2k adreslemesi."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Dosyanın bayt cinsinden boyutu."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Toplam indirme hareketleri süresi."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Yeni sohbet oturumu başladı"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "İleti göndericisi."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Dolu"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Disk bölümü."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Tamamlama sırasında hata"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "İşlenmekte olan dosya sayısı %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Parça dosyalarını sormuştunuz (Sadece 9.5 MB' tan büyük dosyalar)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Var olmayan dosya!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, aMule'nin eD2k bağlantı oluşturucusu"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Hoş geldiniz!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Girdi parametreleri"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Adreslenecek Dosya"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Bu dosya için isteğe bağlı adres ekleyin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "eD2k bağlantısının hesaplanmasını istediğiniz dosyayı buraya girin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "eD2k bağlantısına eklenecek URL' yi girin: aLinkCreator' ün geçerli dosya adını ekleyebilmesi için sonuna / ekleyin"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Parça adreslemesi içeren bağlantı oluştur."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Yeni ve nadir dosyaların yayılmasına yardımcı olun;bunun bedeli ise artan bağlantı boyutu olacaktır."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 Dosya Adreslemesi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k Dosya Adreslemesi"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k bağlantısı"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Aç"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "eD2k bağlantısını hesaplamak için bir dosya açın"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Hesaplanan eD2k bağlantısını panoya kopyala"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Farklı Kaydet"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Hesaplanan eDk2 bağlantısını dosyaya kaydet"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "aLinkCreator Hakkında"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "eD2k bağlantısının hesaplanacağı dosyayı seçiniz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Pano açılamıyor"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Şimdilik kopyalanacak bir şey yok !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Seçiniz"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Açılamıyor "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Lütfen boş olmayan bir dosya adı giriniz."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Şimdilik kaydedilecek bir şey yok !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8018,167 +7924,159 @@ msgstr ""
 "\n"
 "GPL kapsamında dağıtılır."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Adresleniyor…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator sizin için çalışıyor"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "MD4 Adreslemesi hesaplanıyor…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "eD2k Adreslemeleri hesaplanıyor…"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "İptal Edildi !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "%.2f s içinde tamamlandı."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Bu adresi zaten eklemiştiniz. !"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Lütfen boş olmayan bir adres giriniz."
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "%s açılamıyor."
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "ed2k adreslemesi hesaplanırken bellek yetersiz kaldı!"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i gün %i saat %i dakika %i saniye"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uD %02uh %02udk. %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uh %02udk. %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02udk. %02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02us"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule Bağlantı İstatistikleri"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "wxCas çalışmaya başladığından beri en fazla aktarım oranı"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "wxCas'ın önceki açılışlarındaki kesin En Fazla İND. oranı"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Sistem"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Otomatik Yenilemeyi Durdur."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Bağlantı İstatistikleri imajını kaydet."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Bağlantı İstatistikleri imajını yazdır."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Ayarlar"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "wxCas Hakkında"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Otomatik Yenilemeyi Başlat"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Otomatik Yenilemeyi Durdu."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Otomatik Yenileme Başladı."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "İstatistik imajını kaydet."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule Bağlantı İstatistikleri"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8186,11 +8084,11 @@ msgstr ""
 "Yazdırmada bir sorun var.\n"
 "Yazıcınız doğru ayarlanmamış olabilir mi?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Yazdırılıyor"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8208,375 +8106,364 @@ msgstr ""
 "\n"
 "GPL kapsamında dağıtımı yapılır."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "Aman aman, aMule çalışmıyor…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule çalışıyor"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule çalışıyor ama bağlı değil."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule bağlanıyor…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Aman aman, aMule'nin durumu bilinmiyor…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " şu süredir çalışıyor: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " durdu !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " bağlı değil !"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " bağlanıyor…"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " garip şeyler yapıyor, denetleyiniz!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " şuna bağlandı: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "bağlı değil"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " bağlı "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " ile "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Toplam Aktarım: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", Gönderme: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Oturumdaki Aktarım: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Aktarım: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " kB/s, Gönderme "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Paylaşılan: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " dosya(lar), sıradaki kullanıcılar: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Süre: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " bağlı "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Sistem Yükü Ortalaması (1-5-15 dk.): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Sistem çalışma süresi: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Dizin amulesig.dat dosyası içeriyor"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Buraya amulesig.dat dosyasının bulunduğu dizini giriniz"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Saniye bazında yenileme döngüsü"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Her yenileme olayında bir durum imajı oluştur"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Buraya istatistik imajının oluşturulacağı dizini giriniz."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Durum imajını düzenli olarak FTP sunucusuna gönder"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP bağlantısı"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP Yolu"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Buraya FTP Sunucunuz için adresi giriniz."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Buraya durum imajını koyacağınız FTP Sunucusundaki bir dizini giriniz."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Kullanıcı"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "FTP sunucunuza girebilmek için bir Kullanıcı adı giriniz."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "FTP sunucunuza girebilmek için bir Şifre giriniz."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Dakika bazında FTP günceleme hızı"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Onayla"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Dizin imza dosyanızı içeriyor."
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "İstatistik imajının üretildiği dizin"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Şablonu yükler <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web sunucusu HTTP portu"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Web sunucu portu üzerine iletmek için UPnP portunu kullan"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP portu"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Gzip sıkıştırması kullan"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Web sunucusu için tam erişim parolası"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Web sunucusu için konuk parolası"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Konuk girişine izin ver"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Konuk girişini reddet"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Web sunucusu ayarlarını uzak aMule'ye/ aMule'den kaydet/yükle"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule yapılandırma yolu: DOĞRUDAN KULLANMAYINIZ!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "PHP yorumcusunu devreden çıkar (eskimiş)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Her istemde PHP sayfalarını yeniden oluştur"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Web Sunucusu"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "web aracı bağlantısı kabul edildi\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "HATA: web aracı bağlantısı kabul edilemiyor\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "İstem şu hatayla başarısız oldu: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Fihristleme dosyası bulunamadı: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Oturum sona erdi - giriş gerekiyor\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Oturum tamam, giriş yapıldı.\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Oturum tamam, giriş yapılmadı.\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Hiç oturum açılmadı - giriş gerekecek\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Oturum oluşturuldu - giriş gerekiyor\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "İstem işleniyor [özgün]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "URL sorgu dizesinden `pass` unsurunun okunması reddediliyor.\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "Bir parola belirtilmemiş. Giriş yapılamaz."
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Şifre denetleniyor\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Şifre adreslemesi geçersiz.\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Şifre kabul edildi.\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Şifre kötü.\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Herhangi bir şifre girmediniz. Boş şifre kullanılamaz.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Çıkış istendi.\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "İstem işleniyor [yönlendirilmiş]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule (gerekli)"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "Masaüstü kısayolu"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "aMule'ü oturum açtığımda başlat"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "Kurulumu kaldır"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "Kullanıcı verilerini sil (yapılandırma, ED2K sunucuları, Kad düğümleri, kısmi dosyalar)"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "aMule uygulama dosyaları (gerekli)."
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "Masaüstünde bir aMule kısayolu oluştur."
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "Güncel kullanıcı oturum açtığında aMule'ü otomatik olarak başlat (kullanıcı başı ayar)."
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "aMule uygulama dosyalarını, Başlat Menüsü / masaüstü kısayollarını, otomatik başlatma çalıştırma anahtar unsurunu, URL şema kayıtlarını ve Program Ekle/Kaldır unsurunu kaldır (gerekli)."
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "Güncel kullanıcı için %APPDATA%\\aMule unsurunu (aMule.conf, ED2K sunucu listesi, Kad düğümleri, kısmi dosyalar, IP filtreleri, arkadaş listesi) daimi olarak sil. Ayarlarınızı muhafaza etmek için şıkkı işaretlemeyin."
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8584,7 +8471,7 @@ msgstr ""
 "aMule, $INSTDIR. konumundan çalışıyor gibi görünüyor.\r\n"
 "Lütfen aMule'ü (ve aMuleD ile aMuleGUI programlarını) kapatın ve tekrar deneyin."
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8592,11 +8479,11 @@ msgstr ""
 "aMule daemon'u (amuled.exe) $INSTDIR konumundan çalışıyor gibi görünüyor.\r\n"
 "Lütfen onu durdurup tekrar deneyin."
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "$0 konumundaki önceki aMule kurulumu kaldırılıyor…"
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8604,11 +8491,11 @@ msgstr ""
 "$0 konumundaki önceki aMule kurulumu kaldırılamadı.\r\n"
 "Lütfen çalışmakta olan tüm aMule süreçlerini kapatın ve tekrar deneyin, veya evvela önceki kurulumu el ile kaldırın."
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum programını tekrar başlatın."
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "Показати aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "Віддалене керування aMule"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Знімок:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -41,7 +41,7 @@ msgstr ""
 "'Багатоплатформений' p2p-клієнт, що оснований на eMule \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -50,79 +50,79 @@ msgstr ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "Частина aMule основана на \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "Сторінка в Інтернет:"
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "Форум:"
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "Перевірити наявність нової версії під час запуску"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "З'єднується з Kad"
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "Недоступний"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "Додати друга"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "Ви повинні ввести вірну IP-адресу та порт!"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "Інформація"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "Визначений хеш користувача невірний"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -131,49 +131,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "Після назви програми"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "З'єднання невдале "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -182,103 +181,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "Не вдалося відкрити файл ED2KLinks."
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе як джерело для eD2k-посилання маючи LowID."
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "Тепер, виходимо з головної програми..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "Невдалі"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "Вбиваю екземпляр amuleweb з pid `%d' ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule OnExit: Завершується core."
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "Завершення роботи aMule закінчене."
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "Наслідки зневадження пам'яті для виходу aMule:"
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "Ваша локаль змінена на системну за замовчуванням із-за зміни налаштувань. Вибачте."
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "Інфо"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -286,74 +282,70 @@ msgstr ""
 "\n"
 "Налаштування зовнішніх з'єднань"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "ЗАСТЕРЕЖЕННЯ"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "Веб-сервер запущений з %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "Неможливо прив'язати порт до визначеної адреси: %s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "Порт %u недоступний. Ви будете мати LowID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -368,48 +360,48 @@ msgstr ""
 "\n"
 "Перевірте вашу мережу, щоб впевнитись, що порт відкритий."
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "Неможливо створити файл онлайн-підпису aMule"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "Обрана локаль здається не встановлена. (примітка: спроба встановити її в будь-якому випадку)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "Ви запускаєте aMule %s вперше"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "Це тестова версія, оновлюється щодня, та\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "ми не даємо жодної гарантії, якщо вона щось пошкодить, спалить ваш будинок,\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "або вб'є собаку. Але вона *має бути* безпечною у використанні всюди.\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "Більше подробиць, підтримка та нові випуски можуть бути знайдені на нашій сторінці,\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "на https://amule-org.github.io, або у нашому IRC-каналі #aMule на irc.libera.chat.\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "Не соромтеся повідомити про будь-які помилки на https://github.com/amule-org/amule/issues"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -417,224 +409,220 @@ msgstr ""
 "Тека для файлів онлайн-підпису НЕВІРНА!\n"
 "Онлайн-підпис буде ВИМКНЕНО поки ви не виправите це в налаштуваннях."
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "Не вдалося виділити місце на диску для файлу '%s': %s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "ПОМИЛКА: не можу відкрити файл часопису"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "ЗАСТЕРЕЖЕННЯ: журнал порожній. Щось негаразд."
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "Часопис очищено"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "Повідомлення сервера: %s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "Не вдалося звантажити перелік вузлів."
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "Не вдалося відкрити звантажений файл перевірки версії"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "Файл перевірки версії зіпсований"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "Ви використовуєте застарілу версію aMule!"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "Ваша версія aMule %i.%i.%i, а остання %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "ЗАСТЕРЕЖЕННЯ: Ваша версія aMuled застаріла: %i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "Ваша копія aMule оновлена."
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "Неможливо звантажити файл перевірки версії"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "Користувачі: %s | Файли: %s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "Користувачі: %s K: %s | Файли: E: %s K: %s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "Не вибрано жодної мережі"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "з LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "з HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "З'єднано з %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "З'єднується з %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "Від'єднано від eD2k"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad запущена."
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad зупинена."
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "З'єднано з Kad (все гаразд)"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Мережа Kad не може бути використана якщо UDP-порт вимкнено в налаштуваннях, не починаю."
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Мережа Kad вимкнена в налаштуваннях, не з'єднуюсь."
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "ПОМИЛКА: демон aMule не може бути використаний з вимкненими зовнішніми з'єднаннями. Щоб ввімкнути зовнішні з'єднання, використовуйте або звичайний режим з опцією --ec-config або встановіть \"AcceptExternalConnections\" в 1 в файлі ~/.aMule/amule.conf"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "ПОМИЛКА: необхідний вірний пароль, щоб використовувати зовнішні з'єднання, і демон aMule не може бути використаний без зовнішніх з'єднань. Щоб запустити демон aMule, ви маєте встановити відповідне значення у полі \"ECPassword\" у файлі ~/.aMule/amule.conf. Виконайте amuled  з параметром --ec-config, щоб встановити пароль. Більше інформації можете знайти на https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled: OnInit - запускається timer"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "ПОМИЛКА: %s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Це aMule %s оснований на eMule."
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -644,194 +632,187 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "Немає мережі"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "Віддалене керування aMule"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "Жахлива помилка: не вдалося створити Core Timer"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "З'єднатися з віддаленим aMule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "Втрата з'єднання"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "Запит на вихід"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -840,153 +821,143 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "Жахлива помилка: не вдалося створити Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "Переходимо до циклу обробки подій..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "З'єднання..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "Віддалений обробник подій зовнішніх з'єднань графічного інтерфейсу"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "З'єдання невдале. Неможливо з'єднатися з %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "Вимикається"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "Спроба з'єднання з %s (%s:%i) добігла кінця."
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "З'єднання з мережею."
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "З'єдання невдале. Неможливо з'єднатися з %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "Готовий"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "Всі"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "Недоступно"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "Файл не знайдено."
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Недопустиме посилання або вже в переліку."
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Неможливо отримати спільні файли користувача %s"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Шукається друг для lowid-з'єднання"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Підробна версія eMule %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (Підробний eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (підробний eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (оснований на eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Прізвисько: %s ID: %u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Запросив: %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -994,7 +965,7 @@ msgstr[0] "Статистика файлів для цієї сесії: доз�
 msgstr[1] "Статистика файлів для цієї сесії: дозволено %d з %d запитаних, %s передано\n"
 msgstr[2] "Статистика файлів для цієї сесії: дозволено %d з %d запитаних, %s передано\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1002,120 +973,120 @@ msgstr[0] "Статистика файлів для всіх сесій: доз�
 msgstr[1] "Статистика файлів для всіх сесій: дозволено %d з %d запитаних, %s передано\n"
 msgstr[2] "Статистика файлів для всіх сесій: дозволено %d з %d запитаних, %s передано\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "Запитаний невідомий файл"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Повідомлення відфільтроване від '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Нове повідомлення від '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів для теки %s -> відмовлено"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "ЗАСТЕРЕЖЕННЯ: не можна відкрити known.met."
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 #, fuzzy
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "ЗАСТЕРЕЖЕННЯ: Перелік відомих файлів зіпсовано, містить неприпустимий заголовок."
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "Помилка введення-виведення під час читання файлу known.met: %s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, fuzzy, c-format
 msgid "Error while saving %s file: %s"
 msgstr "Помилка під час збереження файлу known.met: %s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категорія"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "Нова категорія"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "Виберіть теку для вхідних файлів"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "Ви повинні визначити назву категорії"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "Ви повинні визначити шлях категорії!"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "Неможливо створити вхідну теку для категорії. Будь ласка, вкажіть вірний шлях!"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "Розмову розпочато: %s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** З'єднано з клієнтом ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** З'єднуюсь з клієнтом ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** Неможливо з'єднатись з клієнтом / з'єднання втрачене***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "Закрити вкладки"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "Закрити всі вкладки"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "Закрити інші вкладки"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "Додати до друзів"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
@@ -1123,7 +1094,7 @@ msgstr[0] "Завантажено файл довіри, %u відомий кл�
 msgstr[1] "Завантажено файл довіри, %u відомі клієнти"
 msgstr[2] "Завантажено файл довіри, %u відомих клієнтів"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
@@ -1131,173 +1102,170 @@ msgstr[0] " - Довіра сплила для %u клієнта"
 msgstr[1] " - Довіра сплила для %u клієнтів"
 msgstr[2] " - Довіра сплила для %u клієнтів"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "Не знайдено 'cryptkey.dat', створюємо."
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "Подробиці клієнта"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "Дозволено"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "Підтримується"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "Не підтримується"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "Вимкнено"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "З'єднано"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "Від'єднана"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f кбайт/с"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "Незавершено"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "Поганий хлопець"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Перевірено - добре"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "Недоступно"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів -> Дозволено"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів -> Відмовлено"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних тек -> Дозволено"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних тек -> Відмовлено"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів для теки %s -> Дозволено"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів для теки %s -> відмовлено"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "Користувач %s (%u) зробив спільною теку %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "Користувач %s (%u) надіслав незапитані спільні теки."
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, fuzzy, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "Користувач %s (%u) надіслав перелік спільних файлів для теки %s"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "Користувач %s (%u) завершив надсилати перелік спільних файлів"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "Користувач %s (%u) надіслав небажаний перелік спільних файлів"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "Користувач %s (%u) заборонив доступ до переліку спільних тек/файлів"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "Коментарі файлу"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Назва файлу"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "Коментар"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Пошук у Kad неможливо виконати коли Kad не працює"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "Шукається друг для lowid-з'єднання"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "Немає коментарів"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
@@ -1305,272 +1273,262 @@ msgstr[0] "%u коментар"
 msgstr[1] "%u коментарі"
 msgstr[2] "%u коментарів"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, fuzzy, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "Не вдалося звантажити GeoIP.dat з %s"
 
 # перевага
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "Авто [низька]"
 
 # перевага
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "Авто [звичайна]"
 
 # перевага
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "Авто [висока]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Висока"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "Дуже висока"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "Випуск"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "Запитується"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "З'єднується через сервер"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "Черга заповнена"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В черзі"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Звантажується"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "Отримується набір хешів"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "Немає потрібних частин"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "Не можу з'єднати LowID з LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "Забагато з'єднань"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "З'єднується через Kad"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Забагато з'єднань Kad"
 
 # користувач
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "заборонений"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "Помилка з'єднання"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "Віддалена черга заповнена"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "Старий MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "Новий MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "Сумісний з eMule"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "Місцевий сервер"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "Обмін джерелами"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "Бездіяльні"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "Посилання"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "Поширювачі джерел"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "Здобутки пошуку"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершених"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "В дії"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ПОМИЛКА: немає місця на диску"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "ПОМИЛКА: частковий met-файл не знайдений"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "ПОМИЛКА: помилка введення-виведення!"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "ПОМИЛКА: невдача!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "В черзі"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "Вже звантажений"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "Невідомий або неправильний формат тимчасового файлу"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "Частина"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "Переданих"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Швидкість"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "Перебіг"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Джерела"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Перевага"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "Стан"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "Залишилось"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "Востаннє повний"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "Останнє отримання"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "Ви впевнені, що хочете видалити вибраний файл?"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "Ви впевнені, що хочете видалити вибрані файли?"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1579,109 +1537,106 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "Зупинити"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "Призупинити"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "Продовжити"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "Видалити завершені"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "Віддати всі A4AF-джерела цьому файлу зараз"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "Віддати всі A4AF-джерела цьому файлу (авто)"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "Віддати всі A4AF-джерела іншим файлам зараз"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "Розширені налаштування"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "Попередній перегляд"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "Показати подробиці файлу"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "Показати всі коментарі"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "Скопіювати magnet-посилання в буфер обміну"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "Скопіювати eD2k-посилання до буферу обміну"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Скопіювати інформацію відгуку до буферу обміну"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "прибрати"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "Призначити категорію"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "Відкрити файл"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "Введіть нову назву для цього файлу:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "Змінити назву файлу"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f кбайт/с"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Звантаження (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1690,47 +1645,47 @@ msgstr ""
 "Щоб попередити показ цього застереження під час кожного попереднього перегляду,\n"
 "оберіть відеопрогравач в налаштуваннях (за замовчуванням %s)."
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "Попередній перегляд файлу"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ПОМИЛКА: не вдалося виконати зовнішній медіа-програвач! Команда: '%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "Зберігається частковий файл %u з %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "Всі часткові файли збережені."
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "Завантаження тимчасових файлів з %s."
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "Завантажуються частковий файл %u з %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "ПОМИЛКА: не вдалося завантажити файл резервної копії. Шукайте на https://github.com/amule-org/amule/discussions вирішення проблем відновлення .part.met"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "Всі часткові файли завантажені."
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "Не знайдено жодного часткового файлу"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
@@ -1738,50 +1693,50 @@ msgstr[0] "Знайдений %u частковий файл"
 msgstr[1] "Знайдені %u часткові файли"
 msgstr[2] "Знайдені %u часткових файлів"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "Файлова система для теки тимчасових файлів не може обробити великі файли."
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "Файлова система для теки вхідних файлів не може обробити великі файли."
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "Звантажую %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "Ви вже спробували звантажити файл '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "Ви вже маєте файл '%s'"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "Ви вже маєте файл '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ви вже спробували звантажити файл %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "Неможливо перетворити magnet-посилання в eD2k-посилання: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "Невідомий протокол посилання: %s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
@@ -1789,256 +1744,255 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "Невірне eD2k-посилання! ПОМИЛКА: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client sent packet after authentication failed."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "Зовнішні з'єднання вимкнені, оскільки відсутній пароль!"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "Зовнішні з'єднання вимкнені у файлі налаштувань."
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "ПОМИЛКА: неможливо дозволити нове зовнішнє з'єднання"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "Відмовлено у зовнішньому з'єднанні, оскільки в налаштуваннях порожній пароль!"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "З'єднується клієнт: %s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "Невідома версія"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "Невірний ID версії EC, може бути двійкова несумісність. Використовуйте ядро та віддаленого клієнта з того самого зрізу"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "Ви не можете під'єднатись до остаточної версії з довільної SVN-версії! Можлива відмова попереджена"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "Невірна версія протоколу."
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "Відсутня позначка версії протоколу."
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: wrong password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Authentication failed: missing password."
 msgstr "Аутентифікація не вдалася."
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Invalid request, please authenticate first."
 msgstr "Невірний запит, ви маєте спочатку представитись."
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "Дозвіл надано."
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "Спроба доступу без уповноваження. З'єднання розірвано."
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "Віддалена PartFile-команда не вдалася: хеш файлу не знайдено: %s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "Хеш файлу не знайдений: %s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "Помилка при виконання OpCode"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "Сервер не додано"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "сервер не знайдено: %s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "потрібно визначити сервер для видалення"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k вимкнена у налаштуваннях"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Веб-пошук через віддалений інтерфейс не має сенсу. "
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "Пошук просувається. За мить отримаю здобутки!"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "Немає точок для графіку."
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "Ваш клієнт не налаштований для такого рівня подробиць."
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "Зовнішнє з'єднання: запит на вимкнення"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "Вже вимикається."
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "Зовнішнє з'єднання: додається посилання '%s'"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "Недопустиме посилання або вже в переліку."
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "Файл не знайдено."
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "Недопустима назва файлу."
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Неможливо змінити назву файлу."
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad вимкнена в налаштуваннях."
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "Вже з'єднано з eD2k"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "З'єднується з eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Вже з'єднано з Kad."
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "З'єднується з Kad"
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "Всі мережі вимкнені."
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "Від'єднується від eD2k."
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "Від'єднується від Kad."
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "Зовнішнє з'єднання: отримано недопустимий opcode: %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "Недопустимий opcode (невірна версія протоколу?)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "Невідоме розширення '%s' для команди '%s'.\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "Невідома команда '%s'.\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2046,7 +2000,7 @@ msgstr ""
 "\n"
 "Ця команда не може мати аргумент.\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2054,7 +2008,7 @@ msgstr ""
 "\n"
 "Ця команда повинна мати аргумент.\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2062,7 +2016,7 @@ msgstr ""
 "\n"
 "Ця команда незавершена, ви повинні використати одне з розширень, що подані нижче.\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2070,11 +2024,11 @@ msgstr ""
 "\n"
 "Доступні розширення:\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "Доступні команди:\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2084,17 +2038,17 @@ msgstr ""
 "\n"
 "Всі команди розрізняють великі та малі літери.Введіть '%s <command>' щоб отримати докладну інформацію по <command>.\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "Вийти з програми."
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "Показати допомогу."
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2102,7 +2056,7 @@ msgstr ""
 "Щоб отримати допомогу по команді, введіть 'help <command>'.\n"
 "Щоб отримати повний перелік команд, введіть ''help\".\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2113,46 +2067,46 @@ msgstr ""
 "Використовуйте '%s' для переліку команд\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "Помилка синтаксису!"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "Помилка обробки команди - не повинно ніколи такого бути! Будь, ласка, повідомте про помилку\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "Ця команда не повинна мати жодного параметру."
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "Ця команда повинна мати параметр."
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "Невірний аргумент."
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "Це незавершена команда"
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "Напишіть '%s' щоб отримати більше допомоги.\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "Це %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "Це %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2160,7 +2114,7 @@ msgstr ""
 "\n"
 "Створюється клієнт...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2169,7 +2123,7 @@ msgstr ""
 "\n"
 "Добре, виходимо %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2183,331 +2137,326 @@ msgstr ""
 "\n"
 "Вихід...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "Показати цей текст допомоги."
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "Хост, де запущений aMule (за замовчуванням: 127.0.0.1)."
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "Порт aMule для зовнішніх з'єднань (зазвичай: 4712)."
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "Пароль зовнішнього з'єднання"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "Читати налаштування з файлу."
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "Не друкувати нічого до stdout."
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "Бути докладним: показувати також всі повідомлення налагодження"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "Вибрати локаль програми (мова)."
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "Записати параметри командного рядка до файлу налаштувань."
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "Створити файл налаштувань оснований на файлі налаштувань aMule."
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "Друкувати версію програми."
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "Подробиці файлу"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, fuzzy, c-format
 msgid "%.1f%% done"
 msgstr "%.2f%% виконано"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f кбайт/с"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "Ласкаво просимо!"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "З'єднання з другом"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "Стан з'єднання:"
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "Мережі"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "Зразковий TCP-порт "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "Розширений порт UDP (Kad / глобальний пошук) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "Ввімкнути UPnP для перенаправлення портів"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "Початковий запуск"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "Ви вже спробували звантажити файл %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "Автоматичне оновлення переліку серверів після запуску"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Переглянути"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "Неможливо відкрити перелік друзів 'emfriends.met' для читання!"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "Неможливо відкрити перелік друзів 'emfriends.met' для запису!"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "Друзі"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "Показати подробиці"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "Додати друга"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "Видалити друга"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "Надіслати повідомлення"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "Переглянути файли"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "Встановити шматок для друга"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "Ви впевнені, що бажаєте видалити вибраного друга?"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "Ви впевнені, що бажаєте видалити вибраних друзів?"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2515,11 +2464,11 @@ msgstr ""
 "Встановлення більш ніж одного шматка для друга не дозволено.\n"
 "Був виділений тільки один слот."
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "Численний вибір"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2528,187 +2477,186 @@ msgstr ""
 "Встановлення більш ніж одного шматка для друга не дозволено.\n"
 "Був виділений тільки один слот."
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "Надіслати повідомлення користувачу"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Повідомлення:"
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "Видалити з друзів"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "Надіслати повідомлення"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Перемкнути на цей файл"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "Запитано інший файл"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "Waiting for upload slot"
 msgstr "Вивантаження очікують: %s"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u"
 msgstr "В черзі"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Uploading"
 msgstr "Вивантаження"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Жоден"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "Ні"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "Так"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "Звантажування..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP завантаження скасоване"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "Неможливо отримати спільні файли користувача %s"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "Звантажені"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "HTTP завантаження скасоване"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "Звантажую новий GeoIP.dat з %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "Неможливо видалити файл GeoIP.dat, оновлення зірване."
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "Неможливо видалити файл GeoIP.dat, оновлення зірване."
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "Неможливо змінити назву нового файлу GeoIP.dat, оновлення зірване."
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Successfully updated %s"
 msgstr "Успішно оновлено GeoIP.dat"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "Помилка оновлення GeoIP.dat"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Failed to download %s from %s"
 msgstr "Не вдалося звантажити GeoIP.dat з %s"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 #, fuzzy
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "Завантажую IP-filters 'ipfilter.dat' та 'ipfilter_static.dat'."
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "Звантаження файлу ipfilter.dat '%s' зазнало невдачі, невідомий формат"
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "Звантаження файлу ipfilter.dat '%s' зазнало невдачі, неможливо відкрити файл."
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
@@ -2716,7 +2664,7 @@ msgstr[0] "Завантажено %u обсяг IP-адрес з '%s'."
 msgstr[1] "Завантажено %u обсяги IP-адрес з '%s'."
 msgstr[2] "Завантажено %u обсягів IP-адрес з '%s'."
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
@@ -2724,16 +2672,16 @@ msgstr[0] "%u спотворений рядок був відкинутий."
 msgstr[1] "%u спотворені рядки були відкинуті."
 msgstr[2] "%u спотворених рядків були відкинуті."
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, fuzzy, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "Неможливо змінити назву нового файлу GeoIP.dat, оновлення зірване."
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
@@ -2741,56 +2689,52 @@ msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Вузли (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "Недопустима IP-адреса для початкового запуску"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "Недопустимий порт для початкового запуску"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "Будь ласка, заповніть потрібні поля"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "Повідомлення"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "Ви впевнені, що хочете звантажити новий файл nodes.dat?\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "Такі дії призведуть до видалення поточних вузлів та перез'єднання з Kademlia."
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "Продовжити?"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kademlia: пошукове слово занадто коротке"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademlia: пошукове слово вже в переліку пошуку: "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
@@ -2798,12 +2742,11 @@ msgstr[0] "Прочитано %u контакт Kad"
 msgstr[1] "Прочитано %u контакти Kad"
 msgstr[2] "Прочитано %u контактів Kad"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "Не знайдено жодного контакту, будь ласка, здійсніть початковий запуск або звантажте файл nodes.dat"
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
@@ -2811,7 +2754,7 @@ msgstr[0] "Тільки %d контакт Kad доступний, nodes.dat не
 msgstr[1] "Тільки %d контакти Kad доступні, nodes.dat не записано"
 msgstr[2] "Тільки %d контактів Kad доступні, nodes.dat не записано"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
@@ -2819,805 +2762,778 @@ msgstr[0] "Записано %d контакт Kad"
 msgstr[1] "Записано %d контакти Kad"
 msgstr[2] "Записано %d контактів Kad"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "Мережа Kad"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "Назва файлу"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "Розмір файлу"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "Відношення передачі"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "Запитано"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "Дозволено"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "Завершених джерел"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "ЗАСТЕРЕЖЕННЯ: Перелік відомих файлів зіпсовано, містить неприпустимий заголовок."
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
 msgstr "Невідома версія"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unable to get error description for error %d"
 msgstr "Тека призначення для звантажень"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "Обчислюється хеш"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "Завершується"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "Завершений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Призупинений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Помилковий"
 
 # файл
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Очікує"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "Ви повинні вказати непорожній пароль."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "Неправильний пароль, не MD5-хеш"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "З'єднання невдале"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "EC з'єднання невдале. Порожня відповідь."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "Зовнішнє з'єднання: невірна відповідь сервера. З'єднання закрите."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "Успіх! Встановлене з'єднання до aMule"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "Успіх! Встановлене з'єднання."
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "Зовнішнє з'єднання: в доступі відмовлено з причини: "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Гаразд."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "ПОМИЛКА: неможливо відкрити TCP-порт"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "ПОМИЛКА: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "Закрити"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "Вирізати"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "Вибрати всі"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "З'єднано"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "З'єднано"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "З'єднано з Kad (за фаєрволом)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "IP серверу: "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "Адреса сервера:"
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "Не з'єднаний"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "Порт TCP: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "Порт TCP: не готовий"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "Порт UDP: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "Порт UDP: не готовий"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "Інформація клієнта"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "Обмеження вивантаження"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "Обмеження звантаження"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "Показати aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "Сховати aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Вийти"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "кбайт/с"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "Безмежно"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule Tray Menu"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "Обмеження швидкості:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "Вивантаження: Немає"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "Вивантаження: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "Звантаження: немає"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "Звантаження: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "Швидкість звантаження: %.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "Швидкість вивантаження: %.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "Прізвисько: %s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "Не вибрано прізвисько!"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "ID клієнта: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "Назва серверу: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "IP серверу: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "Не з'єднано"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "Online-підпис: увімкнено"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "Online-підпис: вимкнено"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "Час роботи: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "Спільні файли: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "Клієнтів в черзі: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "Всього звантажень: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "Всього вивантажень: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "Додає eD2k-посилання або magnet-посилання до ядра."
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "Додати до друзів"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "Натисніть щоб додати eD2k-посилання в текстовий нагляд до черги звантажень."
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "Тут відображаються події. Для повного переліку подій, зверніться до часопису у вкладці серверів."
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "Завантаження..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "Кількість користувачів на сервері, з якими ви з'єднані..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "Користувачів: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "Користувачі, що з'єднані з поточним сервером, та оцінка загальної кількості користувачів."
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "Вивантаження: 0.0 | Звантаження: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "Поточні швидкості вивантаження та звантаження. Значення в дужках (якщо ввімкнено) відображають службовий трафік зв'язку клієнтів."
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "Відображає стан з'єднання та чинні передачі. Червоні стрілки означають, що ви не з'єднані, жовті - маєте LowID (за фаєрволом), зелені - маєте high ID (найкраще)."
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "Не з'єднано..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "З'єднаний сервер в даний час."
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "Пошук"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "Назва:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "Місцевий"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "Глобальний"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "Розширені параметри"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "Фільтрування"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "Тип файлу"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "Будь-який"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "Архіви"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "Аудіо"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "Образи CD"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "Зображення"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "Програми"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "Тексти"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "Відео"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "Розширення"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "Найменший розмір"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "байт"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "кбайт"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "Мбайт"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "Гбайт"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "Найбільший розмір"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "Доступність"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Фільтр:"
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "Здобутки фільтру"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "Перевернути фільтр"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "Сховати відомі файли"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "Почати"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "Більше"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "Зупинити"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Звантаження"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "Очистити поля"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Здобутки"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "Очистити завершені звантаження"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Завершених джерел"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "недоступні"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "Загальні"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "Повна назва:"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met-файл:"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "Хеш:"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "Розмір файлу:"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Передавання"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "Стан часткових файлів:"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "Востаннє повний:"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "Знайдено джерел:"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "Передані джерела:"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "Кількість часткових файлів:"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "Наявні:"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "Чинний час звантаження: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "Передані:"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "Розмір завершених:"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Розумна обробка пошкоджень"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "Втрачено за рахунок спотворень:"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "Здобуто стисненням:"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "Пакунки збережено Р.О.П. :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "Спільні файли: "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "Запитів"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "Прийняті запити"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "Передані дані"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "Відношення поширення"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "Повних джерел"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "Спільні файли"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr ", вивантажень: "
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "Без рейтингу"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "Назва:"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "Назви файлів"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "Прибрати"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "Очистити"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "Застосувати"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "Коментувати/оцінити файл (текст буде видно всім користувачам)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3625,1275 +3541,1271 @@ msgstr ""
 "Для фільму ви можете написати тривалість, сюжет, мову... \n"
 "або ж якщо він підробний, ви можете розповісти це іншим користувачам aMule."
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "Якість файлу"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "Без рейтингу"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "Невірний / Зіпсований / Підробний"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "Погано"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "Непогано"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "Добре"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "Відмінно"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "Змінити оцінку файлу або повідомити користувачів, якщо файл невірний..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "Від'єднано від Kad"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "Оновити"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "Звантажується, будь ласка, зачекайте..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "Невідомий розмір"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "Потрібна інформація"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP-адреса:"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Додаткова інформація"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "Ім'я користувача:"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "Додати"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "Середня за сесію"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Швидкість вивантаження"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "Дерево статистики"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "Ім'я користувача:"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "Програма клієнта:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "Версія клієнта:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP-адреса:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "ID користувача:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "Адреса сервера:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "Назва сервера:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "Приховування:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Передано клієнту"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "Поточні запити:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "Середня швидкість вивантаження:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "Середня швидкість звантаження:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "Вивантажено (сесія):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "Звантажено (сесія):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "Вивантажено (всього):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "Звантажено (всього):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Рахунок"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "Модифікатор звантаження/вивантаження:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "Безпечна ідентифікація:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Queue rank:"
 msgstr "В черзі"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "Рахунок черги:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "Прізвисько"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - багатоплатформений Mule"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "Це ім'я, яке бачать інші користувачі, коли під'єднуються до вас."
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "Мова: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "Затримка перед показом підказок."
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "Це визначає мову"
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "Перевірити наявність нової версії під час запуску"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Перевірка нової версії після запуску"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "Розпочати зменшеним"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "Зменшитись після запуску"
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "Запит на вихід"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "Питає перед виходом."
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "Увімкнути знак у системному лотку"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "Ввімкнути/вимкнути знак в системному лотку або панелі."
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "Зменшитись в знак"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "Зменшуватись в системний лоток, а не в смужку програм."
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "Затримка показу порад: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "с"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "Обрати переглядач тенет"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "Відкрити в новій вкладці, якщо можливо"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "Відкрити сторінку тенет в новій вкладці замість нового вікна, якщо можливо"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "Відеопрогравач"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "Обмеження ширини смуги"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "Виділення шматків"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "Порти"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Це звичайний порт eD2k і не може бути вимкненим."
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "Порт UDP для запитів сервера (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Цей порт використовується для зовнішній запитів eD2k та для мережі Kad"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP порт (не обов'язково):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "Найбільше джерел на звантажуваний файл:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "Автоматичне з'єднання після запуску"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "Перез'єднатись при втраті з'єднання"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "Вилучити мертвий сервер після"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "спроб"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "Перелік"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "Оновити перелік серверів після з'єднання з сервером"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "Оновити перелік серверів після з'єднання з клієнтами"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "Використовувати систему переваг"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "Використовувати розумну перевірку LowID під час з'єднання"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "Безпечне з'єднання"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "Автоматично з'єднуватись тільки з серверами з переліку постійних"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "Встановити високу перевагу доданим вручну серверам"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "Додати файли для звантаження призупиненими"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "Додати файли для звантаження з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "Спробувати спершу звантажити перший та останній шматки"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "Запустити наступний призупинений файл, коли файл завершиться"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "З тієї самої категорії"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "Попереднє виділення місця на диску для нових файлів"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "Повністю виділяти місце для всього нового файлу, це зменшить фрагментування"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "Припинити звантаження коли вільне місце на диску досягнуло "
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "Виберіть це якщо хочете, щоб aMule перевіряв ваше місце на диску"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "Введіть найменше бажане місце на диску"
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "Зберегти 10 джерел рідкісних файлів (менше ніж 20 джерел)"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "Вивантаження"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "Додати нові спільні файли з автоматичною перевагою"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "Розумна обробка пошкоджень (Р.О.П.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "Ввімкнено"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "Вдосконалена Р.О.П. довіряє всім хешам (не радимо)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "Спільні теки"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "Вилучити"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(Праве клацання по значку теки для рекурсивного додавання)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "Робити спільними приховані файли"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Графіки"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "Час оновлення: 5 с"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "Час для середніх графіків: 100 хв"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "Шкала графіку з'єднань: 100"
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "Шкала графіку звантаження"
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "Шкала графіку вивантаження"
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "Кольори: "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "Фон"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "Сітка"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "Звантаження зараз"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "Звантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "Звантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "Вивантаження поточні"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "Вивантаження середні за роботу"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Показувати стовпчик швидкості в системному лотку"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "Вузлів Kad зараз"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "Вузлів Kad запущено"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "Вибрати"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "Дерево"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "Кількість відображуваних версій клієнтів (0=необмежено)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! ЗАСТЕРЕЖЕННЯ !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "Найбільше зовнішніх з'єднань за 5 с"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "Розмір файлу буфера: 240000 байт"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "Розмір черги вивантаження: 5000 клієнтів"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "Час оновлення з'єднання з сервером: вимкнено"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "Використати шкіру: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "Показати \"Швидкий оброблювач eD2k-посилань\" в кожному вікні."
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "Показати розширену інформацію на вкладках категорій"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show application version on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "Показувати швидкість передавання в заголовку"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "Перед назвою програми"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "Після назви програми"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "Показати ширину смуги службового трафіку"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "Вертикальне розміщення панелі інструментів"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "Звантажити файли в черзі"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "Показувати поступ у відсотках"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "Показувати панель поступу"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "Плаский"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "Заборонити гостьовий доступ"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Пароль гостя веб-сервера"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4901,11 +4813,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4915,485 +4827,485 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Спільні файли"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "Вимкнено [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "байт"
 msgstr[1] "байти"
 msgstr[2] "байт"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "кбайт"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "Тбайт"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "к"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "М"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "Г"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "Т"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "байт/с"
 msgstr[1] "байти/с"
 msgstr[2] "байт/с"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "Мбайт/с"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "с"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "хв"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "год"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "діб"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "всі"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "всі інші"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "Незавершені"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "Зупинені"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "Відео"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "Архів"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "Текст"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "Чинні"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Очікується завершення потому перетворення часткового файлу..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "Вноситься %s: %s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "Читається тимчасова тека"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "Витягується основна інформація з інформації звантажуваного файла"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "Створюється файл призначення"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "Завантажуються дані зі старого файлу звантажень (%u з %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "Зберігається блок даних в новий один файл звантаження (%u з %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "Отримується інформація по джерелам звантажуваного файла"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "Додається звантаження та зберігається новий частковий файл"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "Вношу часткові файли"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "Стан"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "Хеш файлу"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (диск: %s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "Будь ласка, виберіть теку з тимчасовими звантаженнями! (підтеки будуть додані)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Ви хочете, щоб джерела успішно внесених звантажень були видалені?"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "Видалити джерела?"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 #, fuzzy
 msgid "ERROR: Failed to create partfile"
 msgstr "ПОМИЛКА: Не вдалося створити частковий файл"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "Спроба завантажити резервну копію met-файлу з %s"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "ПОМИЛКА: Не вдалося відкрити файл part.met: %s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "ПОМИЛКА: файл part.met має розмір 0: %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "ПОМИЛКА: Невірна версія файлу part.met: %s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "ПОМИЛКА: %s (%s) зіпсований (невірна кількість міток), неможливо завантажити файл."
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "ПОМИЛКА: %s (%s) зіпсований (невірна кількість міток), неможливо завантажити файл."
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "Намагання відтворити інформацію файлу..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "Відновлюється файл без назви - спроба відновити як RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "Відновлена вся доступна інформація файлу :D - спроба використати її..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "Неможливо відтворити інформацію файлу"
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "Не вдалося відкрити %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "ЗАСТЕРЕЖЕННЯ: %s може бути зіпсований (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "ПОМИЛКА під час збереження часткового файлу: %s (%s ==> %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "Помилка введення-виведення під час збереження часткового файлу: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "Не вдалося зберегти файл part.met.seeds для %s"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
@@ -5401,17 +5313,17 @@ msgstr[0] "Збережено %i джерело для часткового фа
 msgstr[1] "Збережено %i джерела для часткового файлу: %s (%s)"
 msgstr[2] "Збережено %i джерел для часткового файлу: %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "Збережено %i джерело для часткового файлу: %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "Помилка читання файлу-джерела часткового файлу (%s - %s): %s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
@@ -5419,353 +5331,353 @@ msgstr[0] "Знайдена підробна частина (%d) в (%d) час�
 msgstr[1] "Знайдена підробна частина (%d) в (%d) часткових файлах %s - FileResultHash |%s| FileHash |%s|"
 msgstr[2] "Знайдена підробна частина (%d) в (%d) часткових файлах %s - FileResultHash |%s| FileHash |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "Знайдено завершену частину (%i) в %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "Завершене повторне обчислення хешу: %s"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "Неочікувана помилка під час завершення %s. Файл призупинено"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "Завершене звантаження: %s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "Завершене звантаження: %s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "Видаляється файл: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "ЗАСТЕРЕЖЕННЯ: неможливо обчислити хеш звантаженого файлу - набір хешів неповний для '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "ПОМИЛКА: неможливо обчислити хеш звантаженого файлу - набір хешів неповний (%s). Такого ніколи не повинно бути"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "ЗАСТЕРЕЖЕННЯ: недостатньо вільного місця на диску! Призупиняється файл: %s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "Звантажена частина %i зіпсована в файлі: %s"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "Р.О.П.: відновлено зіпсовану частину %i для %s -> Збережено байт: %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "Виділяється"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "Не вистачає місця на диску"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Звантажені"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "З'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Теки"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Сервери"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "Файли"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "Безпека"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "Зовнішній вигляд"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "Проксі"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "Фільтри"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "Віддалене керування"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "Онлайн-підпис"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "Розширені"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "Події"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "Налагоджувач"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5781,35 +5693,35 @@ msgstr ""
 "aMule чудово працює без зміни будь-яких\n"
 "з цих параметрів."
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "Помилка з'єднання Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "Помилка передавання даних з Cfg до Widget з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "Тип проксі з яким ви з'єднуєтесь"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "Помилка передавання даних з Widget до Cfg з ID %d та ключем %s"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "Перевіряється пароль\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5817,45 +5729,45 @@ msgstr ""
 "aMule має бути перезапущений, щоб зміни подіяли:\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP-порт змінено.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect port changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect acceptance changed.\n"
 msgstr "Дозволено нове зовнішнє з'єднання"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- External connect interface changed.\n"
 msgstr "Зовнішнє з'єднання розірвано."
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "Приховування протоколу"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5863,7 +5775,7 @@ msgstr ""
 "Ваш перелік автоматичного оновлення серверів порожній.\n"
 "'Автоматичне оновлення серверів під час завантаження буде вимкнено."
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5871,34 +5783,34 @@ msgstr ""
 "Ви увімкнули зовнішні з'єднання, але не визначили пароль.\n"
 "Зовнішні з'єднання не можуть бути ввімкнені поки не вказано вірний пароль."
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- Мова змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- Тимчасова тека змінена.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- ED2K network enabled.\n"
 msgstr "Всі мережі вимкнені."
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "Невірна версія протоколу."
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5906,7 +5818,7 @@ msgstr ""
 "Обидві eD2k та Kad-мережі вимкнені.\n"
 "Ви не зможете з'єднатися поки не увімкнете хоча б одну з них"
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5914,7 +5826,7 @@ msgstr ""
 "Kad не розпочне роботу, якщо UDP-порт вимкнено.\n"
 "Увімкніть UDP-порт або вимкніть Kad"
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5924,69 +5836,69 @@ msgstr ""
 "Ви ЗОБОВ'ЯЗАНІ перезапустити aMule зараз.\n"
 "Якщо ж не перезапустите, не скаржтеся, коли станеться щось жахливе.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "Тека для тимчасових звантажуваних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "Пароль встановлений та дозволені зовнішні з'єднання."
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5996,24 +5908,24 @@ msgstr ""
 "Будь ласка заповніть принаймні одну адресу, що посилається на існуючий файл server.met.\n"
 "Натисніть на кнопку \"Перелік\" щоб ввести адресу."
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "Тимчасові файли"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "Вхідні файли"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "Онлайн-підписи"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "Виберіть теку для %s"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
@@ -6021,42 +5933,42 @@ msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "Переглянути, щоб знайти відеопрогравач"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "Вибрати переглядач тенет"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "Виконуваний %s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "Мова системи"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "Редагувати перелік серверів"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -6064,42 +5976,42 @@ msgstr ""
 "Додайте тут адреси файлів server.met.\n"
 "Тільки одна адреса на рядок."
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "Завершених джерел"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "Стан:"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
@@ -6107,7 +6019,7 @@ msgstr[0] "Затримка оновлення: %d секунда"
 msgstr[1] "Затримка оновлення: %d секунди"
 msgstr[2] "Затримка оновлення: %d секунд"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
@@ -6115,12 +6027,12 @@ msgstr[0] "Час усереднення графіків: %d хвилина"
 msgstr[1] "Час усереднення графіків: %d хвилини"
 msgstr[2] "Час усереднення графіків: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "Зміна розміру графіка з'єднань: %d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
@@ -6128,7 +6040,7 @@ msgstr[0] "Розмір файлу буфера: %d байт"
 msgstr[1] "Розмір файлу буфера: %d байти"
 msgstr[2] "Розмір файлу буфера: %d байт"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
@@ -6136,7 +6048,7 @@ msgstr[0] "Розмір черги вивантаження: %d клієнт"
 msgstr[1] "Розмір черги вивантаження: %d клієнти"
 msgstr[2] "Розмір черги вивантаження: %d клієнтів"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
@@ -6144,237 +6056,237 @@ msgstr[0] "Інтервал оновлення з'єднання з сервер
 msgstr[1] "Інтервал оновлення з'єднання з сервером: %d хвилини"
 msgstr[2] "Інтервал оновлення з'єднання з сервером: %d хвилин"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "Інтервал оновлення з'єднання з сервером: вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "вимкнено"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Execute command on '%s' event"
 msgstr "Виконати команду на подію '%s'"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "Ввімкнути виконання команди в ядрі"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "Команда ядра:"
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "Ввімкнути виконання команд в ГІК"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "Команда ГІК:"
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "Наступні змінні будуть замінені:"
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "Спільні теки"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Найменший розмір має бути меншим ніж найбільший. Найбільшим розміром знехтувано."
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "Очікування пошуку"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "Головна"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "Пошук eD2k не може бути виконаний, якщо eD2k не з'єднана"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "Ключове слово для пошуку: %s"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Неочікувана помилка, коли намагаюсь шукати в Kad:"
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID файлу"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "Без рейтингу"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "Звантажити в категорію"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Додати додаткові URL-адреси для цього файлу"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "Пошук схожих файлів (eD2k, місцевий сервер)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "Позначити як відомий файл"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "Скопіювати eD2k посилання до буферу обміну"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ви з'єднані з сервером, який хочете видалити, будь ласка, роз'єднайтесь спочатку."
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Canceled"
 msgstr "Скасувати"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Не вдалося з'єднатися з усіма переліченими прихованими серверами. Робиться ще одна спроба без приховування."
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "Не вдалося з'єднатися з усіма переліченими прихованими серверами. Робиться ще одна спроба без приховування."
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "Не вдалося з'єднатися з усіма переліченими серверами. Робиться ще одна спроба."
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Не вдалося з'єднатися з усіма переліченими серверами. Робиться ще одна спроба."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k вимкнена в налаштуваннях, не з'єднується."
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "Не знайдено справних серверів в переліку серверів з якими можна було з'єднатися"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "З'єднані з %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "З'єднання встановлено з: %s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "Жахлива помилка під час спроби з'єднання. З'єднання з Інтернет може бути відсутнє"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "Втрачене з'єднання з %s (%s:%i)"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) здається мертвий."
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) здається заповнений."
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
@@ -6382,48 +6294,48 @@ msgstr[0] "Автоматичне з'єднання з сервером повт
 msgstr[1] "Автоматичне з'єднання з сервером повториться через %d секунди"
 msgstr[2] "Автоматичне з'єднання з сервером повториться через %d секунд"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "З'єднання з %s (%s:%i) не вдалося."
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "ПОМИЛКА: невірний сокет після сплину часу"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "Спроба з'єднання з %s (%s:%i) добігла кінця."
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "Отриманий застарілий наслідок запиту до DNS, відкидається."
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "Завантажую файл server.met: %s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "Файл server.met не знайдено!"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "Неможливо завантажити файл server.met '%s', невірний формат."
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "Неможливо відкрити server.met!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Файл server.met підробний, знайдена невірна мітка версії: 0x%x, розмір %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
@@ -6431,7 +6343,7 @@ msgstr[0] "%i сервер знайдено в server.met"
 msgstr[1] "%i сервери знайдені в server.met"
 msgstr[2] "%i серверів знайдені в server.met"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
@@ -6439,237 +6351,236 @@ msgstr[0] "Додано %d сервер"
 msgstr[1] "Додано %d сервери"
 msgstr[2] "Додано %d серверів"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 #, fuzzy
 msgid "IO error while reading 'server.met': "
 msgstr "Помилка введення-виведення під час читання файлу known.met: %s"
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "Сервер не додано: [%s:%d] не визначив вірний порт."
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "Сервер не додано: IP-адреса [%s:%d] відфільтрована або неприпустима."
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "Сервер не додано: сервер з такими ж IP:порт [%s:%d] вже в переліку."
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "Сервер додано: сервер на [%s:%d] використовуючи назву '%s'."
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "Ви з'єднані з сервером, який хочете видалити, будь ласка, роз'єднайтесь спочатку."
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "Не вдалося відкрити '%s'"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Неможливо зберегти server.met!"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "Невірна URL-адреса"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, fuzzy, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "Завершилось звантаження переліку серверів з %s"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "Не знайдено жодного запису переліку серверів в addresses.dat. Будь ласка, вставте вірний перелік адрес серверів в цей файл для того щоб автоматично оновити ваш перелік серверів"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "Починається звантаження переліку серверів з %s"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "ЗАСТЕРЕЖЕННЯ: вказана невірна адреса для автоматичного оновлення серверів: %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "Немає правильної адреси автоматичного звантаження server.met в addresses.dat"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "Неможливо звантажити перелік серверів з %s"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "Місцевий сервер відфільтрований IPFilters, з'єднайтесь з іншим!"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Назва сервера"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "Адреса"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "Порт"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "Опис"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Час луни"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "Користувачі"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "Постійні"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версія"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "Ви з'єднані з сервером, який намагаєтесь видалити. Будь ласка, роз'єднайтеся спочатку. Сервер НЕ був видалений."
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(невідома назва)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ви впевнені, що хочете видалити постійний сервер %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "Сервери (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "Сервер"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "З'єднатися з сервером"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "Позначити сервер як постійний"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "Позначити сервер як непостійний"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Позначити сервери як постійні"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Позначити сервери як непостійні"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "Видалити сервер"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Видалити сервери"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Видалити всі сервери"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "Скопіювати eD2k посилання до буферу обміну"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "Перез'єднатись з сервером"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "Ви впевнені, що хочете видалити всі сервери?"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "Ви впевнені, що хочете видалити вибраний сервер?"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ви впевнені, що хочете видалити вибрані сервери?"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "ПОМИЛКА: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "ЗАСТЕРЕЖЕННЯ: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "Новий id клієнта %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "ЗАСТЕРЕЖЕННЯ: ви отримали LowID!"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tНайбільш ймовірно це тому, що ви за фаєрволом або маршрутизатором."
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\tЗа додатковою інформацією, будь ласка, завітайте до https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "Отримана невідома інформація про сервери! - занадто коротко"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
@@ -6677,178 +6588,178 @@ msgstr[0] "Отримано %d новий сервер"
 msgstr[1] "Отримано %d нові сервери"
 msgstr[2] "Отримано %d нових серверів"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "Збереження переліку серверів завершено."
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "Сервер відхилив останню команду"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "З сервера отримано підробний пакет: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "Помилка, що не може бути опрацьована, під час обробки пакету з сервера: %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "Неможливо створити потік DNS-запиту для з'єднання з %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "IP-адреса сервера %s (%s) відфільтрована.  Не з'єднується."
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "використовується приховування протоколу."
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "З'єднуюсь з %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "Неможливо визначити DNS-назву для сервера: %s. Неможливо з'єднатися!"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "Часопис aMule"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "Сервер не додано: не задана ні адреса, ні назва."
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "Сервер не додано: неприпустимий порт."
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "Стан eD2k:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "Стан з'єднання:"
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "З'єднано"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Стан Kademlia:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Running in LAN mode"
 msgstr "Запущений на %s"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "Працює"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Стан Kademlia:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "Стан:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "Стан з'єднання:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "За фаерволом - відкрийте порт TCP:%d на вашому маршрутизаторі або фаерволі"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "Стан з'єднання UDP:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "За фаерволом - відкрийте порт UDP:%d на вашому маршрутизаторі або фаерволі"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "Стан фаєрволу: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "Не потрібен жоден друг: порт TCP відкритий"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "Не потрібен жоден друг: порт UDP відкритий"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "Немає друга"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "З'єднання з другом"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "З'єднання з другом на %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "Проіндексовані джерела:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "Проіндексовані ключові слова:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "Проіндексовані нотатки:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "Проіндексовані завантаження:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "Середня кількість користувачів:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "Всередньому файлів:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "Не запущений"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "Додається файл %s до спільних"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
@@ -6856,7 +6767,7 @@ msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
@@ -6864,7 +6775,7 @@ msgstr[0] "Знайдено %i відомий спільний файл, нев�
 msgstr[1] "Знайдено %i відомі спільні файли, невідомих - %i"
 msgstr[2] "Знайдено %i відомих спільних файли, невідомих - %i"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
@@ -6872,426 +6783,426 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "ПОМИЛКА: спроба зробити спільним %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "Спільна тека не знайдена, пропускаємо: %s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Не знайдені спільні файли в теці: %s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "User Name"
 msgstr "Ім'я користувача"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Швидкість звантаження"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Швидкість вивантаження"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Available Parts"
 msgstr "Наявні:"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Status"
 msgstr "Стан вивантаження"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "Стан звантаження"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Local File Name"
 msgstr "Назва файлу"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Shares File List"
 msgstr "Спільні файли"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "Отримані частини"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "Шлях до теки"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "Додати коментар/рейтинг"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "Редагувати коментар/рейтинг"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "Змінити назву"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Додати файли зі збірки до переліку передач"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "Скопіювати magnet-посилання до буферу обміну"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (джерело)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (джерело з шифруванням)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (назва хосту)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (назва хосту з шифруванням)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (інформація AICH)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "Скопіювати eD2k-посилання до буферу обміну (інформація AICH)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "Вам потрібно мати HighID щоб створити посилання на джерело"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Назва файлу"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "Вивантажені дані (сесія (всього)): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "Всього службового трафіку (пакети): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "Трафік запитів (пакети): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "Трафік обміну джерелами (пакети): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "Трафік з сервером (пакети): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Трафік Kad (пакети): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "Втрати на шифрування (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "Активні вивантаження: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "Вивантаження очікують: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "Вього успішних сесій вивантаження: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "Всього невдалих сесій вивантаження: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "Середній час вивантаження: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "Звантажені дані (сесія (всього)): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "Знайдені джерела: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "Чинні звантаження (шматки): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "Відношення вивантажено/звантажено за сесію (всього): %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "Середня швидкість звантаження (сесія): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "Середня швидкість вивантаження (сесія): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "Найбільша швидкість звантаження (сесія): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "Найбільша швидкість вивантаження (сесія): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "Перепід'єднань: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "Пройшло часу з останньої передачі: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "З'єднано з сервером з: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "Чинні з'єднання (приблизно): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "Досягнуто найбільшої кількості з'єднань: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "Середня кількість з'єднань (приблизно): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Найбільше з'єднань (приблизно): %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "Клієнти"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Unknown: %s"
 msgstr "Невідомий розмір"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Filtered: %s"
 msgstr "Відфільтровані"
 
 # користувач
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, fuzzy, c-format
 msgid "Banned: %s"
 msgstr "заборонений"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "Всього: %i Відомих: %i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "Робочі сервери: %i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "Неробочі сервери: %i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "Всього: %s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "Видалені сервери: %s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "Відфільтровані сервери: %s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "Користувачів на робочих серверах: %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "Файлів на робочих серверах: %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "Всього користувачів: %llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "Всього файлів: %llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "Навантаження на сервер: %.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Кількість спільних файлів: %s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "Загальний розмір спільних файлів: %s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "Середній розмір файлу: %s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "Операційна система"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "Не отримана"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "Чинні з'єднання (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "Недоступний"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "Ніколи"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, fuzzy, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "Команда '%s' з pid '%d' завершилась з кодом стану '%d'."
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Виконати <str> та вийти."
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "Невірний формат IP-адреси. Використовуйте xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "Ця команда потребує аргумент. Вірні аргументи:  'all', назва файлу, або номер.\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "Оброблюється за хешем: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "Оброблюється на назвою файлу: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "Ця команда потребує аргумент. Правильний аргумент: хеш файлу.\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "Невірне число\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Невірний хеш (довжина має бути точно 32 символи)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7300,7 +7211,7 @@ msgstr "Напишіть '%s' щоб отримати більше допомо�
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7309,89 +7220,87 @@ msgstr "Напишіть '%s' щоб отримати більше допомо�
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "Напишіть '%s' щоб отримати більше допомоги.\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "Розмір звантаження: %i"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "Запит невдалий з невідомою помилкою."
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "Дія була вдалою."
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "Запит невдалий з помилкою: %s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "Фільтрування IP для клієнтів %s.\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "Вимк"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "Ввімк"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "Фільтрування IP для серверів %s.\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "Поточний рівень IP-фільтра %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "Обмеження смуги пропускання: вивантаження %u кб/с, звантаження: %u кб/с.\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "З'єднався з %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "Не з'єднується"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "за фаєрволом"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "гаразд"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7400,7 +7309,7 @@ msgstr ""
 "\n"
 "Звантаження:\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7409,7 +7318,7 @@ msgstr ""
 "\n"
 "Вивантаження:\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7418,7 +7327,7 @@ msgstr ""
 "\n"
 "Клієнтів у черзі:\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7427,47 +7336,47 @@ msgstr ""
 "\n"
 "Всього джерел:\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[частковий файл]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Кількість здобутків пошуку: %i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Search progress not available"
 msgstr "Показувати поступ у відсотках"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "Отримано невідому відповідь з серверу, OpCode = %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "Показати коротку інформацію про стан."
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "Показати стан з'єднань, поточні швидкості вивантаження/звантаження, інше.\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "Показати повне дерево статистики."
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7481,11 +7390,11 @@ msgstr ""
 "\n"
 "Наприклад: 'statistics 5' покаже тільки 5 найбільш частих номерів для кожного типу клієнта.\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "Завершити роботу aMule."
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7495,40 +7404,40 @@ msgstr ""
 "Це також вимкне текстові клієнти, оскільки вони непридатні\n"
 "без запущеного ядра.\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload the given object."
 msgstr "Перезавантажується отриманий об'єкт."
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload shared files list."
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload IP filtering table."
 msgstr "Перезавантажується IP фільтр з файлу."
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Reload current IP filtering table."
 msgstr "Вибрати рівні IP-фільтрування."
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Update IP filtering table from URL."
 msgstr "Перезавантажується IP фільтр з файлу."
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "З'єднання з мережею."
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7540,36 +7449,36 @@ msgstr ""
 "щоб з'єднатись тільки з ним. IP-адреса повинна мати вигляд a.b.c.d версії IPv4\n"
 "або назва."
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "З'єднання тільки з eD2k."
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "З'єднання тільки з Kad."
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "Від'єднано тільки від мережі."
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "Це від'єднає від всіх мереж, до яких зараз під'єднано.\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "Від'єднано тільки від eD2k."
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "Від'єднано тільки від Kad."
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Add an eD2k or magnet link to core."
 msgstr "Додає eD2k-посилання або magnet-посилання до ядра."
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7587,52 +7496,52 @@ msgstr ""
 "\n"
 "Magnet-посилання повинне містити eD2k-хеш та довжину файлу.\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "Встановити значення налаштувань."
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Set IP filtering preferences."
 msgstr "Налаштувати IP-фільтри"
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "Ввімкнути IP фільтрування для клієнтів та серверів."
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "Вимкнути IP фільтрування для клієнтів та серверів."
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "Ввімкнути/вимкнути IP фільтрування для клієнтів."
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "Ввімкнути IP-фільтри для клієнтів."
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "Вимкнути IP-фільтри для клієнтів."
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "Ввімкнути/вимкнути IP фільтрування для серверів."
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "Ввімкнути IP-фільтри для серверів."
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "Вимкнути IP-фільтри для серверів."
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "Вибрати рівні IP-фільтрування."
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7640,80 +7549,80 @@ msgstr ""
 "Вірні рівні фільтрування в межах 0-255, і їх значення\n"
 "за замовчуванням(початкове) 127.\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "Встановити обмеження швидкостей."
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "Значення передане цій команді має бути в кб/с.\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "Встановити обмеження швидкості вивантаження."
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Значення передане цій команді має бути в кб/с.\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "Встановити обмеження швидкості звантаження."
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "Значення передане цій команді має бути в кб/с.\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "Отримати та відобразити значення налаштувань."
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering preferences."
 msgstr "Отримати налаштування IP-фільтра."
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for both clients and servers."
 msgstr "Отримати стан IP-фільтра для клієнта і сервера."
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for clients only."
 msgstr "Отримати стан IP-фільтра тільки для клієнта."
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering state for servers only."
 msgstr "Отримати стан IP-фільтра тільки для сервера."
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Get IP filtering level."
 msgstr "Вибрати рівні IP-фільтрування."
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "Отримати обмеження смуги пропускання."
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a search."
 msgstr "Виконати пошук у Kad"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7732,48 +7641,48 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a global search."
 msgstr "Виконати глобальний пошук"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a local search"
 msgstr "Виконати місцевий пошук"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Execute a kad search"
 msgstr "Виконати пошук у Kad"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "Показати здобутки попереднього пошуку."
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the progress of a search."
 msgstr "Показати перебіг пошуку."
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "Почати звантаження файлу"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7781,82 +7690,82 @@ msgstr ""
 "Потрібно вказати номер файлу з останнього пошуку.\n"
 "Наприклад:  'download 12'  розпочне звантаження файлу з номером 12 попереднього пошуку.\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "Призупинити звантаження."
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "Відновити звантаження."
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "Відмінити звантаження."
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "Встановити перевагу звантаження."
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "Встановити перевагу звантаження на низьку, звичайну або автоматичну.\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "Встановити перевагу низькою."
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "Встановити перевагу звичайною."
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "Встановити перевагу високою."
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "Встановити перевагу авто."
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "Показати черги/переліки."
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "Показати чергу звантаження та вивантаження, перелік серверів або перелік спільних файлів.\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "Показати чергу вивантаження."
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "Показати чергу звантаження."
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "Показати часопис."
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "Показати перелік серверів."
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "Перезавантажується перелік спільних файлів."
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "Очистити журнал."
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "Застаріла команда, використовуйте '%s' замість неї."
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7865,262 +7774,259 @@ msgstr ""
 "Це застаріла команда та може бути видалена в майбутньому.\n"
 "Використовуйте '%s' замість неї.\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "Текстовий клієнт aMule"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Перетворюється старий набір хешів AICH в '%s' до 64b в '%s'."
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "ЗАСТЕРЕЖЕННЯ: назва файлу '%s' невірна і буде змінена на '%s'."
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "ЗАСТЕРЕЖЕННЯ: файл '%s' вже існує, новий файл буде перейменований у '%s'."
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "Ви впевнені, що хочете відмінити або видалити всі файли в цій категорії?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "Потрібне підтвердження"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 #, fuzzy
 msgid "Too many categories!"
 msgstr "Забагато з'єднань"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "Всі інші"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "Додати категорію"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "Редагувати категорію"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "Видалити категорію"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "Запитано набір хешів для невідомого файлу: %s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "Відновлюється вивантаження файлу: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "Призупиняється вивантаження файлу: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "Не вдалося виконати команду `%s' на подію `%s'."
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "Звантаження завершено"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "Повний шлях до файлу."
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "Ім'я файлу без шляху."
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "eD2k-хеш файлу."
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "Розмір файлу в байтах."
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "Загальний час звантаження."
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "Розпочато нову розмову"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "Відправник."
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "Немає місця"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "Розділ диску."
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "Помилка під час завершення"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "Кількість оброблених файлів %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ви запитали частковий хеш (використовується тільки для файлів розмір яких більше ніж 9.5 МБ"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Файл не існує!\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, створювач eD2k-посилань aMule"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "Ласкаво просимо!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "Вхідні параметри"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "Файл для обчислення хешу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "Додати додаткові URL-адреси для цього файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "Введіть тут файл, eD2k-посилання якого хочете обчислити"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "Введіть тут адресу, яку хочете додати до eD2k-посилання: Додати / в кінець, щоб дати змогу aLinkCreator долучити поточну назву файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "Створити посилання з частковими хешами"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "Допоможіть поширювати нові та рідкісні файли швидше за рахунок збільшення розміру посилання"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4-хеш файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k-хеш файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k-посилання"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "Скопіювати до буферу обміну"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "Відкрити файл, щоб обчислити його eD2k-посилання"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "Копіювати eD2k-посилання до буферу обміну"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "Зберегти як"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "Зберегти розраховане eD2k-посилання до файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "Про aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "Виберіть файл eD2k-посилання якого потрібно обчислити"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "Не можу відкрити буфер обміну"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "Зараз немає що копіювати!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "Виберіть файл для обчисленого eD2k-посилання"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "Неможливо відкрити "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "Будь ласка, введіть непорожнє ім'я файлу"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "Зараз немає що зберігати!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8140,167 +8046,159 @@ msgstr ""
 "\n"
 "Distributed under GPL"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "Обчислення хешу..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator працює для вас"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "Обчислюється MD4-хеш..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "Обчислюються хеші eD2k..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "Скасовано!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "Виконано за %.2f с"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "Ви вже додали цю URL-адресу!"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "Будь ласка, введіть непустий URL-адресу"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "Неможливо відкрити %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i діб %i год %i хв %i с"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02uдіб %02uгод %02uхв %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02uгод %02uхв %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02uхв %02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02uс"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f байт"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.0f кбайт"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.0f Мбайт"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.0f Гбайт"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.0f Тбайт"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule онлайн-статистика"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "Найбільша швидкість звантаження з тих пір як wxCas запущено"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "Безумовна найбільша швидкість звантаження під час попереднього запуску wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "Очистити"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "Система"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "Зупинити автоматичне оновлення"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "Зберегти зображення онлайн статистики"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "Надрукувати зображення онлайн статистики"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "Налаштування"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "Про wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "Розпочати автоматичне оновлення"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "Автоматичне оновлення зупинено"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "Автоматичне оновлення розпочато"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "Зберегти зображення статистики"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "Онлайн статистика aMule"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8308,11 +8206,11 @@ msgstr ""
 "Негаразди друку.\n"
 "Можливо ваша поточна друкарка не налаштована вірно?"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "Друк"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8330,403 +8228,392 @@ msgstr ""
 "\n"
 "Distributed under GPL"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMule не запущений..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule запущений"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule запущений, але від'єднаний"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule з'єднується..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "Стан aMule невідомий..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " працює "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " зупинений!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " не з'єднаний!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " з'єднується..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " робить щось дивне, перевірте!"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " з'єднався з "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "вимкнено"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " ввімкнено "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " з "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "Всього звантажень: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", вивантажень: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "Сесія звантаження: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "Звантаження: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " кбайт/с, вивантаження: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "Спільні файли: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " файл(ів), клієнтів у черзі: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "Час: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " ввімкнено "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "Середня завантаженість системи (1-5-15 хв): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "Час роботи системи: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "Тека, що містить файл amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "Введіть тут теку, де знаходиться файл amulesig.dat"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "Час оновлення в секундах"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "Створювати зображення статистики під час кожного оновлення"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Введіть назву теки, де б ви хотіли зберігати зображення статистики"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Вивантажувати час від часу ваші зображення статистики на FTP-сервер"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP-адреса"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP-шлях"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "Введіть тут адресу вашого FTP-сервера"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "Введіть тут теку, куди будуть складатися зображення зі статистикою на FTP-сервері"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "Користувач"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "Введіть тут ім'я користувача для входу на ваш FTP-сервер"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "Введіть тут пароль входу на ваш FTP-сервер"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "Час оновлення FTP в хвилинах"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "Перевірити"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "Тека, що містить файл з вашим підписом"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "Тека, де створюються зображення статистики"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "Завантажується зразок <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "HTTP порт веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "Використовувати перенаправлення UPnP-портів на порт веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP порт"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Пароль повного доступу для веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Пароль гостя веб-сервера"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "Дозволити гостьовий доступ"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "Заборонити гостьовий доступ"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "Завантажити/записати налаштування веб-сервера з/до віддаленого aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "Шлях до файлу налаштувань aMule. НЕ ВИКОРИСТОВУЙТЕ БЕЗПОСЕРЕДНЬО!"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "Вимкнути інтерпретатор PHP (застаріло)"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "Перекомпілювати PHP-сторінки під час кожного запиту"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "Веб-сервер aMule"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "з'єднання веб-клієнта прийнято\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "ПОМИЛКА: неможливо прийняти з'єднання веб-клієнта\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "Запит невдалий з наступною помилкою: %s."
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "Файл індексу не знайдено: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "Сесія добігла кінця - запитуємо новий вхід\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "Сесія в порядку, входимо\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "Сесія в порядку, не увійшли\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "Немає відкритих сесій, буде запитано вхід\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "Сесію створено - запит на вхід\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "Оброблюю запит [початковий]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "Перевіряється пароль\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "Неправильний хеш пароля\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "Пароль правильний\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "Пароль неправильний\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "Ви не ввели жодного паролю. Порожній пароль не дозволено.\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "Запитано вихід\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "Обробляється запит [перенаправлений]:"
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "З'єднання невдале "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -17,100 +17,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr ""
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr ""
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr ""
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr ""
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr ""
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr ""
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr ""
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr ""
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr ""
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr ""
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr ""
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr ""
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -119,47 +119,46 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -168,172 +167,165 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr ""
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr ""
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr ""
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr ""
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr ""
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr ""
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -343,269 +335,265 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr ""
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr ""
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr ""
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr ""
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr ""
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr ""
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr ""
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr ""
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr ""
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr ""
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr ""
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr ""
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -615,191 +603,184 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -808,1204 +789,1177 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr ""
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr ""
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr ""
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr ""
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr ""
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr ""
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr ""
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr ""
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr ""
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr ""
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr ""
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr ""
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr ""
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr ""
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr ""
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr ""
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr ""
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr ""
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr ""
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr ""
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr ""
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr ""
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr ""
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr ""
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr ""
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr ""
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr ""
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr ""
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr ""
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr ""
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr ""
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr ""
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr ""
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr ""
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr ""
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr ""
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr ""
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr ""
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr ""
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr ""
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr ""
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr ""
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr ""
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr ""
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr ""
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr ""
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr ""
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr ""
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr ""
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr ""
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr ""
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr ""
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr ""
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2013,23 +1967,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2037,59 +1991,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2098,2647 +2052,2605 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr ""
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr ""
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 msgid "Welcome to aMule!"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 msgid "Connection & bandwidth"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 msgid "Connection speed:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 msgid "Networks & ports"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 msgid "Bootstrap files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 msgid "Your peer lists are already in place - nothing to download."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr ""
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr ""
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr ""
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr ""
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr ""
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr ""
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr ""
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr ""
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr ""
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr ""
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr ""
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr ""
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr ""
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr ""
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr ""
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr ""
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr ""
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr ""
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr ""
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr ""
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr ""
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr ""
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr ""
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr ""
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr ""
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr ""
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr ""
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr ""
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr ""
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr ""
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr ""
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr ""
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr ""
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr ""
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr ""
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr ""
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr ""
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr ""
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr ""
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr ""
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr ""
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr ""
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr ""
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr ""
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr ""
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr ""
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr ""
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr ""
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr ""
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr ""
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr ""
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr ""
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr ""
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr ""
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr ""
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr ""
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr ""
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr ""
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr ""
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
 msgstr ""
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr ""
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr ""
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr ""
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr ""
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr ""
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr ""
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr ""
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr ""
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr ""
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 msgid "Remember search history"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "A password is set."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 msgid "Enable guest access"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 msgid "Guest password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4746,11 +4658,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4760,836 +4672,836 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr ""
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr ""
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr ""
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr ""
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr ""
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr ""
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr ""
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr ""
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr ""
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr ""
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr ""
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr ""
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr ""
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr ""
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr ""
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr ""
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr ""
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr ""
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr ""
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr ""
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr ""
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr ""
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr ""
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr ""
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr ""
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr ""
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5599,1444 +5511,1443 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 msgid "No password set."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the file type registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr ""
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr ""
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr ""
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr ""
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr ""
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr ""
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr ""
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr ""
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr ""
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr ""
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr ""
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr ""
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr ""
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr ""
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr ""
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr ""
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr ""
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr ""
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr ""
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 msgid "Connected since:"
 msgstr ""
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr ""
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr ""
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr ""
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr ""
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr ""
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr ""
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr ""
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr ""
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr ""
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr ""
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr ""
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr ""
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr ""
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr ""
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr ""
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr ""
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr ""
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr ""
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr ""
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr ""
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr ""
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr ""
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr ""
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr ""
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr ""
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr ""
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr ""
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7044,7 +6955,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7052,155 +6963,153 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr ""
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr ""
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr ""
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr ""
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr ""
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr ""
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr ""
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr ""
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr ""
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr ""
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Download:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Upload:\t%s"
 msgstr ""
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Clients in queue:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
 "Total sources:\t%d\n"
 msgstr ""
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr ""
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr ""
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr ""
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr ""
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr ""
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr ""
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7209,46 +7118,46 @@ msgid ""
 "Example: 'statistics 5' will show only the top 5 versions for each client type.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr ""
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
 "running core.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr ""
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr ""
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr ""
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr ""
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr ""
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7256,35 +7165,35 @@ msgid ""
 "or a resolvable DNS name."
 msgstr ""
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr ""
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr ""
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr ""
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr ""
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7295,121 +7204,121 @@ msgid ""
 "The magnet link must contain the eD2k hash and file length.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr ""
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr ""
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr ""
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr ""
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr ""
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr ""
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr ""
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr ""
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr ""
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr ""
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr ""
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr ""
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7428,383 +7337,380 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr ""
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr ""
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr ""
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr ""
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr ""
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr ""
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr ""
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr ""
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr ""
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr ""
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr ""
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr ""
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr ""
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr ""
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr ""
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr ""
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr ""
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr ""
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr ""
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr ""
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr ""
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr ""
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr ""
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr ""
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr ""
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr ""
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr ""
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr ""
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr ""
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr ""
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr ""
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr ""
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr ""
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr ""
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr ""
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr ""
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr ""
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr ""
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr ""
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr ""
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr ""
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr ""
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr ""
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr ""
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -7816,177 +7722,169 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr ""
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -7997,400 +7895,389 @@ msgid ""
 "Distributed under GPL"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr ""
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr ""
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -24,19 +24,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 msgid "About aMule"
 msgstr "关于 aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule 远程控制 "
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "Snapshot:"
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -44,7 +44,7 @@ msgstr ""
 "基于 eMule 的“全平台” P2P客户端 \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
 "\n"
@@ -52,76 +52,76 @@ msgstr ""
 "版权所有 (c) 2003-2026 aMule 团队 \n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "aMule 的一部分是基于 \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr "Kademlia: 基于异或算法的点对点路由。\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " 版权所有 (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr "网站："
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr "论坛："
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr "文档："
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr "问题："
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 msgid "Click to check for a newer version."
 msgstr "单击检查新版本。"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 msgid "Checking for updates..."
 msgstr "正在检查更新…"
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 msgid "You are running the latest version."
 msgstr "运行的是最新版。"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, c-format
 msgid "A new version (%s) is available:"
 msgstr "有新版本（%s）可用："
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr "无法检查更新。请稍后重试。"
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "添加好友"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "您必须输入有效的 IP 地址和端口！"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "信息"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "指定的用户哈希无效！"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -135,47 +135,46 @@ msgstr ""
 "\n"
 "现在立即安装桌面集成吗？"
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 msgid "Add aMule to your application menu?"
 msgstr "添加 aMule 到程序菜单吗？"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr "安装"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr "不是现在"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr "不要再提醒我"
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr "无法安装桌面集成：APPDIR 环境变量未设置。这通常表明 AppImage 以非标准的形式启动。"
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 msgid "aMule integration failed"
 msgstr "aMule 集成失败"
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr "无法安装桌面集成：创建 %s 失败。请检查主目录是可写入的。"
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr "无法安装桌面集成。写入 %s 失败。请检查主目录是可写入的。"
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr "AppImage 集成：aMule 已添加到你的应用程序菜单(%d shell 快捷方式，位于~/.local/bin)。"
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -189,103 +188,100 @@ msgstr ""
 "\n"
 "现在立即重启 aMule 吗？"
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr "aMule 已安装"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr "立即重启"
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr "稍后重启"
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "打开 ED2K 链接文件失败。"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链接的源。"
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "现在，正在退出主程序..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleweb 实例 ... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "失败"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在终止 pid 为“%d”的 amuleapi 实例 ... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 正在退出：中止内核。"
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "aMule 已经关闭。"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "对 aMule 退出的内存 Debug 结果："
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr "将 amule 的 p2p 流量绑定到接口：%s（HTTP 流量使用默认路由）"
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr "将所有网络流量绑定到接口：%s"
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr "警告：未找到配置的网络接口'%s' - 流量未绑定到该接口，可能通过默认路由离开。 在设置中检查接口名。"
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr "警告：绑定到网络接口“%s”需要提升权限，但未成功 - 流量可能通过默认路由离开。请授予相应权限（例如，在 aMule 二进制文件上运行“sudo setcap cap_net_raw+ep”），或以足够的权限运行命令。"
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr "警告：无法绑定到网络接口“%s” − 流量可能经默认路由离开。"
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "对不起，由于配置变动，您的地区设置已经变为系统默认值。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "信息"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -293,20 +289,19 @@ msgstr ""
 "\n"
 "EC 配置"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "密码已设置，启用远程连接。"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "网络引导"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
@@ -314,51 +309,48 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "web 服务器正在运行，pid 为 %d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "错误"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, c-format
 msgid "amuleapi running on pid %d"
 msgstr "amuleapi 正在运行，pid 为 %d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求启动时运行 amuleapi，但 amuleapi 程序无法运行， 请先安装包含 amule REST API 服务器的 包，或者使用 -DBUILD_AMULEAPI=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "无法绑定端口到指定的地址：%s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "端口 %u 不可用，你会成为 Low ID\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -373,48 +365,48 @@ msgstr ""
 "\n"
 "请检测网络设置以确保端口可用于输入输出。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "创建在线统计文件失败"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "创建 aMule 在线统计文件失败"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "您所选择的地区设置在您的计算机上似乎没有安装。(注意：我还是会尝试您所选择的地区设置。)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "这是您第一次运行 aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "此版本是测试版，更新频繁， \n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "我们无法承诺它不会损坏任何东西，烧毁您的房子，\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或杀死你的狗，但 * 一般来讲 * 它应该是安全的。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "如要获取使用信息、用户支持以及下载最新版本，请访问我们的首页\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或进入我们在 irc.libera.chat 的 IRC 频道 #aMule。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "欢迎您到 https://github.com/amule-org/amule/issues 去提交错误报告"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -422,222 +414,218 @@ msgstr ""
 "您为在线统计文件所选择的文件夹无效！\n"
 "在您更正设置之前在线统计将被禁用。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "为文件 '%s' 预分配磁盘空间失败：%s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "错误：无法打开日志文件"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：日志文件为空。肯定有什么地方出错了。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "记录文件已被重置"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "服务器消息：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "跳过下载%s，因为请求的文件不是最新的。"
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "下载节点列表失败。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "打开已下载的版本检查文件失败"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "损坏的版本检查文件"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是老版本的aMule！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可从这里下载：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本太旧：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "您的aMule是最新版本。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "下载版本检查文件失败"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "用户：%s | 文件：%s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "用户：E：%s K：%s | 文件：E：%s K：%s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "没有选择网络"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "是 Low ID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "是 High ID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已连接到 %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在连接到 %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "已从 eD2k 断开"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad 已启动。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "已连接至 Kad (ok）"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "已连接至 Kad 网络 (有防火墙)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "已断开 Kad 连接"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "如果在设置中禁用了 UDP 端口，Kad 网络将不能使用，没有启动。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 网络在设置中被禁用了，没有连接。"
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "错误：当远程连接被禁用的时，aMule 服务程序无法使用。要启用远程连接，请使用普通的 aMule，或使用 --ec-config选项启动 amuled 或在文件 ~/aMule/amule.conf 中设置选项\"AcceptExternalConnections\"为1"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "错误：如果需要使用外部连接，必须设置一个可用的密码，aMule daemon不能在没有启用外部连接的情况下使用。要运行aMule daemon，你必须设置~/.aMule/amule.conf文件中的\"ECPassword\"字段，使它有一个合适的值。执行amuled --ce-config来设置这个密码。更多信息请访问https://amule-org.github.io/docs"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled：正在初始化 - 启动计时器"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "不能创建 Pid 文件"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "错误：%s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "这是基于 eMule 的 aMule %s。"
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "设置"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 msgid "New version available"
 msgstr "有新版"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -652,191 +640,184 @@ msgstr ""
 "\n"
 "要打开下载页吗？"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "无网络"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMule 远程控制"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "严重错误：无法创建核心计时器"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "连接到远程 amule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "连接已断"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 msgid "Abort and exit"
 msgstr "终止并退出"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr "正在重连…（第 %d 次尝试）"
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr "%d 秒后进行下一次重试…"
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -849,40 +830,40 @@ msgstr ""
 "\n"
 "连接恢复前将暂停该接口。"
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "严重错误：无法建立轮询计时器"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "准备事件循环..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "正在连接..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr "连接失败。请检查主机、端口和密码。"
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "远程 GUI 外部连接事件处理程序"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "连接失败。不能连接到 %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "下降"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 msgid "Reconnect attempt timed out; retrying."
 msgstr "重连尝试超时；重试中。"
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -891,681 +872,658 @@ msgstr ""
 "连接超时。无法在指定时间内连接到 %s:%d。\n"
 "请检查主机、端口，并确保 aMule 正在运行且已启用外部连接。"
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "到远程核心的连接丢失。正尝试重新连接…"
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
 msgstr "已重新连接到远程核心。"
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "重新连接尝试 %d：正在连接到 %s:%d"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr "重新连接无法开始；即将重试。"
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "就绪"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "全部"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 msgid "not readable"
 msgstr "不可读"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 msgid "not found"
 msgstr "未找到"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr "核心拒绝了这些共享的文件夹：%s"
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "非法链接或已经存在列表中。"
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目录。"
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "未知"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "无法获取用户 %s 的共享文件"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "正在搜索好友进行 Low ID 连接"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (假冒 eMule 版本 %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (假冒 eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (假冒 eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (基于 eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "昵称：%s ID：%u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "已请求： %s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "本次会话运行文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 msgstr[1] "本次会话运行文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "所有会话文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 msgstr[1] "所有会话文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "请求了未知文件"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "来自 %s（IP：%s）的消息被过滤掉了"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "新消息来自于 %s（IP：%s）"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "用户 %s（%u）请求目录 %s 的共享文件列表 -> 已忽略"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "警告：%s 文件无法打开。"
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "警告：已取消文件列表损坏，包含有非法头部。"
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "读取 %s 文件时发生 IO 错误：%s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "保存 %s 文件时发生错误：%s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "输入验证码"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "分类"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "新分类"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "请选择下载文件夹"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "必须定义分类名称！"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "必须定义分类路径！"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "无法建立该分类的接收文件夹，请给出一个有效的分类路径！"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "聊天已开始：%s（%s：%u）- %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** 已连接到用户 ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** 正在连接用户 ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** 无法连接用户/连接丢失 ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** 您已经通过了 captcha 检测，用户已经接收到你的信息了。***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** 您输入了错误的 captcha 信息，您的信息已经被忽略。您可以通过重新发送一条信息来再一次请求一个captcha验证。***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "聊天"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "关闭分页"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "关闭所有分页"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "关闭其它分页"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "加为好友"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "积分文件已载入，%u 个已知用户"
 msgstr[1] "积分文件已载入，%u个已知用户"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u 个客户端的积分已过期！"
 msgstr[1] " - %u 个客户端的积分已过期！"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "文件 'crytkey.dat' 未找到，正在创建。"
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "客户端详细信息"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Low ID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "High ID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "已启用"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "已支持"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "不支持"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "已禁用"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "已连接"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "断开连接"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f kB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "未完成"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "坏蛋"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "验证 - 通过"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "不可用"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "用户 %s (%u) 请求您的共享文件列表 -> 已接受"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "用户 %s (%u) 请求您的共享文件列表 -> 已拒绝"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "用户 %s (%u) 请求了您的共享文件夹列表 -> 已接受"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "用户 %s（%u）请求了您的共享文件夹列表 -> 已拒绝"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "用户 %s (%u) 请求目录“%s”的共享文件列表 -> 已接受"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "用户 %s (%u) 请求目录“%s”的共享文件列表 -> 已拒绝"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "用户 %s (%u) 共享了目录“%s”"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "用户 %s（%u）发送了未经请求的共享目录。"
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "用户 %s (%u) 发送了目录“%s”的共享文件列表"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "用户 %s (%u) 完成了共享文件列表的发送"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "用户 %s (%u) 发送了未经请求的共享文件列表"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "用户 %s (%u) 拒绝了目录/文件列表的访问"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "文件评论"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "用户名"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "文件名"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "评价"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "评论"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr "无法启动 Kad 搜索"
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad搜索不能使用，因为Kad没有连接"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 msgid "Searching Kad for comments..."
 msgstr "正在搜索 Kad 获取评论…"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "没有评论"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u 条评论"
 msgstr[1] "%u 条评论"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "封禁了客户端 %s，发送了 %s 受损的数据，共发送 %s （文件 “%s”）"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "加载 \"%s\" 的地区数据失败。"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "自动 [低]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "自动 [普通]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "自动 [高]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "极高"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "发布"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "正在询问"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "通过服务器连接中"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "队列已满"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "正在排队"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下载"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "正在接收校检码"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "没有需要的部分"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "无法连接两个 Low ID 用户"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "连接过多"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "正在通过 Kad 连接"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Kad 连接过多"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "已封杀"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "连接错误"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "队列已满"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "旧版 MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "新版 MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule 兼容程序"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "本地服务器"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "源交换"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "被动"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "链接"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "资源种子"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "搜索结果"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "正在处理"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 msgid "ERROR: Out of disk space"
 msgstr "错误：磁盘空间不足"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "错误：缺少参数"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "错误：IO 错误！"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "错误：失败！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "已加入队列"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "已经在下载"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "未知或错误的临时文件格式。"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "块"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "已传输"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "进度"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "源"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "优先级"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "状态"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "剩余时间"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "最后一次发现完整文件"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "最后一次下载"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "您确定要删除选择的文件吗？"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "您确定要删除选择的文件吗？"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1574,109 +1532,106 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "自动"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "停止 (&S)"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "暂停 (&P)"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "继续 (&R)"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "清除已完成的文件 (&l)"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "立即转移所有已要求其它文件 (A4AF) 到这个文件"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "自动转移所有已要求其它文件 (A4AF) 到这个文件"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "立即转移所有已要求其它文件 (A4AF) 到其它文件"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "扩展选项"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "预览"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "显示文件信息 (&D)"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "显示所有评论"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "复制 magnet 地址到剪贴板"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "复制 eD2k 链接到剪贴板 (&L)"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "复制统计信息到剪贴板"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "清除分类"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "指定到分类"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "打开文件 (&O)"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "请输入新文件名:"
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "重命名文件"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下载 (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr "默认的 Windows 外壳处理器"
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1685,346 +1640,345 @@ msgstr ""
 "为了不让此提示在每次预览时都出现，\n"
 "请在设置中预设您喜欢的播放器（默认为%s）。"
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "文件预览"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "错误: 无法运行外部媒体播放器！ 命令: `%s'"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "正在保存 PartFile %u 之 %u"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "所有 PartFile 都已经保存。"
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "从 %s 载入临时文件。"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "载入 PartFile %u 之 %u"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "错误：载入备份文件失败！请到 https://github.com/amule-org/amule/discussions 搜索 .part 和 .met 文件的恢复方法。"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "所有 PartFile 已经载入。"
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "没有找到 part 文件"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "发现 %u 个 part 文件"
 msgstr[1] "发现 %u 个 part 文件"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "存放零时文件分区的文件系统不支持大文件。"
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "存放下载文件分区的文件系统不支持大文件。"
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "正在下载 %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "您已经在下载文件 '%s'"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "你已有文件“%s”（请求的文件名为“%s”）"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "您已下载了文件 '%s'"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "您已经尝试下载文件 %s"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "无法转换 magnet 链接为 eD2k：%s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "未知链接协议：%s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] "无法添加 %u 个链接（详情请查看日志）"
 msgstr[1] "无法添加 %u 个链接（详情请查看日志）"
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "非法 eD2k 链接！错误: %s"
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "客户端在验证失败后发送包。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "已关闭远程连接。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "密码未设置，已禁止远程连接！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "配置文件中已禁止远程连接"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "新的远程连接已被接受"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "错误：不能接受新的远程连接"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由于未设置密码，远程连接已被拒绝！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "正在连接客户端：%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "未知版本"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "错误的远程连接版本号，可能会不兼容，请使用相同版本的核心和远程程序。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您无法从任意开发快照连接到发布版本！*sigh* 防止可能发生的崩溃"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "非法协议版本。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "缺失协议版本标签。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "身份验证失败: 指定为 EC 密码的 MD5 哈希值无效。"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "验证失败：密码错误。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "认证失败: 没有密码。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "无效请求，请先验证。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "登录成功。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "发送错误消息喔 \"%s\"到客户端。"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "来自%s的非法登录尝试，已关闭连接。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "远程 Part 文件命令失败：文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "文件校验码不存在：%s"
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "OpCode 处理错误！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "服务器没有被添加"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到服务器：%s"
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "必须定义需删除的服务器"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 在设置中已禁用。"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 msgid "Friend not found."
 msgstr "未找到好友。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 msgid "Client not found."
 msgstr "未找到客户端。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr "EC_TAG_FRIEND_SHARED 需要 EC_TAG_FRIEND 或 EC_TAG_CLIENT。"
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "远程界面使用网络搜索没有意义。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "正在搜索，请稍等然后重新获取结果！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "此图没有节点。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "您的客户端没有为详细级别进行配置。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "远程连接：已请求关闭"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "已经在关闭。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "远程连接：正在添加链接 '%s'。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "%d 个链接失败，共 %d 个（无效或已经在列表中）。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr "版本检查受限；请稍后再试。"
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr "版本检查在此 daemon 上不可用。"
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "文件未找到。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "无效的文件名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "无法重命名文件。"
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad 在设置中被禁用。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "已经连接至 eD2k。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "正在连接至 eD2k..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "已连接至 Kad。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "正在连接至 Kad..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "全部网络都被禁用了。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "已从 eD2k 断开连接。"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "已从 Kad 断开连接。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "远程连接：非法 opcode：%#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "非法的 opcode（错误的协议版本？)"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "未知扩展选项 '%s' 用于命令 '%s'。\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "未知命令 '%s'。\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2032,7 +1986,7 @@ msgstr ""
 "\n"
 "此命令不能含有参数。\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2040,7 +1994,7 @@ msgstr ""
 "\n"
 "此命令必须有参数。\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2048,7 +2002,7 @@ msgstr ""
 "\n"
 "此命令不完整，您必须使用以下扩展选项中的一个。\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2056,11 +2010,11 @@ msgstr ""
 "\n"
 "可用扩展选项：\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "可用命令：\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2071,17 +2025,17 @@ msgstr ""
 "全部命令都不区分大小写。\n"
 "输入 '%s <命令>' 获取在 <命令> 中的详细信息。\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "退出程序。"
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "显示帮助。"
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2089,7 +2043,7 @@ msgstr ""
 "输入 'help <命令>' 可显示命令的帮助。\n"
 "输入 'help' 可显示全部命令列表。\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2100,46 +2054,46 @@ msgstr ""
 "使用 '%s' 列出所有命令\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "语法错误！"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "处理指令时发生意外错误 - 这不应该发生！请提交错误报告\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "此命令不需要任何参数。"
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "此命令必须有一个参数。"
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "无效参数。"
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "此命令不完整。"
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "输入 '%s' 显示更多帮助信息。\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "这是 %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "这是 %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2147,7 +2101,7 @@ msgstr ""
 "\n"
 "正在建立用户...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2156,7 +2110,7 @@ msgstr ""
 "\n"
 "完成，正在退出 %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2170,331 +2124,326 @@ msgstr ""
 "\n"
 "退出...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "显示帮助信息。"
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "aMule 正在运行的主机 (默认: 127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule 的远程连接端口。(默认：4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "远程连接密码。"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "从文件读取设置。"
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "不在控制台输出任何信息。"
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "详细显示调试信息。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "设置程序地区(语言)。"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "把命令行参数写入设置文件。"
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "基于 aMule 的设置文件建立新设置文件。"
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "输出程序版本。"
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr "强制使用 ZLIB 压缩，忽略目标 IP 的地域属性（适用于服务器可通过解析为局域网 IP 的 VPN 隧道访问场景）。"
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr "将所有控制台输出的副本附加到此日志文件（默认：<config-dir>/amuleapi.log）。"
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr "不写入日志文件；只打印到控制台。"
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "文件信息"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "%.1f%% 已完成"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "欢迎！"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "已连接至好友"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "连接类型："
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "网络"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "标准 TCP 端口 "
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "扩展 UDP 端口 (Kad/全局搜索) "
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "启用 UPnP 以用于路由器端口转发"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "启动"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已经尝试下载文件 %s"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "启动时自动更新服务器列表"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr "登录时自动启动 aMule"
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "将 aMule 注册为打开 ed2k:// 链接的应用"
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "将 aMule 注册为打开 magnet: 链接的应用"
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "浏览"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr "（此文件夹中的所有文件均与其他对等方共享）"
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "存放临时下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "读取好友列表文件 emfriends.met 失败！"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "写好友列表文件emfriends.met失败！"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "好友"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "查看详细信息 (&D)"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "添加好友"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "删除好友"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "发送消息 (&M)"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "查看共享文件"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "建立好友通道"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "确定删除选中的好友吗？"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "确定删除选中的好友吗？"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2502,11 +2451,11 @@ msgstr ""
 "不允许设置超过一个好友通道。\n"
 " 只能指定一个通道。"
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "多选"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2514,1065 +2463,1032 @@ msgstr ""
 "不允许设置超过一个好友通道。\n"
 " 只分配了一个通道。"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "发送消息给用户"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "发送消息："
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "从好友中删除"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "发送消息"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "转移到这个文件"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "在队列中: %u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "已要求其它文件"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "等待上传机会"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "在队列中: %u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "正在上传"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "没有"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "是"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "正在下载..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "HTTP 下载已经取消"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "要下载的地址不能为空"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "创建 %s 的 HTTP 请求失败"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr "HTTP 下载：%s 返回的响应体为空"
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "无法移动已下载文件到 %s"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "已下载 %s （%llu 字节）"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "The URL %s returned: %i"
 msgstr "URL %s 返回了：%i"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "%s HTTP 下载失败：%s"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr "HTTP 401 未授权访问 %s"
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr "已将现有的 GeoLite2-Country.mmdb 迁移至 %s"
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr "IP2Country：已选择 MaxMind 作为 GeoIP 源，但未配置许可证密钥。请打开偏好设置 -> IP2Country，粘贴您的免费 MaxMind 许可证密钥，然后点击“立即更新”。"
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr "IP2Country：已选择自定义 URL 作为 GeoIP 源，但未配置 URL。请打开偏好设置 -> IP2Country，并提供指向 .mmdb 文件（或包含该文件的.gz/.tar.gz 压缩包）的 URL。"
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr "IP2Country：无法解析 GeoIP 下载链接。"
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download new %s from %s"
 msgstr "下载新的 %s，来源 %s"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "%s 文件下载失败，更新终止。"
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "删除%s文件失败，放弃更新。"
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "重名命%s文件失败，放弃更新。"
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "成功更新 %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, c-format
 msgid "Error updating %s"
 msgstr "更新 %s 出错"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr "当前月份的 DB-IP 下载失败，正在尝试使用上个月的 URL 重试。"
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "从%s下载%s失败"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "正在载入IP过滤文件ipfilter.dat和ipfilter_static.dat。"
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "载入 ipfilter.dat 文件 '%s' 失败，遇到未知格式。"
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "载入 ipfilter.dat 文件 '%s' 失败，无法打开文件。"
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "载入了 %u 个 IP 段，来源为 “%s”。"
 msgstr[1] "载入了 %u 个 IP 段，来源为 “%s”。"
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "丢弃了 %u 行错误数据。"
 msgstr[1] "丢弃了 %u 行错误数据。"
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "重名命新的%s文件失败，放弃更新。"
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP过滤器已准备好"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr "从已知用户启动"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "节点（%u）"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "无效 IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "无效端口"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "请填写所有必要信息"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "消息"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "确定要下载新的 node.dat 文件吗？\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "这样将删除您当前节点并重启 Kad 连接。"
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "继续？"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kad：搜索关键词太短"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kademila：搜索关键词已经在搜索列表中： "
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "无法读取 node.dat 档案 - 版本 （0） 太旧，已经不再支持了。"
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "读取 %u 个 Kad 联系人"
 msgstr[1] "读取 %u 个 Kad 联系人"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "没有找到联系人，请尝试 bootstrap 或者下载一个 nodes.dat 文件。"
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "只有 %d 个 Kad 联系人可用，nodes.dat 没有写入"
 msgstr[1] "只有%d个Kad联系人可用，nodes.dat没有写入"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "已写入 %d 个 Kad 联系人"
 msgstr[1] "已写入%d个Kad联系人"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 msgid "Kad user"
 msgstr "Kad 用户"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "“%s” 的 Kad 笔记搜索未启动：Kad 未连接"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "“%s” 的 Kad 笔记搜索未启动：已经有一个该文件的笔记查询在运行"
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "“%s” 的 Kad 笔记搜索未启动：文件不在共享列表、下载队列或搜索结果中"
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "“%s” 的 Kad 笔记搜索未启动：另一个 Kad 搜索（比如来源搜索）已经在使用此文件的哈希值 —— 请稍后重试"
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "“%s” 的 Kad 笔记搜索未启动：PrepareLookup 失败"
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "文件名"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "文件大小"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "共享率"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "已请求"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "已接受"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "完成的源"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "警告: 已知文件列表已经损坏，包含有非法头部。"
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "在已知文件列表载入条目失败，文件可能损坏"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "已知文件列表包含非法条目，文件可能损坏："
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "未知错误 %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "无法获取错误 %d 的错误描述"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "正在计算哈希"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "即将完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "已完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "已出错"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "等待中"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "您必须输入一个非空密码。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "密码无效，不是一个 MD5 哈希值！"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "连接失败"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection lost - exiting."
 msgstr "外部连接丢失 — 正在退出。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "远程连接失败，回复为空。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "远程连接：错误回应，握手失败。连接已经关闭。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "成功！已建立到 aMule 的连接 "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "成功！已经建立连接。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "远程连接：访问被拒绝，原因："
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "远程连接：握手失败。"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "ListenSocket: Ok."
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "错误: 无法监听 TCP 端口。"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "错误: "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "警告: "
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "关闭"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "剪切"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "复制"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "全选"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k： "
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 msgid "Connected (LowID)"
 msgstr "已连接 (LowID)"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 msgid "Connected (HighID)"
 msgstr "已连接 (HighID)"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 msgid "Kad: "
 msgstr "Kad: "
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 msgid "Connected (firewalled)"
 msgstr "已连接 (有防火墙)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 msgid "Server: "
 msgstr "服务器： "
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 msgid "Server IP: "
 msgstr "服务器 IP: "
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "未连接"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP: %s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP 端口: %d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP 端口: 未就绪"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP 端口: %d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP 端口: 未就绪"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "客户端信息"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "上传限制"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "下载限制"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "连接"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "显示 aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "隐藏 aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "退出"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "KB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "无限制"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule 托盘菜单"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "速度限制:"
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "上传: 无"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "上传: %u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "下载: 无"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "下载: %u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Download speed: %.1f%s"
 msgstr "下载速度: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "上传速度: %.1f%s"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "昵称：%s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "未选择昵称！"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "客户端 ID: "
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "服务器名称: "
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "服务器 IP: "
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "未连接"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "在线签名: 启用"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "在线签名: 禁用"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "运行时间: %s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "共享文件: %d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "排队客户端: %d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "总下载: %s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "总上传: %s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
 msgstr "在此添加 eD2k 或 magnet 链接"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 msgid "Add links"
 msgstr "添加链接"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "点击此处将添加文本框中的 eD2k 链接至下载队列。"
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "此处显示系统事件。如需完整事件列表，请到服务器分页。"
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "正在载入..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "当前服务器上用户数..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "用户: 0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "当前服务器上的用户和估算总用户数。"
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "上传: 0.0 | 下载: 0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "当前平均上传下载速度。括号中的值为于其他用户连接所消耗的带宽。"
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "显示当前连接状态及当前传送状态。红色箭头表示未连接，黄色箭头表示 Low ID (有防火墙)，绿色箭头表示正常连接(最佳连接方式)。"
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "未连接..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "现在已连接的服务器。"
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "搜索"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "名称:"
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "类型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "本地"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "全局"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "附加参数"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "过滤"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "文件类型"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "任何"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "归档"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "音频"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "CD 映像"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "图片"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "程序"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "文本"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "视频"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "扩展名"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "大小下限"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "字节"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "大小上限"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "可用来源数"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "过滤："
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "过滤结果"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "反向排序结果"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "隐藏已知文件"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "开始"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "更多"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr "向已响应的 Kad 节点请求扩大搜索范围。每次点击都会查询下一个最近的节点，以获取更多联系人（KADEMLIA_FIND_VALUE_MORE），从而显示搜索初始 alpha 边界遗漏的其他文件匹配项。"
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "下载"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "重置表单"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "搜索结果"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "清除已完成的下载"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "文件源:"
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "常规"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "全名 :"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr ".met 文件 :"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "eD2k 文件哈希 :"
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "文件大小 :"
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "传输"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "part 文件状态 :"
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "最后发现完成的文件 :"
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "已发现源 :"
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "正在传输的源 :"
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "文件分块数量 :"
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "可用 :"
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "数据率 :"
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "下载活动时间: "
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "已传输 :"
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "已完成大小 :"
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "智能损坏数据处理"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "因数据损坏而丢失 :"
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "压缩效益 :"
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "由 I.C.H. 挽救的数据包 :"
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 msgid "Sharing"
 msgstr "共享:"
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "请求"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "接受的请求"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "已传送数据"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "共享比率"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "完成的源"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Shared since"
 msgstr "共享始于"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Last upload"
 msgstr "最后上传"
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 msgid "Media Info"
 msgstr "媒体信息"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr "长度："
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 msgid "Bitrate :"
 msgstr "比特率："
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr "编解码器："
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr "艺术家："
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "标题 :"
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "文件名"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "替换"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "清除"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "应用"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "评论/评价文件（文本将对全部用户可见）"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3580,570 +3496,568 @@ msgstr ""
 "像电影的话，您可以说明它的长度、情节和语言等等...\n"
 "如果文件是假冒的，您可以提醒其它 aMule 用户。"
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "文件质量"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "未评价"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "无效 / 损坏 / 假冒"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "差"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "一般"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "好"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "很好"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "选择文件评价或者提醒其它用户该文件是无效的..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 msgid "Get from Kad"
 msgstr "从 Kad 获取"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "刷新"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "正在下载，请等待 ..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "未知大小"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "必填信息"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP 地址 :"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "端口 :"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "附加信息"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "用户名 :"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "添加"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "本次运行平均值"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "上传速度"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "活跃下载"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "统计树"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "用户名："
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "用户哈希:"
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "客户端软件:"
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "客户端版本:"
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP 地址:"
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "用户 ID:"
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "服务器 IP:"
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "服务器名称:"
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "模糊协议:"
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad:"
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "到客户端的传输"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "当前请求:"
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "平均上传速度:"
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "平均下载速度:"
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "上传 (本次运行):"
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "下载 (本次运行):"
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "上传 (总共):"
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "下载 (总共):"
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "得分"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "下载/上传比率:"
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "安全身份认证:"
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "队列等级:"
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "队列积分:"
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "昵称"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - 跨平台的电骡"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "其他用户连接到您的时候，他们会看到这个名字。"
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "语言: "
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "显示提示前的延迟时间。"
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "这用来指定控制语言。"
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 msgid "Periodically check for a new version"
 msgstr "定期检查新版本"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "启用此选项将让 aMule 检查新版本（开启时检查及运行时每天检查一次）"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "在操作系统中注册一个按用户自动启动的条目，以便在登录时启动 aMule。如果移动了 aMule 的可执行文件，之后请手动启动一次 aMule 以刷新该条目。"
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "让 aMule 成为 ed2k:// 链接的默认处理程序，因而在浏览器或文件管理器中点击一个该类型链接时可以在本应用打开。"
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr "aMule 仅支持兼容 eD2k 的磁力链接（包含 xt=urn:ed2k:）。不支持 BitTorrent 磁力链接，点击此类链接将静默失败。如果你正在使用 BitTorrent 客户端（如 Transmission、qBittorrent 等），请勿开启此项。"
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "启动时最小化"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "启用后会使 aMule 在启动时立即最小化。"
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "退出时确认"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "在退出前让 aMule 询问。"
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "启用状态栏图标"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "启用/禁用系统状态栏图标。"
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "按下关闭按钮时隐藏应用程序窗口"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "最小化至系统状态栏图标"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "启用此选项将使 aMule 最小化到系统状态栏，而不是任务栏。"
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr "下载完成后通知"
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr "启用此项将使 aMule 在下载完成时显示通知。"
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "工具提示延迟时间: "
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "浏览器"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "如果可能的话，在新标签页中打开"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能的话，在新的标签页中打开而不是新的窗口"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "视频播放器"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "带宽限制"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "槽速度"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "端口"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "这是标准的 eD2k 端口，不能被禁用。"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "用户服务器请求的 UDP 端口 (TCP+3):"
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "此 UDP 端口用于扩展 eD2k 请求和 Kad 网络"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP 的 TCP 端口 (可选):"
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "为本地地址绑定 IP (全部绑定则留空):"
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr "仅限高级用户：将 aMule 的所有流量绑定到一个网络接口，可以从列表中选择，也可以按名称（例如 tun0、eth0、en0）输入或索引。与绑定到 IP 地址不同，这可以防止流量通过默认路由泄漏—— 在 VPN 环境下有用。无需管理员权限。"
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "每个下载文件的最大的源数量:"
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "启动后自动连接"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "断线后自动重连"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "如果"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr "即使静态服务器连不上也永远不删除。"
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "次连接失败，则删除该服务器"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "列表"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "与服务器连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "与其他用户连接时更新服务器列表"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "启用优先级系统"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "连接时启用智能 Low ID 检测"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "安全连接"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "只自动连接到静态服务器列表里的服务器"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "设置手动添加的服务器为高优先级"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "添加新下载文件时设为暂停状态"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "添加新下载文件时设定优先级为自动"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "尝试先下载文件的第一段和最后一段"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr "末端模式：在下载最后的区块时，切换至速度更快的来源"
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "当一个文件完成时开始下一个暂停的文件"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "来自同一分类"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "依照字母顺序"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "为新文件预分配磁盘空间"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "为新文件分配全部所需的磁盘空间，这样可以减少碎片"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "停止下载当可用磁盘空间只有"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "要求检查磁盘空间"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "请输入最低硬盘空间。"
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "保存稀有文件（少于20个源）的10个源"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "上传"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "添加新共享文件时设优先级为自动"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智能损坏数据处理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "启用"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "高级 I.C.H. 信任全部哈希值 (不推荐)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr "媒体元数据提取"
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr "从共享的音视频文件提取长度/比特率/编解码器信息"
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr "启用此功能后，aMule 会对每个共享媒体文件运行 ffprobe 填充其他客户端在搜索到该文件时看到的“长度”、“比特率”和“编解码器”列。需要安装 ffmpeg（ffprobe 二进制文件）。"
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr "ffprobe 路径："
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr "ffprobe 二进制文件的完整路径。留空让 amule 在启动时自动检测。"
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr "检测"
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
@@ -4151,684 +4065,682 @@ msgstr ""
 "已完成下载的文件存储在此处。此文件夹中的所有文件将自动与其他对等点共享。\n"
 "如果此文件夹中还包含您不想共享的文件，请为 aMule 选择一个专用子文件夹。"
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "共享的文件夹"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr "(由核心共享的文件夹。输入路径添加一个。)"
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr "核心机器上文件夹的绝对路径，如 /home/user/shared"
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr "递归"
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr "分享此文件夹下每个子文件夹，包括之后创建的子文件夹。"
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "删除"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(鼠标右键单击文件夹图标来递归共享)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "共享隐藏文件"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr "自动重新扫描共享文件夹以检测更改"
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr "在共享文件夹中跟踪符号链接"
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr "排除文件匹配："
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr "以“|”分隔的通配符模式，例如 .DS_Store|Thumbs.db|*.tmp。不会共享文件名匹配的文件。匹配不区分大小写。"
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr "模式是正则表达式"
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr "启用后，整个字段是一个正则表达式（'|' 表示交替）。禁用后，它是一个以 '|' 分隔的通配符列表。"
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "图表"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "刷新延迟：5 秒"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "平均值图表显示时间：100 分钟"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "连接图表尺寸: 100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "下载图表尺寸："
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "上传图表尺寸："
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 msgid "Colors: "
 msgstr "颜色： "
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "网格"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "目前下载"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "动态平均下载"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "本次运行平均下载"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "目前上传"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "动态平均上传"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "活跃连接"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 msgid "Systray Icon Speed Bar"
 msgstr "系统状态栏图标速度显示"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "当前 Kad 节点"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "选择"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "树"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "显示用户软件版本的数量(0代表不限制)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "！！！警告！！！"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "5 秒内最大新连接数"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr "并发 Kad 源查找"
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 msgid "Kad source re-search interval (minutes)"
 msgstr "Kad 源重新搜索间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 msgid "Source re-ask interval (minutes)"
 msgstr "源重新请求间隔（分钟）"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "文件缓冲：24000 字节"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr "使用 MMAP：内存映射文件访问（降低内存占用）"
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr "映射 part 文件到内存而不是在堆栈上缓冲，降低进程内存占用。在一些磁盘上可能降低下载速度；最适合内存紧张或重度上传的主机。"
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上传队列长度：5000 用户"
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "服务器连接刷新周期：禁用"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "停用电脑自动进入待命模式功能"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "要使用的皮肤: "
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在全部窗口都显示“快捷 eD2k 链接处理栏”。"
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "在分类页中显示附加信息"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "在标题栏显示应用程序版本"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "在标题栏显示传输速度"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "在应用程序名称之前"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "在应用程序名称之后"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "显示额外开销的带宽"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "垂直显示工具栏"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr "实时列排序（值更改时自动调整顺序）"
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "下载队列文件"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "显示进度百分比"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "拒绝访客访问"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "Web服务器的访客密码"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 msgid "Run webserver on startup (deprecated)"
 msgstr "启动时运行 web 服务器（已废弃）"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4840,11 +4752,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4860,11 +4772,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4874,504 +4786,504 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "共享文件"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "已禁用 [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "字节"
 msgstr[1] "字节"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "KB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "K"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "字节/秒"
 msgstr[1] "字节/秒"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "秒"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "分钟"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "小时"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "日"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "所有"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "其它"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "未完成"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "已停止"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "视频"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "归档"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "文本"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "活动"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "使用配置目录：%s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "等待partfile转换线程结束..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "正在导入 %s：%s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "正在读取临时文件夹"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "正在从下载信息文件获取基本信息"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "创建目标文件"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "从旧下载文件载入数据（%u 共 %u）"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "正在保存数据块至新的单个下载文件（%u 共 %u）"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "正在获取源下载文件信息"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "正在下载和保存新part文件"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "导入 part 文件"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "状态"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "文件校验码"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (磁盘：%s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "请选择一个目录用于搜索临时下载文件！（子目录也将被包括）"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "要删除成功导入的下载项的源文件吗？"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "删除源？"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "错误：无法创建 part 文件"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "尝试从 %s 载入 met 文件的备份"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "错误：无法打开part.met文件：%s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "错误：part.met文件大小为0： %s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "错误：无效的 part.met 文件版本：%s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "错误：文件 %s（%s）已损坏（损坏的标签：%s），无法读取文件。"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "错误：文件 %s（%s）已损坏（标签数不对），无法读取文件。"
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "尝试恢复文件信息..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "尝试恢复无名文件 - 保存为 RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "成功恢复所有文件信息 :D - 尝试使用文件信息..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "无法恢复文件：("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "无法读取 %s（%s）"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "警告：%s可能已损坏（%i）"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "part 文件存盘时发生错误：%s（%s => %s）"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "保存 part 文件时，发生 IO 错误: "
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr "已向 '%s' 写入 0/未知字节——保留现有 .part.met 文件。"
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "%s 的 part.met.seeds 文件存盘失败"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "保存了 part 文件的 %i 个源种子：%s (%s)"
 msgstr[1] "保存了 part 文件的 %i 个源种子：%s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "无法为 part 文件 %s（%s）读取源"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "读取 part 文件的种子文件出错（%s - %s）：%s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "发现损坏的数据块 (%d) 于%d段文件 %s - 文件结果校检码 |%s| 文件校检码 |%s|"
 msgstr[1] "发现损坏的数据块 (%d) 于%d段文件 %s - 文件结果校检码 |%s| 文件校检码 |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "发现了已完成的数据段 %i 在%s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "重新校验 %s 完成"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "在完成文件%s时遇到意外文件错误，文件已暂停"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "完成下载：%s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, c-format
 msgid ""
 "Finished downloading:\n"
@@ -5380,306 +5292,306 @@ msgstr ""
 "完成下载：\n"
 "%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "正在删除文件: %s"
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "警告：无法为已下载的数据段计算校检码 - 校检码集不完整 '%s'"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "警告：无法生成校检码 - 校检码集不完整（%s）， 正常情况下这是不应该发生的"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr "分块 %u（属于文件 '%s'）标记为已完成，但该分片文件大小小于预期（现有 %llu 字节，需要 %llu 字节）；正在重新开放该区间以重新下载。"
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "计算已下载部分 %u (长度 %u，最多 %u) 的哈希值时出现 EOF 错误，它属于part 文件 “%s”（长度 %u）：%s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "警告：硬盘空间不足！暂停文件：%s"
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "下载的数据段 %i 已损坏 文件： (%s)"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：修复了损坏的数据段 %i（%s），挽救数据（字节）： %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "正在分配"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "磁盘空间不足"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下载"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "连接"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "目录"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "服务器"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "文件"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "界面"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr "IP2Country"
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "代理"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "过滤"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "远程控制"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "高级"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "调试"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5689,15 +5601,15 @@ msgstr ""
 "    %PARTFILE - 文件的完整路径\n"
 "    %PARTNAME - 仅文件名"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr "系统托盘图标支持在编译时需要 libayatana-appindicator3。"
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr "在 Wayland 上不可用：该协议无法报告窗口何时被最小化，因此此选项无法拦截系统的最小化按钮。解决方法：使用 `GDK_BACKEND=x11` 启动 aMule，以改用 XWayland。"
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5713,35 +5625,35 @@ msgstr ""
 "即使不改动这些设置，aMule\n"
 "也完全可以正常运行。"
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "使用ID %d和密匙%s连接Cfg到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从Cfg转移到小插件失败"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "正在连接的代理服务器类型"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "通过ID %d和密匙%s把数据从小插件转移到Cfg失败"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "管理密码"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5749,39 +5661,39 @@ msgstr ""
 "重启aMule后这些更改才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Network interface binding changed.\n"
 msgstr "- 更改了网络接口绑定.\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- 外部连接端口已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- 更改了外部连接接受。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- 更改了外部连接接口。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "- 模糊协议支持已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 msgid "- amuleapi settings changed.\n"
 msgstr "- amuleapi 设置已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5789,7 +5701,7 @@ msgstr ""
 "您的自动更新服务器列表是可空的，\n"
 "启动时自动更新服务器列表功能将被禁用。"
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5797,32 +5709,32 @@ msgstr ""
 "您已经启用了远程连接但还没有设置密码。\n"
 "远程连接在没有有效密码的情况下不能使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- 语言已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- 临时文件目录已更改。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "-ED2K网络已启用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr "共享文件排除模式不是有效的正则表达式。已禁用该筛选器。"
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5830,7 +5742,7 @@ msgstr ""
 "eD2k 和 Kad 网络都已被禁用，\n"
 "你至少要启用其中的一项才能连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5838,7 +5750,7 @@ msgstr ""
 "如果你的 UDP 端口被禁用，Kad 将不能启动。\n"
 "启动 UDP 端口或禁用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5848,68 +5760,68 @@ msgstr ""
 "你必须现在重启aMule，\n"
 "如果现在不重启的话，出现任何问题可别怪别人。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr "无法将 aMule 注册为登录时自动启动。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr "无法移除登录时自动启动的条目。"
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Autostart"
 msgstr "自启动"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr "注册URL处理程序"
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr "aMule 仅支持兼容 eD2k 的磁力链接。如果替换当前磁力链接处理程序（%s），BitTorrent 磁力链接将停止工作——aMule 无法下载 BitTorrent 内容。是否继续？"
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr "目前已存在另一个应用程序作为这些链接（%s) 的默认处理程序。是否要将其换成aMule？"
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr "无法将 aMule 注册为URL处理程序。自动启动存储可能为只读。"
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr "无法移除URL处理程序的注册。"
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "启用 web 服务器和 aMule API 需要外部连接。"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr "aMule Web 服务器已弃用。请考虑运行 aMule API。"
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5919,64 +5831,64 @@ msgstr ""
 "请输入至少一个指向有效 server.met 的网址，\n"
 "点击这个勾选框旁边的\"列表\"按钮然后输入网址。"
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "临时文件"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "传入文件"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "在线签名"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "为%s选择文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "将排除 %u 个共享文件，共 %u 个"
 msgstr[1] "将排除 %u 个共享文件，共 %u 个"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "浏览寻找视频播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "选择浏览器"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select ffprobe binary"
 msgstr "选择 ffprobe 文件"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "可执行%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr "未在 PATH 或标准安装位置找到 ffprobe。安装 ffmpeg（ffmpeg 自带 ffprobe），或使用“浏览”手动选择一个二进制文件。"
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr "重置此页面设置为默认值?"
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset to defaults"
 msgstr "重置为默认"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "编辑服务器列表"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5984,114 +5896,114 @@ msgstr ""
 "在此添加下载 server.met 文件的地址\n"
 "每行只限一个。"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr "IP2Country 更新失败"
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr "数据来自 MaxMind GeoLite2"
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 msgid "Custom source"
 msgstr "自定义源"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr "数据来源：DB-IP.com"
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s"
 msgstr "状态：已加载%s"
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "状态：已加载%s~%s"
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr "状态：加载失败 - 点击“立即更新”以刷新。"
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr "状态：未找到 - 点击“立即更新”进行下载。"
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延迟：%d秒"
 msgstr[1] "更新延迟：%d秒"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值图表显示时间：%d分钟"
 msgstr[1] "平均值图表显示时间：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "网络连接图表缩放：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "文件缓冲区大小：%d字节"
 msgstr[1] "文件缓冲区大小：%d字节"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上传队列长度：%d个用户"
 msgstr[1] "上传队列长度：%d个用户"
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "服务器连接刷新周期：%d分钟"
 msgstr[1] "服务器连接刷新周期：%d分钟"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "服务器连接刷新周期：已禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "禁用"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "在“%s”事件时执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "在核心启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "核心命令："
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "在图形界面端启用执行命令"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "图形界面命令："
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr "以下变量将被替换："
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
@@ -6099,1082 +6011,1081 @@ msgstr ""
 "以下文件夹看起来像是系统或敏感位置：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确定要这样做吗？"
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr "正在扫描子目录..."
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 msgid "Updating shared folders"
 msgstr "正在上传共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "已扫描 %u 个目录......"
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "共享的文件夹"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "搜索错误"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必须小于最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "搜索警告"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "主要"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k未连接时eD2k搜索无法进行"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 msgid "No keyword for Kad search - aborting"
 msgstr "Kad 搜索没有关键字 - 中止"
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "尝试Kad搜索时出现未预料的错误： "
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr "Kad 搜索：向另一个节点请求了更广泛的结果。"
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad 搜索：没有剩余节点可重新请求更多结果（已达上限或尚无响应）。"
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "文件 ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr "长度"
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 msgid "Bitrate"
 msgstr "比特率"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "编解码器"
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "下载分类"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "获取此文件的 %s"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "搜索相关文件（eD2k，本地服务器）"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "标记为已知文件"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "复制eD2k链接至剪贴板"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "当前未连接到支持“相关文件”搜索功能的服务器"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "新建"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "无法连接至列出的全部混淆静态服务器，尝试不用混淆再连一次。"
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "无法连接至列出的全部模糊协议服务器，尝试不使用模糊协议。"
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "无法连接列出的所有静态服务器。开始新的一轮尝试。"
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "无法连接列表中的所有服务器. 开始新的一轮尝试."
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "设置中已禁用eD2k网络，将不会连接。"
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "服务器列表中没有可以连接的服务器"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "已连接至 %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "已成功连接到：%s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "尝试连接时出现严重错误，网络可能没有连接"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "连接已断开 %s（%s：%i）"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s（%s：%i）可能已当机"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s（%s：%i）可能已没有空位"
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "服务器自动连接会在 %d 秒后重新尝试"
 msgstr[1] "服务器自动连接会在 %d 秒后重新尝试"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "连接失败 %s（%s：%i）"
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "错误：连接超时，端口无效"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "连接超时 %s（%s：%i）"
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "获取更新的DNS查询结果，丢弃。"
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "正在载入 server.met 文件：%s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "没找到 server.met 文件！"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "载入 server.met 文件 '%s' 失败，遇到未知格式。"
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "未能打开 server.met 文件!"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "Server.met 文件损坏，发现错误的版本标记：0x%x，大小 %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "server.met 中找到%i个服务器"
 msgstr[1] "server.met 中找到%i个服务器"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "新增%d个服务器"
 msgstr[1] "新增%d个服务器"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "错误: 文件 'server.met' 已经损坏: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "读取“server.met”时发生 IO 错误: "
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "没有添加服务器：[%s:%d] 未指定有效端口。"
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "没有添加服务器：[%s:%d] IP 地址无效或被过滤。"
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "没有添加服务器： 服务器列表中已有[%s：%d]"
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "成功添加服务器：[%s:%d] 服务器名为 '%s'"
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "您在连接您已决定删除的服务器，请断开连接。"
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "无法打开“%s”"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "无法保存 server.met！"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "无效 URL"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "从%s下载服务器列表完成"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "addresses.dat文件内没有服务器列表地址，请粘贴一个有效服务器列表地址到该文件以自动更新服务器列表."
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "正在开始从 %s 下载服务器列表"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "警告：自动下载服务器列表的地址错误：%s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "addresses.dat 文件中没有有效的自动更新 server.met 的地址"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "无法从 %s 下载服务器列表"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "本地服务器被IP过滤器过滤掉了，正在重新连接至其他服务器！"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "服务器名称"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "地址"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "端口"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "描述"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "响应时间"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "用户数"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "静态"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr "TCP 标志"
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr "UDP 标志"
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "现在正连接在要删除的服务器。该服务器暂时无法删除。请先断开连接。"
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(未知名称)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "您确定要删除静态服务器 %s ?"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "服务器（%i）"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "服务器"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "连接到服务器"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "标记服务器为静态"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "标记服务器为非静态"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "标记服务器为静态"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "标记服务器为非静态"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "删除服务器"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "删除服务器"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "删除所有服务器"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "复制eD2k链接至剪贴板"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "重新连接到服务器"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "您确定要删除所有服务器吗？"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "您确定要删除已选的服务器吗？"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "您确定要删除已选的服务器吗？"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "错误: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "警告: %s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr "服务器 %s（%s）拒绝了我们的登录（未分配客户端 ID）。正在断开连接。"
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "新的用户编号是 %u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "警告: 您获得了 Low ID！"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t大概这是因为您处在防火墙或路由器后面。"
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\t如需了解更多相关信息，请访问 https://amule-org.github.io/docs"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "收到未知服务器信息 ! - 长度过短"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "收到 %d 个新服务器"
 msgstr[1] "收到 %d 个新服务器"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "服务器列表保存完毕。"
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "服务器拒绝了上一个明令"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "从服务器接收到虚假数据包: %s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "处理来自服务器的数据包时出现未处理的错误 ： %s"
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "无法建立DNS线程以连接 %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "服务器 IP %s (%s) 已被过滤，不在连接。"
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "使用模糊协议。"
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "正在连接至 %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "无法解析服务器 %s 的 DNS： 无法连接！"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 msgid "aMuleGUI Log"
 msgstr "aMule图形用户界面日志"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "没有添加服务器： 没有指定 IP 地址或主机名。"
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "没有添加服务器： 指定的服务器端口组合无效。"
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k状态:"
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 msgid "Connection Type:"
 msgstr "连接类型："
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "已连接"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kad 状态:"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "以局域网模式运行"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "正在运行"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 msgid "Kademlia client ID:"
 msgstr "Kad 客户端 ID:"
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "状态:"
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "连接状态:"
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "被防火墙阻挡-请在你的路由器或者防火墙中打开TCP端口%d"
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP连接状态:"
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "被防火墙阻挡-请在你的路由器或者防火墙中打开UDP端口%d"
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "防火墙状态: "
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "没有好友请求 - TCP 端口打开"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "没有好友请求 - UDP 端口打开"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "没有好友"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "已连接至好友"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "连接到好友于 %s"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "索引源:"
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "索引关键词:"
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "索引批注:"
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "索引载入:"
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "平均用户:"
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "平均文件:"
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "没有运行"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "将文件 %s 加入共享"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "发现 %i 个已知共享文件"
 msgstr[1] "发现 %i 个已知共享文件"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "发现 %i 个已知共享的文件， %i 个未知"
 msgstr[1] "发现 %i 个已知共享的文件， %i 个未知"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] "筛选器排除了 %i 个文件的共享"
 msgstr[1] "筛选器排除了 %i 个文件的共享"
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "错误：尝试共享%s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "找不到共享目录，跳过：%s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "在目录中没有找到可以共享的文件：%s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "用户名"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下载速度"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上传速度"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "可用分块"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "上传状态"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "下载状态"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "来源"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "本地文件名"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "共享文件列表"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "已获取的部分"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "所在目录"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "添加评论/评价"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "编辑评论/评价"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "重命名"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr "验证本地数据"
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "添加收藏中的文件至传输列表"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "复制magnet地址到剪贴板（&U）"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "复制 eD2k 链接到剪贴板 (含源) (&S)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "复制 eD2k 链接到剪贴板 (含源) (包括加密选项) (&W)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "复制 eD2k 链接到剪贴板 (含主机名) (&H)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "复制 eD2k 链接到剪贴板 (含主机名) (包括加密选项) (&C)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "复制 eD2k 链接到剪贴板 (含 &AICH 信息)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "复制 eD2k 链接到剪贴板 (含 &AICH 信息、源)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "目前不支持验证 Part 文件的本地数据：%s"
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "你需要高ID来产生源链接"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "远程文件名"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "本次上传 (全部): %s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "总开销 (数据包): %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "文件请求开销 (数据包): %s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "源交换开销 (数据包): %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "服务器开销 (数据包): %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "Kad 开销 (数据包): %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "加密开销 (UDP): %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "活动上传: %s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "等待上传: %s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "成功上传会话总数: %s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "失败上传会话总数: %s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "平均上传时间: %s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "本次下载 (总共): %s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "发现的源: %s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "活动下载 (块数): %s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "本次上传/下载比率: %s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "平均下载速度 (本次运行): %s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "平均上传速度 (本次运行): %s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "最大下载速度 (本次运行): %s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "最大上传速度 (本次运行): %s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "重新连接: %i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "首次传输到现在时间: %s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "与服务器连接时间: %s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "活跃连接 (估计值): %i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "达到最大连接数: %s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "平均连接数 (估计): %g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "最高连接（估计值）： %i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "用户"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "未知大小: %s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "过滤: %s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "封杀: %s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "总数：%i　已知：%i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "有效服务器：%i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "无效服务器：%i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "总共：%s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "已删除服务器：%s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "被过滤的服务器：%s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "有效服务器中的用户数： %llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "有效服务器中的文件数： %llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "用户总数：%llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "文件总数：%llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "服务器开销：%.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共享文件数：%s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "共享文件大小总和：%s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "平均文件大小：%s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "操作系统"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "没有收到"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "活跃连接 (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "不可用"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "从来没有"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "命令“%s”，pid “%d”已完成，状态代码为“%d”。"
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "执行 <str> 然后退出。"
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "无效 IP 地址格式，请使用 xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "此命令需要一个参数，合法参数为 'all'、文件名或一个数字。\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "正在用此哈希值处理: "
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "正在用此文件名处理: "
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "此命令需要一个参数，合法参数为文件校验码。\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "非有效数字\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "无效的校验值（长度必须为32个字符）\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 msgid ""
 "Invalid search filter syntax.\n"
 "Type 'help search' to get more help.\n"
@@ -7184,7 +7095,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 msgid ""
 "No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
@@ -7194,7 +7105,7 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
@@ -7202,82 +7113,80 @@ msgstr ""
 "未定义搜索类型。\n"
 "输入“help search”以获得更多帮助。\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, c-format
 msgid "Download File: %lu %s\n"
 msgstr "下载文件：%lu %s\n"
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "请求失败，错误未知。"
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "操作成功。"
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "请求失败，错误为：%s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "用户的IP过滤器是：%s。\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "关"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "开"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "服务器的IP过滤器是%s。\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "当前IP过滤级别时 %d.\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "带宽限制：上传：%u kB/s，下载：%u kB/s。\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr "Endgame 源轮替状态为 %s。\n"
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "已启动搜索（id %u）。\n"
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "已连接到 %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "正在连接"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "被防火墙阻挡"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "确定"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7286,7 +7195,7 @@ msgstr ""
 "\n"
 "下载：\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7295,7 +7204,7 @@ msgstr ""
 "\n"
 "上传：\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7304,7 +7213,7 @@ msgstr ""
 "\n"
 "队列长度：\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7313,46 +7222,46 @@ msgstr ""
 "\n"
 "源总数：\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[part 文件]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr "搜索已过期或未知的ID。开始新的搜索。\n"
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "搜索结果数量：%i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "搜索进度: %u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "搜索进度不可用"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "从服务器收到未知的回复，操作码是 %#x."
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "显示简短的状态信息。"
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "显示连接状态，当前上传下载速度等等。\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "显示全部统计树。"
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7366,11 +7275,11 @@ msgstr ""
 "\n"
 "比如：“statistics 5” 只显示每个客户端类型的前 5 大版本。\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "关闭 aMule。"
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7379,35 +7288,35 @@ msgstr ""
 "关闭远程运行的服务程序（amule/amuled）,\n"
 "当远程服务程序不可用时，文本客户端也将关闭。\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "重新载入所给的对象。"
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "重新载入共享文件列表。"
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "重新载入IP过滤表。"
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "重新载入当前IP过滤表。"
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "从URL更新IP过滤表。"
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "如果URL省略了则将使用设置的URL。"
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "连接至网络。"
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7419,35 +7328,35 @@ msgstr ""
 "此IP必须是用点分隔的十进制IPv4地址，\n"
 "或者是可以解析的DNS名称。"
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "只连接eD2k。"
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "只连接Kad。"
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "断开网络。"
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "这将断开当前已连接的全部网络。\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "只断开eD2k。"
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "只断开 Kad 连接。"
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "添加一个eD2k或magnet链接到核心。"
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7465,51 +7374,51 @@ msgstr ""
 "magnet链接必须包含eD2k校验码和文件大小。\n"
 "\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "设置一个参数值。"
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "设置IP过滤参数。"
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "开启用户和服务器的 IP 过滤。"
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "关闭用户和服务器的 IP 过滤。"
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "启动/禁用用户 IP 过滤。"
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "开启用户 IP 过滤。"
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "关闭用户 IP 过滤。"
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "启用/禁用服务器 IP 过滤。"
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "开启服务器 IP 过滤。"
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "关闭服务器 IP 过滤。"
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "选择 IP 过滤级别。"
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7517,71 +7426,71 @@ msgstr ""
 "正确的 IP 过滤级别是在0-255之间，\n"
 "默认（初始）值是127。\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "设置带宽限制。"
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "这些命令的值必须使用单位 KB/s。\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "设置上传带宽限制。"
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "给出的值的单位必须为 KB/s。\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "设置下载带宽限制。"
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 msgid "Enable or disable endgame source rotation."
 msgstr "启用/禁用 末端 源轮替。"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "给出的值必须是 1/ON(启用)或 0/OFF(禁用)。\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "获取并显示设置值。"
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "获取 IP 过滤器设置。"
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "获取用户和服务器的 IP 过滤器状态。"
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "只获取用户的 IP 过滤器状态。"
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "只获取服务器的 IP 过滤器状态。"
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "获取 IP 过滤级别。"
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "获取带宽限制。"
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr "获取 末端 源轮替状态。"
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "执行搜索。"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7615,23 +7524,23 @@ msgstr ""
 "示例：'search global linux iso --type Iso --min-size 100M' 返回\n"
 "至少100 MiB 大小文件类型为 lso 的 \"linux iso\"。\n"
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "执行全局搜索。"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "执行本地搜索"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "执行 Kad 搜索"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 msgid "Show the results of a search."
 msgstr "显示搜索结果。"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
@@ -7639,11 +7548,11 @@ msgstr ""
 "返回搜索结果。\n"
 "可使用搜索 ID（从“搜索 ...”）；若没有 ID，返回最近启动的搜索的结果。\n"
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "显示搜索进度。"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
@@ -7651,11 +7560,11 @@ msgstr ""
 "显示搜索进度。\n"
 "可使用搜索 id; 如不使用 id 则显示最近启动的搜索的进度。\n"
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "开始下载文件"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7663,341 +7572,338 @@ msgstr ""
 "必须指定上次搜索的文件数量。\n"
 "示例：'download 12' 将开始下载上次搜索结果中的12个文件。\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "停止下载。"
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "继续下载。"
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "取消下载。"
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "设置下载优先级。"
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "设置下载的优先级为低、正常、高或自动。\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "设为低优先级。"
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "设为正常优先级。"
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "设为高优先级。"
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "设为自动优先级。"
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "显示队列/列表。"
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "显示上传/下载队列，服务器列表或共享文件列表。\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "显示上传队列。"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "显示下载队列。"
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "显示日志。"
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "显示服务器列表。"
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 msgid "Show shared files list."
 msgstr "显示共享文件列表。"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "重设日志。"
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "废弃的命令，请使用%s代替。"
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
 "Use '%s' instead.\n"
 msgstr "这是一个已废弃的命令，将来可能被删除，请使用 '%s' 替代。\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule 文本客户端"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "正把 “%s” 中旧的 AICH 校验和集转换为 “%s” 中的 64b。"
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr "验证本地数据（%s）：%s 的结果没问题"
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr "验证本地数据（%s）：发现错误！%s 个失败的文件块：MD4: %s。%s %s"
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "警告：文件名 '%s' 非法，已经重命名为 '%s'。"
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "警告：文件 '%s' 已经存在，新文件重命名为 '%s'。"
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "您确定要删除分类中的所有下载文件吗?"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "需要确认"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "仅支持 99 个分类。"
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "分类过多！"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "所有其它"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "选择显示过滤"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "新建分类"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "编辑分类"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "删除分类"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "请求未知文件校检码：%s"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "继续上传此文件: %s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "暂停上传此文件: %s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "无法执行命令 `%s' 于 `%s' 事件。"
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "下载已完成"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "文件的完整路径。"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "不包含路径部分的文件名。"
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "文件的eD2k校验码。"
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "文件大小（字节）。"
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "累计下载活动时间。"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "新的聊天对话已启动"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "消息发送者。"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "空间不足"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "磁盘分区。"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "最后阶段出错"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "正在处理文件号 %u: %s"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "您要求了 part 文件哈希（只用于大于 9.5 MB 的文件）"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> 文件不存在！\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator，aMule eD2k链接的创建程序"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "欢迎！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "输入参数"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "要计算哈希的文件"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "添加附加链接到该文件"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "在此处输入需要生成eD2k链接的文件名"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "在这里输入要添加的eD2k链接，在结尾加 '/' 以附加此文件名"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "创建有文件块校检码的链接"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "该选项可以帮助新文件和稀有文件更快散播，只是链接长度会增加"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 文件哈希"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k 文件哈希"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k 链接"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "保存"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "复制到剪贴板"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "打开"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "打开一个文件并生成它的 eD2k 链接"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "将生成的 eD2k 链接复制到剪贴板"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "另存为"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "保存已生成的eD2k链接至文件"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "关于 aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "选择要生成 eD2k 链接的文件"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "不能打开剪贴簿"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "当前无内容需要复制！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "选择已生成 eD2k 链接的文件"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "无法读取 "
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "请输入一个非空的文件名"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "暂时没有东西可保存！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8017,167 +7923,159 @@ msgstr ""
 "\n"
 "基于 GPL 协议发布"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "正在生成哈希值..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator 正在为您工作"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "计算 MD4 哈希..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "计算 eD2k 哈希..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "已取消！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "在 %.2f 秒内完成"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "您已添加了该链接！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "请输入一个非空的链接"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "无法打开 %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr "计算 ed2k 哈希时内存不足！"
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i 天 %i 小时 %i 分钟 %i 秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02u天 %02u小时 %02u分钟 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02u小时 %02u分钟 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02u分钟 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas，aMule在线统计"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "本次运行最高下载速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "历史最高下载速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "重置"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "系统"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "停止自动刷新"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "保存在线统计图"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "打印在线统计图"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "设置"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "关于 wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "开始自动刷新"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "自动刷新已停止"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "自动刷新已开始"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "保存统计图"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule 在线统计"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8185,11 +8083,11 @@ msgstr ""
 "打印时出现问题。\n"
 "可能当前打印机没有设置正确？"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "打印中"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8207,375 +8105,364 @@ msgstr ""
 "\n"
 "基于 GPL 协议分发"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMule 没有在运行..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule 正在运行"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule 正在运行，但是已断开连接"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule 正在连接..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "aMule 的状态不明..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " 已经运行 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " 已停止！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr " 未连接！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " 正在连接..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " 状态不正常，请检查！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " 已连接至 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "关闭"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " 是在 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " 和 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "总下载: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr ", 上传: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "本次运行下载: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "下载: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " KB/s, 上传: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "共享: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " 队列中的文件，客户端: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "时间: "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " 在 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "系统平均负载 (1-5-15 分钟): "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "系统运行时间: "
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat 文件所在的目录"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "请输入 amulesig.dat 文件所在的目录"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "刷新周期（秒）"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "每次刷新都生成统计图"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "输入存放所产生的统计图的目录"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Upload periodically your stat image to FTP server"
 msgstr "定期上传统计图到 FTP 服务器"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP 地址"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP 路径"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "输入 FTP 服务器的地址"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "输入 FTP 服务器上存放统计图的目录"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "用户名"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "输入登录 FTP 服务器的用户名"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "输入登录FTP服务器的密码"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP上传周期 (分钟)"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "检测"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "统计文件所在文件夹"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "统计图存放文件夹"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "载入模板 <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "Web服务器的HTTP端口"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "为Web服务器端口启用uPnP"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP 端口"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "使用 gzip 压缩"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "Web服务器的完整权限密码"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "Web服务器的访客密码"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "允许访客访问"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "拒绝访客访问"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "载入/保存Web服务器设置从/至远程aMule"
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule设置文件路径，不要直接使用！"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "禁用 PHP 解释器（已废弃）"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "为每个请求重编译 PHP 页面"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule Web 服务器"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "网页客户端连接已被接受\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "错误：无法接受网页客户端连接\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "请求失败，错误为: %s 。"
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "索引文件未找到: "
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "会话过期 - 正在请求登录\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "会话正常，已登录\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "会话正常，未登录\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "没有会话已打开 - 将请求登录\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "会话已创建 - 正在请求登录\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "正在处理请求 [原始]: "
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr "拒绝从 URL 查询字符串读取 `pass`\n"
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "没有指定密码，不允许登录。"
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "检查密码\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "密码哈希值无效\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "密码正确\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "密码错误\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "您没有输入密码，不能输入空密码。\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "已请求注销\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "正在处理请求 [已重定向]: "
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr "aMule（必需）"
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr "桌面快捷方式"
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr "登录时启动 aMule"
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr "卸载"
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr "删除用户数据（配置、ED2K 服务器、Kad 节点、part文件）"
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 msgid "aMule application files (required)."
 msgstr "aMule 程序文件（必需）。"
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr "在桌面上创建 aMule 快捷方式。"
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr "当前用户登录时自动启动 aMule（每用户设置）。"
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr "删除 aMule 应用程序文件、开始菜单/桌面快捷方式、自启动注册表键、URL scheme 注册和添加/删除程序条目（必需）。"
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr "永久删除当前用户的 %APPDATA%\\aMule 目录（包含 aMule.conf 文件、ED2K 服务器列表、Kad 节点、part文件、IP 过滤器和好友列表）。取消选中此项可保留您的设置。"
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
@@ -8583,7 +8470,7 @@ msgstr ""
 "aMule 似乎正从 $INSTDIR 目录运行。\n"
 "请关闭 aMule（以及 aMuleD / aMuleGUI），然后重试。"
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
@@ -8591,11 +8478,11 @@ msgstr ""
 "aMule守护进程（amuled.exe）似乎正从 $INSTDIR目录运行。\n"
 "请停止它并重试。"
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr "正在删除之前 $0 位置的 aMule 安装…"
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
@@ -8603,11 +8490,11 @@ msgstr ""
 "无法删除之前在 $0 处安装的 aMule。\n"
 "请关闭所有正在运行的 aMule 进程并重试，或者先手动卸载之前的版本。"
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。"
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 20:56+0200\n"
+"POT-Creation-Date: 2026-07-28 21:43+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -26,20 +26,20 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/AboutDialog.cpp:62
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "About aMule"
 msgstr "顯示 aMule"
 
-#: src/AboutDialog.cpp:74
+#: src/AboutDialog.cpp
 msgid "aMule remote control "
 msgstr "aMule 遠端控制"
 
-#: src/AboutDialog.cpp:79
+#: src/AboutDialog.cpp
 msgid "Snapshot:"
 msgstr "快照："
 
-#: src/AboutDialog.cpp:81
+#: src/AboutDialog.cpp
 msgid ""
 "'All-Platform' p2p client based on eMule \n"
 "\n"
@@ -47,7 +47,7 @@ msgstr ""
 "源自 eMule 的「跨平台」P2P 客戶端程式\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid ""
 "Copyright (c) 2003-2026 aMule Team \n"
@@ -56,79 +56,79 @@ msgstr ""
 "Copyright (c) 2003-2019 aMule 團隊\n"
 "\n"
 
-#: src/AboutDialog.cpp:85
+#: src/AboutDialog.cpp
 msgid "Part of aMule is based on \n"
 msgstr "部份 aMule 源自 \n"
 
-#: src/AboutDialog.cpp:86
+#: src/AboutDialog.cpp
 msgid "Kademlia: Peer-to-peer routing based on the XOR metric.\n"
 msgstr " KAD：基於 XOR 演算法的 P2P 路由。\n"
 
-#: src/AboutDialog.cpp:87
+#: src/AboutDialog.cpp
 msgid " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 msgstr " Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n"
 
-#: src/AboutDialog.cpp:100
+#: src/AboutDialog.cpp
 msgid "Website:"
 msgstr ""
 
-#: src/AboutDialog.cpp:101
+#: src/AboutDialog.cpp
 msgid "Forum:"
 msgstr ""
 
-#: src/AboutDialog.cpp:102
+#: src/AboutDialog.cpp
 msgid "Documentation:"
 msgstr ""
 
-#: src/AboutDialog.cpp:103
+#: src/AboutDialog.cpp
 msgid "Issues:"
 msgstr ""
 
-#: src/AboutDialog.cpp:112
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Click to check for a newer version."
 msgstr "啓動時檢查新版本"
 
-#: src/AboutDialog.cpp:113
+#: src/AboutDialog.cpp
 msgid "Check for updates"
 msgstr ""
 
-#: src/AboutDialog.cpp:162
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "Checking for updates..."
 msgstr "Kad 連線中..."
 
-#: src/AboutDialog.cpp:172
+#: src/AboutDialog.cpp
 #, fuzzy
 msgid "You are running the latest version."
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/AboutDialog.cpp:176
+#: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "A new version (%s) is available:"
 msgstr "不可用"
 
-#: src/AboutDialog.cpp:180
+#: src/AboutDialog.cpp
 msgid "Could not check for updates. Please try again later."
 msgstr ""
 
-#: src/AddFriend.cpp:42
+#: src/AddFriend.cpp
 msgid "Add a Friend"
 msgstr "加入好友"
 
-#: src/AddFriend.cpp:57
+#: src/AddFriend.cpp
 msgid "You have to enter a valid IP and port!"
 msgstr "請輸入有效的 IP 位址和通訊埠！"
 
-#: src/AddFriend.cpp:58 src/AddFriend.cpp:67
+#: src/AddFriend.cpp
 msgid "Information"
 msgstr "資訊"
 
-#: src/AddFriend.cpp:66
+#: src/AddFriend.cpp
 msgid "The specified userhash is not valid!"
 msgstr "這個使用者 hash 值無效！"
 
-#: src/AppImageIntegration.cpp:413
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule can install desktop launchers, icons, and shell command shortcuts into your home directory so it appears in your application menu like a regularly installed app.\n"
 "\n"
@@ -137,49 +137,48 @@ msgid ""
 "Install desktop integration now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:419
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "Add aMule to your application menu?"
 msgstr "在程式名稱後"
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Install"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:421
+#: src/AppImageIntegration.cpp
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:663
+#: src/AppImageIntegration.cpp src/amuleDlg.cpp
 msgid "Don't ask again"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:442
+#: src/AppImageIntegration.cpp
 msgid "Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:445 src/AppImageIntegration.cpp:458
-#: src/AppImageIntegration.cpp:479
+#: src/AppImageIntegration.cpp
 #, fuzzy
 msgid "aMule integration failed"
 msgstr "無法連線 "
 
-#: src/AppImageIntegration.cpp:454
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to create %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:475
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "Cannot install desktop integration: failed to write %s. Check that your home directory is writable."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:508
+#: src/AppImageIntegration.cpp
 #, c-format
 msgid "AppImage integration: aMule added to your application menu (%d shell shortcuts under ~/.local/bin)."
 msgstr ""
 
-#: src/AppImageIntegration.cpp:513
+#: src/AppImageIntegration.cpp
 msgid ""
 "aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n"
 "\n"
@@ -188,103 +187,100 @@ msgid ""
 "Restart aMule now?"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:519
+#: src/AppImageIntegration.cpp
 msgid "aMule installed"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Restart now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:521
+#: src/AppImageIntegration.cpp
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:206
+#: src/amuleAppCommon.cpp
 msgid "Failed to open ED2KLinks file."
 msgstr "無法開啟 ED2K 連結檔。"
 
-#: src/amuleAppCommon.cpp:282
+#: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
 
-#: src/amule.cpp:301
+#: src/amule.cpp
 msgid "Now, exiting main app..."
 msgstr "正在離開主程式..."
 
-#: src/amule.cpp:331
+#: src/amule.cpp
 #, c-format
 msgid "Terminating amuleweb instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:335
+#: src/amule.cpp
 #, c-format
 msgid "Killing amuleweb instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:337 src/amule.cpp:350 src/ClientRef.cpp:180
-#: src/SearchDlg.cpp:1041 src/ServerListCtrl.cpp:98
+#: src/amule.cpp src/ClientRef.cpp src/SearchDlg.cpp src/ServerListCtrl.cpp
 msgid "Failed"
 msgstr "失敗"
 
-#: src/amule.cpp:344
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Terminating amuleapi instance with pid '%d' ... "
 msgstr "正在終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:348
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "Killing amuleapi instance with pid '%d' ... "
 msgstr "正在強行終止 pid %d 的 amuleweb 執行緒... "
 
-#: src/amule.cpp:356
+#: src/amule.cpp
 msgid "aMule OnExit: Terminating core."
 msgstr "aMule 離開中：正在終止主程式。"
 
-#: src/amule.cpp:467
+#: src/amule.cpp
 msgid "aMule shutdown completed."
 msgstr "已關閉 aMule 。"
 
-#: src/amule.cpp:471
+#: src/amule.cpp
 msgid "Memory debug results for aMule exit:"
 msgstr "離開 aMule 時記憶體除錯結果："
 
-#: src/amule.cpp:652
+#: src/amule.cpp
 #, c-format
 msgid "Binding aMule's peer-to-peer traffic to interface: %s (HTTP updates use the default route)"
 msgstr ""
 
-#: src/amule.cpp:656
+#: src/amule.cpp
 #, c-format
 msgid "Binding all network traffic to interface: %s"
 msgstr ""
 
-#: src/amule.cpp:660
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: configured network interface '%s' was not found - traffic is NOT bound to it and may leave via the default route. Check the interface name in Preferences."
 msgstr ""
 
-#: src/amule.cpp:666
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: binding to network interface '%s' requires elevated privileges and was NOT applied - traffic may leave via the default route. Grant the capability (e.g. 'sudo setcap cap_net_raw+ep' on the aMule binary) or run with sufficient privileges."
 msgstr ""
 
-#: src/amule.cpp:674
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: could not bind to network interface '%s' - traffic may leave via the default route."
 msgstr ""
 
-#: src/amule.cpp:733
+#: src/amule.cpp
 msgid "Your locale has been changed to System Default due to a configuration change. Sorry."
 msgstr "對不起，由於版本變更，您的地區設定已經被變更爲系統預設值。"
 
-#: src/amule.cpp:735 src/amule.cpp:1589 src/CatDialog.cpp:128
-#: src/CatDialog.cpp:136 src/CatDialog.cpp:149 src/ServerList.cpp:366
-#: src/ServerListCtrl.cpp:152
+#: src/amule.cpp src/CatDialog.cpp src/ServerList.cpp src/ServerListCtrl.cpp
 msgid "Info"
 msgstr "資訊"
 
-#: src/amule.cpp:742
+#: src/amule.cpp
 msgid ""
 "\n"
 "EC configuration"
@@ -292,74 +288,70 @@ msgstr ""
 "\n"
 "外部連線設定"
 
-#: src/amule.cpp:745
+#: src/amule.cpp
 msgid "Password set and external connections enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/amule.cpp:755 src/KadDlg.cpp:195 src/KadDlg.cpp:204
-#: src/PrefsUnifiedDlg.cpp:1496 src/SharedFilesCtrl.cpp:470
+#: src/amule.cpp src/KadDlg.cpp src/PrefsUnifiedDlg.cpp src/SharedFilesCtrl.cpp
 msgid "WARNING"
 msgstr "警告"
 
-#: src/amule.cpp:992
+#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
 
-#: src/amule.cpp:997
+#: src/amule.cpp
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1006 src/FirstRunWizard.cpp:411
+#: src/amule.cpp src/FirstRunWizard.cpp
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:1013 src/FirstRunWizard.cpp:416
+#: src/amule.cpp src/FirstRunWizard.cpp
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:1103
+#: src/amule.cpp
 #, c-format
 msgid "web server running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1116
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1121 src/amule.cpp:1185 src/amule.cpp:1299 src/amule.cpp:1601
-#: src/amule-remote-gui.cpp:603 src/amule-remote-gui.cpp:671
-#: src/amule-remote-gui.cpp:709 src/amule-remote-gui.cpp:1282
-#: src/amule-remote-gui.cpp:1345 src/amule-remote-gui.cpp:1372
-#: src/DownloadQueue.cpp:1481 src/PrefsUnifiedDlg.cpp:1282
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp
 msgid "ERROR"
 msgstr "錯誤"
 
-#: src/amule.cpp:1174
+#: src/amule.cpp
 #, fuzzy, c-format
 msgid "amuleapi running on pid %d"
 msgstr "執行中的網站伺服器 pid：%d"
 
-#: src/amule.cpp:1180
+#: src/amule.cpp
 #, fuzzy
 msgid "You requested to run amuleapi on startup, but the amuleapi binary cannot be run. Please install the package containing aMule's REST API server, or build aMule from source with -DBUILD_AMULEAPI=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp:1267
+#: src/amule.cpp
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr "無法選定使用此位址的通訊埠：%s"
 
-#: src/amule.cpp:1291
+#: src/amule.cpp
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr "通訊埠 %u 已被佔用。您會變成 LOWID。\n"
 
-#: src/amule.cpp:1296
+#: src/amule.cpp
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -374,48 +366,48 @@ msgstr ""
 "\n"
 "請檢查網路設定以確保通訊埠可正常使用。"
 
-#: src/amule.cpp:1393
+#: src/amule.cpp
 msgid "Failed to create OnlineSig File"
 msgstr "無法建立線上簽名識別檔"
 
-#: src/amule.cpp:1401
+#: src/amule.cpp
 msgid "Failed to create aMule OnlineSig File"
 msgstr "無法建立 aMule 線上簽名識別檔"
 
-#: src/amule.cpp:1564
+#: src/amule.cpp
 msgid "The selected locale seems not to be installed on your box. (Note: I'll try to set it anyway)"
 msgstr "在您的電腦上似乎沒有安裝您所選取的地區設定。 (但仍會採用您所選擇的設定)"
 
-#: src/amule.cpp:1574
+#: src/amule.cpp
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr "這是您第一次執行 aMule %s"
 
-#: src/amule.cpp:1577
+#: src/amule.cpp
 msgid "This version is a testing version, updated daily, and\n"
 msgstr "這個版本是測試版，每日有更新，\n"
 
-#: src/amule.cpp:1578
+#: src/amule.cpp
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr "但我們無法擔保它不會造成任何損害、燒掉您的房子、\n"
 
-#: src/amule.cpp:1579
+#: src/amule.cpp
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr "或害死您的狗。但一般來講它「應該」是安全的。\n"
 
-#: src/amule.cpp:1584
+#: src/amule.cpp
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr "在我們的網頁可找到更多資訊、使用者支援以及程式最新版本：\n"
 
-#: src/amule.cpp:1585
+#: src/amule.cpp
 msgid "at https://amule-org.github.io, or in our IRC channel #aMule at irc.libera.chat.\n"
 msgstr "https://amule-org.github.io，或我們在 irc.libera.chat 的 IRC 頻道 #aMule。\n"
 
-#: src/amule.cpp:1587
+#: src/amule.cpp
 msgid "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr "歡迎您到 https://github.com/amule-org/amule/issues 提出錯誤報告"
 
-#: src/amule.cpp:1599
+#: src/amule.cpp
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
@@ -423,224 +415,220 @@ msgstr ""
 "您選擇的線上簽名識別檔案所在資料夾無效！\n"
 " 在您變更偏好設定之前，線上簽名識別功能將被停用。"
 
-#: src/amule.cpp:1662
+#: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
 
-#: src/amule.cpp:2039
+#: src/amule.cpp
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr "無法為檔案 %s 預先分配磁碟空間：%s"
 
-#: src/amule.cpp:2168
+#: src/amule.cpp
 msgid "ERROR: can't open logfile"
 msgstr "錯誤：無法開啟記錄檔"
 
-#: src/amule.cpp:2172
+#: src/amule.cpp
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr "警告：沒有記錄檔，肯定有什麽地方出錯了。"
 
-#: src/amule.cpp:2189
+#: src/amule.cpp
 msgid "Log has been reset"
 msgstr "記錄已被清除"
 
-#: src/amule.cpp:2213
+#: src/amule.cpp
 #, c-format
 msgid "ServerMessage: %s"
 msgstr "伺服器訊息：%s"
 
-#: src/amule.cpp:2256 src/IP2Country.cpp:220 src/IPFilter.cpp:514
-#: src/ServerList.cpp:875
+#: src/amule.cpp src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr "略過不下載 %s ，因為並不是新近檔案。"
 
-#: src/amule.cpp:2259
+#: src/amule.cpp
 msgid "Failed to download the nodes list."
 msgstr "無法下載節點清單。"
 
-#: src/amule.cpp:2322
+#: src/amule.cpp
 msgid "Failed to open the downloaded version check file"
 msgstr "無法開啟下載的版本檢查檔"
 
-#: src/amule.cpp:2325 src/amule.cpp:2344
+#: src/amule.cpp
 msgid "Corrupted version check file"
 msgstr "損壞的版本檢查檔"
 
-#: src/amule.cpp:2367
+#: src/amule.cpp
 msgid "You are using an outdated version of aMule!"
 msgstr "您使用的是過期的 aMule 版本！"
 
-#: src/amule.cpp:2369
+#: src/amule.cpp
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr "您的 aMule 版本是 %i.%i.%i，最新版本是 %li.%li.%li"
 
-#: src/amule.cpp:2373
+#: src/amule.cpp
 msgid "The latest version can always be found at https://github.com/amule-org/amule/releases/latest"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amule.cpp:2376
+#: src/amule.cpp
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr "警告：您的 aMuled 版本已經過期：%i.%i.%i < %li.%li.%li"
 
-#: src/amule.cpp:2382
+#: src/amule.cpp
 msgid "Your copy of aMule is up to date."
 msgstr "您的 aMule 是最新版本。"
 
-#: src/amule.cpp:2389
+#: src/amule.cpp
 msgid "Failed to download the version check file"
 msgstr "無法下載版本檢查檔"
 
-#: src/amule.cpp:2558 src/amule-remote-gui.cpp:1133
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr "使用者：%s | 檔案：%s"
 
-#: src/amule.cpp:2559 src/amule-remote-gui.cpp:1134
+#: src/amule.cpp src/amule-remote-gui.cpp
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr "使用者：E:%s K:%s | 檔案：E:%s K:%s"
 
-#: src/amule.cpp:2573 src/amule-remote-gui.cpp:1147
+#: src/amule.cpp src/amule-remote-gui.cpp
 msgid "No networks selected"
 msgstr "未選取網路"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:903
+#: src/amule.cpp src/TextClient.cpp
 msgid "with LowID"
 msgstr "有 LowID"
 
-#: src/amule.cpp:2641 src/TextClient.cpp:904
+#: src/amule.cpp src/TextClient.cpp
 msgid "with HighID"
 msgstr "有 HighID"
 
-#: src/amule.cpp:2643
+#: src/amule.cpp
 #, c-format
 msgid "Connected to %s %s"
 msgstr "已連線到 %s %s"
 
-#: src/amule.cpp:2648
+#: src/amule.cpp
 #, c-format
 msgid "Connecting to %s"
 msgstr "正在連線到 %s"
 
-#: src/amule.cpp:2650
+#: src/amule.cpp
 msgid "Disconnected from eD2k"
 msgstr "已中斷 eD2k 網路連線"
 
-#: src/amule.cpp:2659
+#: src/amule.cpp
 msgid "Kad started."
 msgstr "Kad 已啓動。"
 
-#: src/amule.cpp:2661
+#: src/amule.cpp
 msgid "Kad stopped."
 msgstr "Kad 已停止。"
 
-#: src/amule.cpp:2669
+#: src/amule.cpp
 msgid "Connected to Kad (ok)"
 msgstr "已連線到 Kad"
 
-#: src/amule.cpp:2671
+#: src/amule.cpp
 msgid "Connected to Kad (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/amule.cpp:2675
+#: src/amule.cpp
 msgid "Disconnected from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/amule.cpp:2707
+#: src/amule.cpp
 msgid "Kad network cannot be used if UDP port is disabled on preferences, not starting."
 msgstr "Kad 網路未啟動：如果在偏好設定中停用了 UDP 埠，Kad 網路將不能使用。"
 
-#: src/amule.cpp:2711
+#: src/amule.cpp
 msgid "Kad network disabled on preferences, not connecting."
 msgstr "Kad 網路在偏好設定中被停用了，沒有連線。"
 
-#: src/amuled.cpp:217
+#: src/amuled.cpp
 msgid "ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"
 msgstr "錯誤：當停用外部連線時，aMule 背景服務程式無法使用。要啓用外部連線，請使用標準的 aMule，或使用 --ec-config 選項啓動 amuled，或在檔案 ~/aMule/amule.conf 中將「AcceptExternalConnections」設定值改為 1"
 
-#: src/amuled.cpp:224
+#: src/amuled.cpp
 #, fuzzy
 msgid "ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"
 msgstr "錯誤：需要有效的密碼以使用外部連線，且 aMule 背景服務程式要有外部連線才可使用。要執行 aMule 背景服務程式，您必須在檔案 ~/aMule/amule.conf 中將 「ECPassword」 設定值改為適當的數字。使用 --ec-config 參數啓動 amuled 以設定密碼。請到 https://amule-org.github.io/docs 取得更多資訊"
 
-#: src/amuled.cpp:244
+#: src/amuled.cpp
 msgid "amuled: OnInit - starting timer"
 msgstr "amuled：初始中 - 正在開始計時器"
 
-#: src/amuled.cpp:274
+#: src/amuled.cpp
 msgid "Cannot Create Pid File"
 msgstr "無法建立 pid 檔案"
 
-#: src/amuled.cpp:343
+#: src/amuled.cpp
 #, c-format
 msgid "ERROR: %s"
 msgstr "錯誤：%s"
 
-#: src/amuleDlg.cpp:248
+#: src/amuleDlg.cpp
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "這是 aMule %s (源自 eMule)。"
 
-#: src/amuleDlg.cpp:249
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:251
+#: src/amuleDlg.cpp
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:280
+#: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:359 src/amuleDlg.cpp:1738 src/amuleDlg.cpp:1983
-#: src/muuli_wdr.cpp:1492 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:360 src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1750 src/DownloadListCtrl.cpp:737
-#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1585 src/muuli_wdr.cpp:3467
-#: src/Statistics.cpp:829
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3341
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1762 src/muuli_wdr.cpp:2973
-#: src/muuli_wdr.cpp:3423 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1768 src/muuli_wdr.cpp:3471
-#: src/PrefsUnifiedDlg.cpp:317 src/Statistics.cpp:779 src/Statistics.cpp:1235
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/Statistics.cpp
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1775 src/muuli_wdr.cpp:3473
-#: src/PrefsUnifiedDlg.cpp:333 src/utils/wxCas/src/wxcasprefs.cpp:39
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: src/amuleDlg.cpp:369
+#: src/amuleDlg.cpp
 msgid "Navigate"
 msgstr ""
 
-#: src/amuleDlg.cpp:655
+#: src/amuleDlg.cpp
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:659
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -650,193 +638,186 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:741
+#: src/amuleDlg.cpp
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:764 src/DataToText.cpp:68 src/IPFilter.cpp:547
-#: src/ServerWnd.cpp:503
+#: src/amuleDlg.cpp src/DataToText.cpp src/IPFilter.cpp src/ServerWnd.cpp
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:958
+#: src/amuleDlg.cpp
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:962
+#: src/amuleDlg.cpp
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:968
+#: src/amuleDlg.cpp
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:972
+#: src/amuleDlg.cpp
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:981
+#: src/amuleDlg.cpp
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
-#: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
-#: src/utils/wxCas/src/wxcasframe.cpp:1041
+#: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1986 src/Preferences.cpp:979
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/Preferences.cpp
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3465
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1748 src/muuli_wdr.cpp:3466
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3467
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1760 src/muuli_wdr.cpp:3469
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3470
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1772 src/muuli_wdr.cpp:3471
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1779 src/muuli_wdr.cpp:3473
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1782 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1786 src/muuli_wdr.cpp:3474
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
+#: src/amuleDlg.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1789 src/muuli_wdr.cpp:3475
+#: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1986
+#: src/amuleDlg.cpp
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1989
+#: src/amuleDlg.cpp
 msgid "No network"
 msgstr "無網路"
 
-#: src/amule-gui.cpp:238
+#: src/amule-gui.cpp
 msgid "aMule remote control"
 msgstr "aMulle 遠端控制"
 
-#: src/amule-gui.cpp:240 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule"
 msgstr "aMule"
 
-#: src/amule-gui.cpp:386
+#: src/amule-gui.cpp
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr "嚴重錯誤：無法建立主程式端計時器"
 
-#: src/amule-remote-gui.cpp:80
+#: src/amule-remote-gui.cpp
 msgid "Connect to remote amule"
 msgstr "連線到遠端 amule"
 
-#: src/amule-remote-gui.cpp:144 src/ServerConnect.cpp:411
+#: src/amule-remote-gui.cpp src/ServerConnect.cpp
 msgid "Connection lost"
 msgstr "失去連線"
 
-#: src/amule-remote-gui.cpp:151
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Abort and exit"
 msgstr "離開前先確認"
 
-#: src/amule-remote-gui.cpp:161
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnecting... (attempt %d)"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:164
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Next attempt in %d s..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:171
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection to %s lost.\n"
@@ -845,722 +826,699 @@ msgid ""
 "The interface is paused until the connection is restored."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:483
+#: src/amule-remote-gui.cpp
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr "嚴重錯誤：無法建立 Poll Timer"
 
-#: src/amule-remote-gui.cpp:514
+#: src/amule-remote-gui.cpp
 msgid "Going to event loop..."
 msgstr "正在進行事件迴圈..."
 
-#: src/amule-remote-gui.cpp:569
+#: src/amule-remote-gui.cpp
 msgid "Connecting..."
 msgstr "正在連線..."
 
-#: src/amule-remote-gui.cpp:602
+#: src/amule-remote-gui.cpp
 msgid "Connection failed. Please check the host, port, and password."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:641
+#: src/amule-remote-gui.cpp
 msgid "Remote GUI EC event handler"
 msgstr "遠端 GUI 外部連線事件處理器"
 
-#: src/amule-remote-gui.cpp:668 src/ExternalConnector.cpp:472
+#: src/amule-remote-gui.cpp src/ExternalConnector.cpp
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr "無法連線到 %s:%d\n"
 
-#: src/amule-remote-gui.cpp:675 src/amule-remote-gui.cpp:779
+#: src/amule-remote-gui.cpp
 msgid "Going down"
 msgstr "關閉中"
 
-#: src/amule-remote-gui.cpp:697
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnect attempt timed out; retrying."
 msgstr "連線到 %s (%s:%i) 時逾時。"
 
-#: src/amule-remote-gui.cpp:706
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
 "Please check the host, port and that aMule is running with External Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:730
+#: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:763
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "Reconnected to the remote core."
 msgstr "連線到網路。"
 
-#: src/amule-remote-gui.cpp:793
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "無法連線到 %s:%d\n"
 
-#: src/amule-remote-gui.cpp:821
+#: src/amule-remote-gui.cpp
 msgid "Reconnect could not start; retrying shortly."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:956
+#: src/amule-remote-gui.cpp
 msgid "Ready"
 msgstr "就緒"
 
-#: src/amule-remote-gui.cpp:1191 src/TransferWnd.cpp:343
+#: src/amule-remote-gui.cpp src/TransferWnd.cpp
 msgid "All"
 msgstr "全部"
 
-#: src/amule-remote-gui.cpp:1272
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not readable"
 msgstr "N/A"
 
-#: src/amule-remote-gui.cpp:1273
+#: src/amule-remote-gui.cpp
 #, fuzzy
 msgid "not found"
 msgstr "找不到檔案。"
 
-#: src/amule-remote-gui.cpp:1278
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "The core rejected these shared folders:%s"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1336 src/ExternalConn.cpp:2346
+#: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "無效連結或已在清單中。"
 
-#: src/amule-remote-gui.cpp:1363
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 
-#: src/amule-remote-gui.cpp:2341 src/BaseClient.cpp:1830
-#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
-#: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
-#: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
-#: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
-#: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1171 src/DownloadListCtrl.cpp:1184
-#: src/DownloadListCtrl.cpp:1195 src/ExternalConn.cpp:609
-#: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
-#: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
-#: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
-#: src/HTTPDownload.cpp:89 src/KnownFile.cpp:1087 src/KnownFile.cpp:1093
-#: src/MuleTrayIcon.cpp:422 src/MuleTrayIcon.cpp:848 src/PartFile.cpp:2838
-#: src/PartFile.cpp:2844 src/Server.cpp:134 src/Server.cpp:210
-#: src/Statistics.cpp:1161
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
-#: src/BaseClient.cpp:1375
+#: src/BaseClient.cpp
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "無法從使用者 %s 取得分享檔案清單"
 
-#: src/BaseClient.cpp:1627
+#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "搜尋 LowID 連線好友"
 
-#: src/BaseClient.cpp:1847
+#: src/BaseClient.cpp
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (假 eMule 版本 %#x)"
 
-#: src/BaseClient.cpp:1855
+#: src/BaseClient.cpp
 msgid " (Fake eMule)"
 msgstr " (假 eMule)"
 
-#: src/BaseClient.cpp:1858
+#: src/BaseClient.cpp
 msgid "xMule (Fake eMule)"
 msgstr "xMule (假 eMule)"
 
-#: src/BaseClient.cpp:1903
+#: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (源自 eMule v0.%u)"
 
-#: src/BaseClient.cpp:2127
+#: src/BaseClient.cpp
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "暱稱：%s ID：%u"
 
-#: src/BaseClient.cpp:2129
+#: src/BaseClient.cpp
 #, c-format
 msgid "Requested: %s\n"
 msgstr "已要求：%s\n"
 
-#: src/BaseClient.cpp:2131
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "本次：共接受 %d/%d 個要求，已傳送 %s\n"
 
-#: src/BaseClient.cpp:2137
+#: src/BaseClient.cpp
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "總計：共接受 %d/%d 個要求，已傳送 %s\n"
 
-#: src/BaseClient.cpp:2143
+#: src/BaseClient.cpp
 msgid "Requested unknown file"
 msgstr "已要求不明檔案"
 
-#: src/BaseClient.cpp:2820
+#: src/BaseClient.cpp
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "來自 %s (IP：%s) 的訊息被過濾掉了"
 
-#: src/BaseClient.cpp:2968
+#: src/BaseClient.cpp
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "來自 %s (IP:%s) 的新訊息"
 
-#: src/BaseClient.cpp:3060
+#: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "使用者 %s (%u) 要求不存在的目錄 %s 的分享檔案清單 -> 已忽略"
 
-#: src/CanceledFileList.cpp:51 src/KnownFileList.cpp:102
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr "警告：無法開啟 %s 。"
 
-#: src/CanceledFileList.cpp:58
+#: src/CanceledFileList.cpp
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr "警告：已取消檔案清單損壞，內有無效標頭。"
 
-#: src/CanceledFileList.cpp:78 src/KnownFileList.cpp:150
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr "讀取 %s 時發生 IO 錯誤：%s"
 
-#: src/CanceledFileList.cpp:100 src/KnownFileList.cpp:235
+#: src/CanceledFileList.cpp src/KnownFileList.cpp
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr "儲存 %s 時發生錯誤：%s"
 
-#: src/CaptchaDialog.cpp:34
+#: src/CaptchaDialog.cpp
 msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
-#: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:780 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "分類"
 
-#: src/CatDialog.cpp:83
+#: src/CatDialog.cpp
 msgid "New Category"
 msgstr "新分類"
 
-#: src/CatDialog.cpp:116
+#: src/CatDialog.cpp
 msgid "Choose a folder for incoming files"
 msgstr "請選擇新進檔案資料夾"
 
-#: src/CatDialog.cpp:128
+#: src/CatDialog.cpp
 msgid "You must specify a name for the category!"
 msgstr "請輸入此分類的名稱！"
 
-#: src/CatDialog.cpp:136
+#: src/CatDialog.cpp
 msgid "You must specify a path for the category!"
 msgstr "請輸入此分類的路徑！"
 
-#: src/CatDialog.cpp:148
+#: src/CatDialog.cpp
 msgid "Failed to create incoming dir for category. Please specify a valid path!"
 msgstr "無法建立該分類的目錄。請輸入有效的路徑！"
 
-#: src/ChatSelector.cpp:132
+#: src/ChatSelector.cpp
 #, c-format
 msgid "Chat-Session Started: %s (%s:%u) - %s %s"
 msgstr "已開始交談：%s (%s:%u) - %s %s"
 
-#: src/ChatSelector.cpp:206 src/ChatSelector.cpp:285
+#: src/ChatSelector.cpp
 msgid "*** Connected to Client ***"
 msgstr "*** 已連線到客戶端 ***"
 
-#: src/ChatSelector.cpp:249
+#: src/ChatSelector.cpp
 msgid "*** Connecting to Client ***"
 msgstr "*** 正在連線到客戶端 ***"
 
-#: src/ChatSelector.cpp:279
+#: src/ChatSelector.cpp
 msgid "*** Failed to Connect to client / Connection lost ***"
 msgstr "*** 無法連線到客戶端 / 連線中斷 ***"
 
-#: src/ChatSelector.cpp:328
+#: src/ChatSelector.cpp
 msgid "*** You have passed the captcha check and the user has received your message. ***"
 msgstr "*** 您已通過圖形驗證，使用者已收到您的訊息。 ***"
 
-#: src/ChatSelector.cpp:330
+#: src/ChatSelector.cpp
 msgid "*** Your response to the captcha was wrong and your message has been ignored. You can request a new captcha by sending a new message. ***"
 msgstr "*** 您輸入的驗證碼不正確，訊息將被忽略。要重傳送訊息，請重新輸入圖形驗證碼。 ***"
 
-#: src/ChatWnd.cpp:98
+#: src/ChatWnd.cpp
 msgid "Chat"
 msgstr "交談"
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:180
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close tab"
 msgstr "關閉分頁"
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:181
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close all tabs"
 msgstr "關閉所有分頁"
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:182
+#: src/ChatWnd.cpp src/MuleNotebook.cpp
 msgid "Close other tabs"
 msgstr "關閉其它分頁"
 
-#: src/ChatWnd.cpp:106 src/GenericClientListCtrl.cpp:655
+#: src/ChatWnd.cpp src/GenericClientListCtrl.cpp
 msgid "Add to Friends"
 msgstr "加入好友"
 
-#: src/ClientCreditsList.cpp:154
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid "Creditfile loaded, %u client is known"
 msgid_plural "Creditfile loaded, %u clients are known"
 msgstr[0] "積分檔已載入，有 %u 個已知客戶端"
 
-#: src/ClientCreditsList.cpp:160
+#: src/ClientCreditsList.cpp
 #, c-format
 msgid " - Credits expired for %u client!"
 msgid_plural " - Credits expired for %u clients!"
 msgstr[0] " - %u 個客戶端的積分已過期！"
 
-#: src/ClientCreditsList.cpp:301
+#: src/ClientCreditsList.cpp
 msgid "No 'cryptkey.dat' file found, creating."
 msgstr "找不到 crytkey.dat，正在建立新的。"
 
-#: src/ClientDetailDialog.cpp:42
+#: src/ClientDetailDialog.cpp
 msgid "Client Details"
 msgstr "客戶端詳細資訊"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:246
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp:90 src/ServerWnd.cpp:224
-#: src/utils/wxCas/src/onlinesig.cpp:244
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
-#: src/ClientDetailDialog.cpp:111
+#: src/ClientDetailDialog.cpp
 msgid "Enabled"
 msgstr "已啟用"
 
-#: src/ClientDetailDialog.cpp:114
+#: src/ClientDetailDialog.cpp
 msgid "Supported"
 msgstr "已支援"
 
-#: src/ClientDetailDialog.cpp:117 src/ClientRef.cpp:178
+#: src/ClientDetailDialog.cpp src/ClientRef.cpp
 msgid "Not supported"
 msgstr "不支援"
 
-#: src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp
 msgid "Disabled"
 msgstr "已停用"
 
-#: src/ClientDetailDialog.cpp:130 src/MuleTrayIcon.cpp:396
-#: src/ServerWnd.cpp:206 src/ServerWnd.cpp:261 src/TextClient.cpp:914
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "已連線"
 
-#: src/ClientDetailDialog.cpp:132 src/MuleTrayIcon.cpp:386
-#: src/MuleTrayIcon.cpp:398 src/ServerWnd.cpp:261
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 msgid "Disconnected"
 msgstr "已中斷連線"
 
-#: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1048 src/GenericClientListCtrl.cpp:980
-#: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:811
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f kB/s"
 msgstr "%.1f KB/s"
 
-#: src/ClientRef.cpp:182
+#: src/ClientRef.cpp
 msgid "Not complete"
 msgstr "未完成"
 
-#: src/ClientRef.cpp:184
+#: src/ClientRef.cpp
 msgid "Bad Guy"
 msgstr "壞蛋"
 
-#: src/ClientRef.cpp:186
+#: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "驗證通過"
 
-#: src/ClientRef.cpp:189
+#: src/ClientRef.cpp
 msgid "Not Available"
 msgstr "N/A"
 
-#: src/ClientTCPSocket.cpp:821
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr "使用者 %s (%u) 要求您的分享檔案清單 -> 已接受"
 
-#: src/ClientTCPSocket.cpp:842
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr "使用者 %s (%u) 要求您的分享檔案清單 -> 已拒絕"
 
-#: src/ClientTCPSocket.cpp:878
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr "使用者 %s (%u) 要求您的分享目錄清單 -> 接受"
 
-#: src/ClientTCPSocket.cpp:884
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr "使用者 %s (%u) 要求您的分享目錄清單 -> 拒絕"
 
-#: src/ClientTCPSocket.cpp:911
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr "使用者 %s (%u) 要求目錄 %s 的分享檔案清單 -> 已接受"
 
-#: src/ClientTCPSocket.cpp:926
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr "使用者 %s (%u) 要求目錄 %s 的分享檔案清單 -> 已拒絕"
 
-#: src/ClientTCPSocket.cpp:950
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr "使用者 %s (%u) 分享的目錄 %s"
 
-#: src/ClientTCPSocket.cpp:975
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr "使用者 %s (%u) 傳送了未要求的分享目錄。"
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr "使用者 %s (%u) 傳送了目錄 %s 內的分享檔案清單"
 
-#: src/ClientTCPSocket.cpp:996
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr "使用者 %s (%u) 已傳送分享檔案清單"
 
-#: src/ClientTCPSocket.cpp:1001
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr "使用者 %s (%u) 傳送了未經要求的分享檔案清單"
 
-#: src/ClientTCPSocket.cpp:1013
+#: src/ClientTCPSocket.cpp
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr "使用者 %s (%u) 拒絕傳送分享檔案/目錄清單"
 
-#: src/CommentDialog.cpp:53 src/CommentDialogLst.cpp:65
+#: src/CommentDialog.cpp src/CommentDialogLst.cpp
 msgid "File Comments"
 msgstr "檔案註解"
 
-#: src/CommentDialogLst.cpp:77 src/FriendListCtrl.cpp:65
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/CommentDialogLst.cpp:78 src/DownloadListCtrl.cpp:174
-#: src/FileDetailListCtrl.cpp:43 src/SearchListCtrl.cpp:97
-#: src/SharedFilesCtrl.cpp:109
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "檔案名稱"
 
-#: src/CommentDialogLst.cpp:79 src/SearchListCtrl.cpp:103
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "評價"
 
-#: src/CommentDialogLst.cpp:80
+#: src/CommentDialogLst.cpp
 msgid "Comment"
 msgstr "註解"
 
-#: src/CommentDialogLst.cpp:133
+#: src/CommentDialogLst.cpp
 msgid "Could not start a Kad search"
 msgstr ""
 
-#: src/CommentDialogLst.cpp:134 src/SearchList.cpp:317
+#: src/CommentDialogLst.cpp src/SearchList.cpp
 msgid "Kad search can't be done if Kad is not running"
 msgstr "Kad 網路尚未連線，無法使用 Kad 搜尋"
 
-#: src/CommentDialogLst.cpp:143 src/CommentDialogLst.cpp:176
+#: src/CommentDialogLst.cpp
 #, fuzzy
 msgid "Searching Kad for comments..."
 msgstr "搜尋 LowID 連線好友"
 
-#: src/CommentDialogLst.cpp:201 src/muuli_wdr.cpp:806
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "No comments"
 msgstr "沒有註解"
 
-#: src/CommentDialogLst.cpp:203
+#: src/CommentDialogLst.cpp
 #, c-format
 msgid "%u comment"
 msgid_plural "%u comments"
 msgstr[0] "%u 個註解"
 
-#: src/CorruptionBlackBox.cpp:237
+#: src/CorruptionBlackBox.cpp
 #, c-format
 msgid "Banned client %s for sending %s corrupt data of %s total for the file '%s'"
 msgstr "已封鎖客戶端 %s：因傳送 %s (總計 %s ) 損壞資料 (檔案 %s )"
 
-#: src/CountryFlags.cpp:60
+#: src/CountryFlags.cpp
 #, c-format
 msgid "Failed to load country data for '%s'."
 msgstr "無法自 %s 下載國家資料。"
 
-#: src/DataToText.cpp:36
+#: src/DataToText.cpp
 msgid "Auto [Lo]"
 msgstr "自動 [低]"
 
-#: src/DataToText.cpp:38
+#: src/DataToText.cpp
 msgid "Auto [No]"
 msgstr "自動 [普]"
 
-#: src/DataToText.cpp:40
+#: src/DataToText.cpp
 msgid "Auto [Hi]"
 msgstr "自動 [高]"
 
-#: src/DataToText.cpp:45 src/SharedFilesCtrl.cpp:144
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:2317
-#: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
-#: src/SharedFilesCtrl.cpp:145
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:741 src/muuli_wdr.cpp:2318
-#: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
-#: src/SharedFilesCtrl.cpp:146
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:742 src/muuli_wdr.cpp:2319
-#: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
-#: src/SharedFilesCtrl.cpp:147
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
-#: src/DataToText.cpp:53 src/SharedFilesCtrl.cpp:148
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Very High"
 msgstr "極高"
 
-#: src/DataToText.cpp:55 src/SharedFilesCtrl.cpp:149
+#: src/DataToText.cpp src/SharedFilesCtrl.cpp
 msgid "Release"
 msgstr "釋放"
 
-#: src/DataToText.cpp:70
+#: src/DataToText.cpp
 msgid "Asking"
 msgstr "正在要求"
 
-#: src/DataToText.cpp:72
+#: src/DataToText.cpp
 msgid "Connecting via server"
 msgstr "正在經伺服器連線"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1097
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp
 msgid "Queue Full"
 msgstr "等候區已滿"
 
-#: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:627
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "等候中"
 
-#: src/DataToText.cpp:76 src/libs/ec/cpp/ECSpecialTags.cpp:52
-#: src/OtherFunctions.cpp:697 src/PartFile.cpp:4383 src/TransferWnd.cpp:351
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下載"
 
-#: src/DataToText.cpp:78
+#: src/DataToText.cpp
 msgid "Receiving hashset"
 msgstr "正在接收 hash 值組"
 
-#: src/DataToText.cpp:80
+#: src/DataToText.cpp
 msgid "No needed parts"
 msgstr "沒有需要的部份"
 
-#: src/DataToText.cpp:82
+#: src/DataToText.cpp
 msgid "Cannot connect LowID to LowID"
 msgstr "無法由 LowID 連線至 LowID"
 
-#: src/DataToText.cpp:84
+#: src/DataToText.cpp
 msgid "Too many connections"
 msgstr "連線數過多"
 
-#: src/DataToText.cpp:88
+#: src/DataToText.cpp
 msgid "Connecting via Kad"
 msgstr "正在用 Kad 連線"
 
-#: src/DataToText.cpp:90
+#: src/DataToText.cpp
 msgid "Too many Kad connections"
 msgstr "Kad 連線數過多"
 
-#: src/DataToText.cpp:92
+#: src/DataToText.cpp
 msgid "Banned"
 msgstr "已封鎖"
 
-#: src/DataToText.cpp:94
+#: src/DataToText.cpp
 msgid "Connection Error"
 msgstr "連線錯誤"
 
-#: src/DataToText.cpp:96
+#: src/DataToText.cpp
 msgid "Remote Queue Full"
 msgstr "遠端等候區已滿"
 
-#: src/DataToText.cpp:125
+#: src/DataToText.cpp
 msgid "Old MLDonkey"
 msgstr "舊 MLDonkey"
 
-#: src/DataToText.cpp:128
+#: src/DataToText.cpp
 msgid "New MLDonkey"
 msgstr "新 MLDonkey"
 
-#: src/DataToText.cpp:138
+#: src/DataToText.cpp
 msgid "eMule Compatible"
 msgstr "eMule 相容版"
 
-#: src/DataToText.cpp:148
+#: src/DataToText.cpp
 msgid "Local Server"
 msgstr "本地伺服器"
 
-#: src/DataToText.cpp:150
+#: src/DataToText.cpp
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3228
-#: src/SearchDlg.cpp:119 src/TextClient.cpp:911
+#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
-#: src/DataToText.cpp:154
+#: src/DataToText.cpp
 msgid "Source Exchange"
 msgstr "來源交換"
 
-#: src/DataToText.cpp:156
+#: src/DataToText.cpp
 msgid "Passive"
 msgstr "被動"
 
-#: src/DataToText.cpp:158
+#: src/DataToText.cpp
 msgid "Link"
 msgstr "連結"
 
-#: src/DataToText.cpp:160
+#: src/DataToText.cpp
 msgid "Source Seeds"
 msgstr "來源種子"
 
-#: src/DataToText.cpp:162
+#: src/DataToText.cpp
 msgid "Search Result"
 msgstr "搜尋結果"
 
-#: src/DataToText.cpp:173 src/DownloadListCtrl.cpp:177
-#: src/OtherFunctions.cpp:693 src/TransferWnd.cpp:349
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
-#: src/DataToText.cpp:175
+#: src/DataToText.cpp
 msgid "In progress"
 msgstr "正在處理"
 
-#: src/DataToText.cpp:177
+#: src/DataToText.cpp
 #, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "錯誤：磁碟空間不足"
 
-#: src/DataToText.cpp:179
+#: src/DataToText.cpp
 msgid "ERROR: Partmet not found"
 msgstr "錯誤：找不到暫存檔資訊檔案"
 
-#: src/DataToText.cpp:181
+#: src/DataToText.cpp
 msgid "ERROR: IO error!"
 msgstr "錯誤：IO 錯誤！"
 
-#: src/DataToText.cpp:183
+#: src/DataToText.cpp
 msgid "ERROR: Failed!"
 msgstr "錯誤：失敗！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
+#: src/DataToText.cpp src/SearchListCtrl.cpp
 msgid "Queued"
 msgstr "待處理"
 
-#: src/DataToText.cpp:187
+#: src/DataToText.cpp
 msgid "Already downloading"
 msgstr "已在下載清單中"
 
-#: src/DataToText.cpp:189
+#: src/DataToText.cpp
 msgid "Unknown or bad tempfile format."
 msgstr "不明或錯誤的暫存檔格式。"
 
-#: src/DownloadListCtrl.cpp:173
+#: src/DownloadListCtrl.cpp
 msgid "Part"
 msgstr "部份"
 
-#: src/DownloadListCtrl.cpp:175 src/PartFileConvertDlg.cpp:98
-#: src/SearchListCtrl.cpp:98 src/SharedFilesCtrl.cpp:110
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:176 src/muuli_wdr.cpp:3295
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Transferred"
 msgstr "已傳輸"
 
-#: src/DownloadListCtrl.cpp:178 src/muuli_wdr.cpp:629
-#: src/SharedFilesCtrl.cpp:122 src/SourceListCtrl.cpp:30
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
-#: src/DownloadListCtrl.cpp:179
+#: src/DownloadListCtrl.cpp
 msgid "Progress"
 msgstr "進度"
 
-#: src/DownloadListCtrl.cpp:180 src/FileDetailListCtrl.cpp:44
-#: src/PartFile.cpp:4429 src/SearchListCtrl.cpp:99
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "來源"
 
-#: src/DownloadListCtrl.cpp:181 src/DownloadListCtrl.cpp:745
-#: src/muuli_wdr.cpp:628 src/ServerListCtrl.cpp:97 src/ServerListCtrl.cpp:460
-#: src/SharedFilesCtrl.cpp:112 src/SharedFilesCtrl.cpp:152
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先等級"
 
-#: src/DownloadListCtrl.cpp:182 src/PartFile.cpp:4432
-#: src/SearchListCtrl.cpp:105
+#: src/DownloadListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Status"
 msgstr "狀態"
 
-#: src/DownloadListCtrl.cpp:183
+#: src/DownloadListCtrl.cpp
 msgid "Time Remaining"
 msgstr "剩餘時間"
 
-#: src/DownloadListCtrl.cpp:184
+#: src/DownloadListCtrl.cpp
 msgid "Last Seen Complete"
 msgstr "最後看到完整檔案"
 
-#: src/DownloadListCtrl.cpp:185
+#: src/DownloadListCtrl.cpp
 msgid "Last Reception"
 msgstr "最後一次下載"
 
-#: src/DownloadListCtrl.cpp:495
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected file?"
 msgstr "您確定要刪除這個檔案嗎？"
 
-#: src/DownloadListCtrl.cpp:497
+#: src/DownloadListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected files?"
 msgstr "您確定要刪除這些檔案嗎？"
 
-#: src/DownloadListCtrl.cpp:499 src/DownloadListCtrl.cpp:746
-#: src/FriendListCtrl.cpp:180 src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2266
-#: src/muuli_wdr.cpp:2351 src/muuli_wdr.cpp:3111 src/muuli_wdr.cpp:5964
-#: src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
-#: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:378
-#: src/utils/wxCas/src/wxcasprefs.cpp:235
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
-#: src/DownloadListCtrl.cpp:640 src/SharedFilesCtrl.cpp:264
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid ""
 "Feedback from: %s (%s)\n"
@@ -1569,109 +1527,106 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:743 src/muuli_wdr.cpp:2320
-#: src/SharedFilesCtrl.cpp:150
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp:747 src/TransferWnd.cpp:379
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
 msgstr "停止(&S)"
 
-#: src/DownloadListCtrl.cpp:748 src/TransferWnd.cpp:380
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Pause"
 msgstr "暫停(&P)"
 
-#: src/DownloadListCtrl.cpp:749 src/TransferWnd.cpp:381
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Resume"
 msgstr "續傳(&R)"
 
-#: src/DownloadListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp
 msgid "C&lear completed"
 msgstr "清除已傳完成的(&l)"
 
-#: src/DownloadListCtrl.cpp:755
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file now"
 msgstr "立即轉移所有 A4AF 到這個檔案"
 
-#: src/DownloadListCtrl.cpp:756
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to this file (Auto)"
 msgstr "自動轉移所有 A4AF 到這個檔案"
 
-#: src/DownloadListCtrl.cpp:760
+#: src/DownloadListCtrl.cpp
 msgid "Swap every A4AF to any other file now"
 msgstr "立即轉移所有 A4AF 到其它檔案"
 
-#: src/DownloadListCtrl.cpp:762
+#: src/DownloadListCtrl.cpp
 msgid "Extended Options"
 msgstr "擴充選項"
 
-#: src/DownloadListCtrl.cpp:767 src/DownloadListCtrl.cpp:819
-#: src/muuli_wdr.cpp:1804
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp
 msgid "Preview"
 msgstr "預覽"
 
-#: src/DownloadListCtrl.cpp:768 src/SharedFilesCtrl.cpp:155
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Show file &details"
 msgstr "顯示檔案詳細資訊(&D)"
 
-#: src/DownloadListCtrl.cpp:769 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:750
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Show all comments"
 msgstr "顯示所有註解"
 
-#: src/DownloadListCtrl.cpp:773
+#: src/DownloadListCtrl.cpp
 msgid "Copy magnet URI to clipboard"
 msgstr "複製 magnet 網址到剪貼簿"
 
-#: src/DownloadListCtrl.cpp:774 src/SharedFilesCtrl.cpp:177
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy eD2k &link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿(&L)"
 
-#: src/DownloadListCtrl.cpp:775 src/SharedFilesCtrl.cpp:186
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "複製傳輸狀況到剪貼簿"
 
-#: src/DownloadListCtrl.cpp:784
+#: src/DownloadListCtrl.cpp
 msgid "unassign"
 msgstr "取消"
 
-#: src/DownloadListCtrl.cpp:790
+#: src/DownloadListCtrl.cpp
 msgid "Assign to category"
 msgstr "分類"
 
-#: src/DownloadListCtrl.cpp:821
+#: src/DownloadListCtrl.cpp
 msgid "&Open the file"
 msgstr "開啟檔案(&O)"
 
-#: src/DownloadListCtrl.cpp:891 src/SharedFilesCtrl.cpp:919
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"
 msgstr "請輸入新檔案名稱："
 
-#: src/DownloadListCtrl.cpp:892 src/SharedFilesCtrl.cpp:920
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File rename"
 msgstr "更改檔名"
 
-#: src/DownloadListCtrl.cpp:1046 src/GenericClientListCtrl.cpp:978
-#: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:808
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
 
-#: src/DownloadListCtrl.cpp:1182 src/DownloadListCtrl.cpp:1193
+#: src/DownloadListCtrl.cpp
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1340
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下載 (%i)"
 
-#: src/DownloadListCtrl.cpp:1505
+#: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1511
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1680,346 +1635,345 @@ msgstr ""
 "請在偏好設定中設定影片播放器 (預設為 %s)，\n"
 "以避免這個警告訊息繼續出現。"
 
-#: src/DownloadListCtrl.cpp:1514
+#: src/DownloadListCtrl.cpp
 msgid "File preview"
 msgstr "檔案預覽"
 
-#: src/DownloadListCtrl.cpp:1573
+#: src/DownloadListCtrl.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "錯誤：無法執行媒體播放器！指令：「 %s 」"
 
-#: src/DownloadQueue.cpp:98
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Saving PartFile %u of %u"
 msgstr "正在儲存暫存檔 (%u / %u)"
 
-#: src/DownloadQueue.cpp:101
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Saved."
 msgstr "已儲存所有暫存檔。"
 
-#: src/DownloadQueue.cpp:107
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading temp files from %s."
 msgstr "正在從 %s 載入暫存檔。"
 
-#: src/DownloadQueue.cpp:126
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Loading PartFile %u of %u"
 msgstr "正在載入暫存檔 (%u / %u)"
 
-#: src/DownloadQueue.cpp:150
+#: src/DownloadQueue.cpp
 msgid "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/discussions for .part.met recovery solutions."
 msgstr "錯誤：無法載入備份檔案，請到 https://github.com/amule-org/amule/discussions 搜尋復原 .part.met 的方法。"
 
-#: src/DownloadQueue.cpp:161
+#: src/DownloadQueue.cpp
 msgid "All PartFiles Loaded."
 msgstr "已載入所有暫存檔。"
 
-#: src/DownloadQueue.cpp:164
+#: src/DownloadQueue.cpp
 msgid "No part files found"
 msgstr "找不到暫存檔"
 
-#: src/DownloadQueue.cpp:166
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Found %u part file"
 msgid_plural "Found %u part files"
 msgstr[0] "找到 %u 個暫存檔"
 
-#: src/DownloadQueue.cpp:238 src/DownloadQueue.cpp:1535
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr "設定存放暫存檔的目錄，檔案系統不支援大容量檔案。"
 
-#: src/DownloadQueue.cpp:242 src/DownloadQueue.cpp:1540
+#: src/DownloadQueue.cpp
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr "設定存放新進檔案的目錄，檔案系統不支援大容量檔案。"
 
-#: src/DownloadQueue.cpp:381
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Downloading %s"
 msgstr "下載 %s"
 
-#: src/DownloadQueue.cpp:388
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file '%s'"
 msgstr "您已經在下載檔案 %s 了"
 
-#: src/DownloadQueue.cpp:406
+#: src/DownloadQueue.cpp
 #, fuzzy, c-format
 msgid "You already have the file '%s' (requested as '%s')"
 msgstr "您已經有檔案 %s"
 
-#: src/DownloadQueue.cpp:409
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You already have the file '%s'"
 msgstr "您已經有檔案 %s"
 
-#: src/DownloadQueue.cpp:416
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "您已經在下載檔案 %s 了"
 
-#: src/DownloadQueue.cpp:1455
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr "無法將 magnet 連結轉換為 eD2k: %s"
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr "有不明協定的連結：%s"
 
-#: src/DownloadQueue.cpp:1477
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 
-#: src/DownloadQueue.cpp:1501
+#: src/DownloadQueue.cpp
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr "無效的 eD2k 連結！錯誤：%s "
 
-#: src/ExternalConn.cpp:380
+#: src/ExternalConn.cpp
 msgid "Client sent packet after authentication failed."
 msgstr "客戶端在驗證失敗後傳送封包。"
 
-#: src/ExternalConn.cpp:397
+#: src/ExternalConn.cpp
 msgid "External connection closed."
 msgstr "已關閉外部連線。"
 
-#: src/ExternalConn.cpp:474
+#: src/ExternalConn.cpp
 msgid "External connections disabled due to empty password!"
 msgstr "未設定密碼，外部連線已被停用！"
 
-#: src/ExternalConn.cpp:495
+#: src/ExternalConn.cpp
 msgid "External connections disabled in config file"
 msgstr "已在設定檔中停用外部連線"
 
-#: src/ExternalConn.cpp:576
+#: src/ExternalConn.cpp
 msgid "New external connection accepted"
 msgstr "已接受新的外部連線"
 
-#: src/ExternalConn.cpp:579
+#: src/ExternalConn.cpp
 msgid "ERROR: couldn't accept a new external connection"
 msgstr "錯誤：無法接受新的外部連線"
 
-#: src/ExternalConn.cpp:596
+#: src/ExternalConn.cpp
 msgid "External connection refused due to empty password in preferences!"
 msgstr "由於偏好設定中未設定密碼，外部連線已被拒絕！"
 
-#: src/ExternalConn.cpp:608
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr "連線中客戶端：%s %s"
 
-#: src/ExternalConn.cpp:610
+#: src/ExternalConn.cpp
 msgid "Unknown version"
 msgstr "不明版本"
 
-#: src/ExternalConn.cpp:623
+#: src/ExternalConn.cpp
 msgid "Incorrect EC version ID, there might be binary incompatibility. Use core and remote from same snapshot."
 msgstr "不正確的外部連線版本 ID，這將導致執行檔不相容，請使用相同版本的主程式和遠端程式。"
 
-#: src/ExternalConn.cpp:631
+#: src/ExternalConn.cpp
 msgid "You cannot connect to a release version from an arbitrary development snapshot! *sigh* possible crash prevented"
 msgstr "您不能用開發中版本 (SVN) 連線到正式發行版，這是為了避免系統遭受不確定的損害"
 
-#: src/ExternalConn.cpp:714
+#: src/ExternalConn.cpp
 msgid "Invalid protocol version."
 msgstr "協定版本無效。"
 
-#: src/ExternalConn.cpp:720
+#: src/ExternalConn.cpp
 msgid "Missing protocol version tag."
 msgstr "缺少協定版本標記。"
 
-#: src/ExternalConn.cpp:728
+#: src/ExternalConn.cpp
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr "驗證失敗：指定無效的 hash 值做為外部連線密碼。"
 
-#: src/ExternalConn.cpp:776
+#: src/ExternalConn.cpp
 msgid "Authentication failed: wrong password."
 msgstr "驗證失敗：密碼錯誤。"
 
-#: src/ExternalConn.cpp:778
+#: src/ExternalConn.cpp
 msgid "Authentication failed: missing password."
 msgstr "驗證失敗：沒有密碼。"
 
-#: src/ExternalConn.cpp:789
+#: src/ExternalConn.cpp
 msgid "Invalid request, please authenticate first."
 msgstr "無效的要求，請先通過登入驗證。"
 
-#: src/ExternalConn.cpp:794
+#: src/ExternalConn.cpp
 msgid "Access granted."
 msgstr "登入成功。"
 
-#: src/ExternalConn.cpp:802
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr "傳送錯誤訊息「%s」給客戶端。"
 
-#: src/ExternalConn.cpp:807
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr "%s 試圖非法登入，已關閉連線。"
 
-#: src/ExternalConn.cpp:1420
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr "無法執行對遠端暫存檔的指令：找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1424
+#: src/ExternalConn.cpp
 #, c-format
 msgid "FileHash not found: %s"
 msgstr "找不到檔案 hash 值：%s "
 
-#: src/ExternalConn.cpp:1471 src/ExternalConn.cpp:1559
-#: src/ExternalConn.cpp:1680
+#: src/ExternalConn.cpp
 msgid "OOPS! OpCode processing error!"
 msgstr "糟糕！指令碼處理錯誤！"
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp
 msgid "Server not added"
 msgstr "伺服器未被加入"
 
-#: src/ExternalConn.cpp:1521
+#: src/ExternalConn.cpp
 #, c-format
 msgid "server not found: %s"
 msgstr "找不到伺服器：%s "
 
-#: src/ExternalConn.cpp:1538
+#: src/ExternalConn.cpp
 msgid "need to define server to be removed"
 msgstr "必須指定要刪除的伺服器"
 
-#: src/ExternalConn.cpp:1553
+#: src/ExternalConn.cpp
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:1658
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Friend not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1668
+#: src/ExternalConn.cpp
 #, fuzzy
 msgid "Client not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:1674
+#: src/ExternalConn.cpp
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1992
+#: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "從遠端界面使用網頁搜尋功能沒有意義。"
 
-#: src/ExternalConn.cpp:2027
+#: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"
 msgstr "搜尋中，請稍候！"
 
-#: src/ExternalConn.cpp:2266
+#: src/ExternalConn.cpp
 msgid "No points for graph."
 msgstr "此圖沒有參考點。"
 
-#: src/ExternalConn.cpp:2276
+#: src/ExternalConn.cpp
 msgid "Your client is not configured for this detail level."
 msgstr "您的客戶端並沒有設定這個細部等級。"
 
-#: src/ExternalConn.cpp:2303
+#: src/ExternalConn.cpp
 msgid "External Connection: shutdown requested"
 msgstr "外部連線：必須關閉"
 
-#: src/ExternalConn.cpp:2315
+#: src/ExternalConn.cpp
 msgid "Already shutting down."
 msgstr "已經在關閉中。"
 
-#: src/ExternalConn.cpp:2333
+#: src/ExternalConn.cpp
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr "外部連線：正在加入連結 %s 。"
 
-#: src/ExternalConn.cpp:2351
+#: src/ExternalConn.cpp
 #, fuzzy, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr "無效連結或已在清單中。"
 
-#: src/ExternalConn.cpp:2374
+#: src/ExternalConn.cpp
 msgid "Version check throttled; try again shortly."
 msgstr ""
 
-#: src/ExternalConn.cpp:2379
+#: src/ExternalConn.cpp
 msgid "Version check is not available on this daemon."
 msgstr ""
 
-#: src/ExternalConn.cpp:2509
+#: src/ExternalConn.cpp
 msgid "File not found."
 msgstr "找不到檔案。"
 
-#: src/ExternalConn.cpp:2514
+#: src/ExternalConn.cpp
 msgid "Invalid file name."
 msgstr "無效的檔名。"
 
-#: src/ExternalConn.cpp:2522
+#: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "無法重新命名。"
 
-#: src/ExternalConn.cpp:2839
+#: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:3004 src/ExternalConn.cpp:3032
+#: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."
 msgstr "Kad 網路已在偏好設定中被停用了。"
 
-#: src/ExternalConn.cpp:3045
+#: src/ExternalConn.cpp
 msgid "Already connected to eD2k."
 msgstr "eD2k 網路已連線。"
 
-#: src/ExternalConn.cpp:3048
+#: src/ExternalConn.cpp
 msgid "Connecting to eD2k..."
 msgstr "eD2k 連線中..."
 
-#: src/ExternalConn.cpp:3057
+#: src/ExternalConn.cpp
 msgid "Already connected to Kad."
 msgstr "Kad 網路已連線。"
 
-#: src/ExternalConn.cpp:3060
+#: src/ExternalConn.cpp
 msgid "Connecting to Kad..."
 msgstr "Kad 連線中..."
 
-#: src/ExternalConn.cpp:3067
+#: src/ExternalConn.cpp
 msgid "All networks are disabled."
 msgstr "所有網路都被停用了。"
 
-#: src/ExternalConn.cpp:3076
+#: src/ExternalConn.cpp
 msgid "Disconnected from eD2k."
 msgstr "已中斷 eD2k 網路連線。"
 
-#: src/ExternalConn.cpp:3081
+#: src/ExternalConn.cpp
 msgid "Disconnected from Kad."
 msgstr "已中斷 Kad 網路連線。"
 
-#: src/ExternalConn.cpp:3090
+#: src/ExternalConn.cpp
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr "外部連線：接收到無效的指令碼 - %#x"
 
-#: src/ExternalConn.cpp:3095
+#: src/ExternalConn.cpp
 msgid "Invalid opcode (wrong protocol version?)"
 msgstr "無效的指令碼（協定版本錯誤？）"
 
-#: src/ExternalConnector.cpp:130
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr "不明的副檔名 %s 傳給指令「 %s 」。\n"
 
-#: src/ExternalConnector.cpp:133
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Unknown command '%s'.\n"
 msgstr "不明的指令「 %s 」。\n"
 
-#: src/ExternalConnector.cpp:145
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command cannot have an argument.\n"
@@ -2027,7 +1981,7 @@ msgstr ""
 "\n"
 "這個指令不能有引數。\n"
 
-#: src/ExternalConnector.cpp:147
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command must have an argument.\n"
@@ -2035,7 +1989,7 @@ msgstr ""
 "\n"
 "這個指令必須要有引數。\n"
 
-#: src/ExternalConnector.cpp:151
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
@@ -2043,7 +1997,7 @@ msgstr ""
 "\n"
 "這個指令不完整，您必須使用以下其中一個副檔名。\n"
 
-#: src/ExternalConnector.cpp:157
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Available extensions:\n"
@@ -2051,11 +2005,11 @@ msgstr ""
 "\n"
 "可用的副檔名：\n"
 
-#: src/ExternalConnector.cpp:159
+#: src/ExternalConnector.cpp
 msgid "Available commands:\n"
 msgstr "可用的指令：\n"
 
-#: src/ExternalConnector.cpp:178
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2066,17 +2020,17 @@ msgstr ""
 "所有指令都不區分大小寫。\n"
 "輸入「 %s <指令> 」取得 <指令> 的詳細資訊。\n"
 
-#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
+#: src/ExternalConnector.cpp
 msgid "Exits from the application."
 msgstr "離開程式。"
 
-#: src/ExternalConnector.cpp:294
+#: src/ExternalConnector.cpp
 msgid "Show help."
 msgstr "顯示幫助。"
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:297
+#: src/ExternalConnector.cpp
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
@@ -2084,7 +2038,7 @@ msgstr ""
 "輸入「 help <指令> 」可顯示該指令的說明。\n"
 "輸入「 help 」可顯示所有指令一覽。\n"
 
-#: src/ExternalConnector.cpp:325
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2095,46 +2049,46 @@ msgstr ""
 "使用「 %s 」列出所有指令\n"
 "\n"
 
-#: src/ExternalConnector.cpp:358
+#: src/ExternalConnector.cpp
 msgid "Syntax error!"
 msgstr "語法錯誤！"
 
-#: src/ExternalConnector.cpp:361
+#: src/ExternalConnector.cpp
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr "處理指令時發生意外錯誤！請提出錯誤報告\n"
 
-#: src/ExternalConnector.cpp:364
+#: src/ExternalConnector.cpp
 msgid "This command should not have any parameters."
 msgstr "這個指令不能有參數。"
 
-#: src/ExternalConnector.cpp:367
+#: src/ExternalConnector.cpp
 msgid "This command must have a parameter."
 msgstr "這個指令必須要有參數。"
 
-#: src/ExternalConnector.cpp:370
+#: src/ExternalConnector.cpp
 msgid "Invalid argument."
 msgstr "無效的引數。"
 
-#: src/ExternalConnector.cpp:373
+#: src/ExternalConnector.cpp
 msgid "This is an incomplete command."
 msgstr "不完整的指令。"
 
-#: src/ExternalConnector.cpp:382
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr "輸入「 %s 」顯示更多協助資訊。\n"
 
-#: src/ExternalConnector.cpp:436
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr "這是 %s %s %s\n"
 
-#: src/ExternalConnector.cpp:438
+#: src/ExternalConnector.cpp
 #, c-format
 msgid "This is %s %s\n"
 msgstr "這是 %s %s\n"
 
-#: src/ExternalConnector.cpp:453
+#: src/ExternalConnector.cpp
 msgid ""
 "\n"
 "Creating client...\n"
@@ -2142,7 +2096,7 @@ msgstr ""
 "\n"
 "正在建立客戶端...\n"
 
-#: src/ExternalConnector.cpp:486
+#: src/ExternalConnector.cpp
 #, c-format
 msgid ""
 "\n"
@@ -2151,7 +2105,7 @@ msgstr ""
 "\n"
 "OK，正在離開 %s...\n"
 
-#: src/ExternalConnector.cpp:492
+#: src/ExternalConnector.cpp
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2165,331 +2119,326 @@ msgstr ""
 "\n"
 "正在離開...\n"
 
-#: src/ExternalConnector.cpp:501
+#: src/ExternalConnector.cpp
 msgid "Show this help text."
 msgstr "顯示協助資訊。"
 
-#: src/ExternalConnector.cpp:504
+#: src/ExternalConnector.cpp
 msgid "Host where aMule is running. (default: 127.0.0.1)"
 msgstr "執行 aMule 的主機。(預設：127.0.0.1)"
 
-#: src/ExternalConnector.cpp:509
+#: src/ExternalConnector.cpp
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr "aMule 的外部連線埠。 (預設：4712)"
 
-#: src/ExternalConnector.cpp:514
+#: src/ExternalConnector.cpp
 msgid "External Connection password."
 msgstr "外部連線密碼。"
 
-#: src/ExternalConnector.cpp:519
+#: src/ExternalConnector.cpp
 msgid "Read configuration from file."
 msgstr "從檔案讀取設定。"
 
-#: src/ExternalConnector.cpp:522
+#: src/ExternalConnector.cpp
 msgid "Do not print any output to stdout."
 msgstr "不顯示任何輸出訊息。"
 
-#: src/ExternalConnector.cpp:524
+#: src/ExternalConnector.cpp
 msgid "Be verbose - show also debug messages."
 msgstr "詳細顯示除錯資訊。"
 
-#: src/ExternalConnector.cpp:527
+#: src/ExternalConnector.cpp
 msgid "Sets program locale (language)."
 msgstr "設定程式的地區設定 (語言)。"
 
-#: src/ExternalConnector.cpp:532
+#: src/ExternalConnector.cpp
 msgid "Write command line options to config file."
 msgstr "把命令列選項寫入設定檔。"
 
-#: src/ExternalConnector.cpp:536
+#: src/ExternalConnector.cpp
 msgid "Creates config file based on aMule's config file."
 msgstr "使用 aMule 的設定檔建立新設定檔。"
 
-#: src/ExternalConnector.cpp:539
+#: src/ExternalConnector.cpp
 msgid "Print program version."
 msgstr "列出程式版本。"
 
-#: src/ExternalConnector.cpp:542
+#: src/ExternalConnector.cpp
 msgid "Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:549
+#: src/ExternalConnector.cpp
 msgid "Append a copy of all console output to this log file (default: <config-dir>/amuleapi.log)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:555
+#: src/ExternalConnector.cpp
 msgid "Do not write a log file; print to the console only."
 msgstr ""
 
-#: src/FileDetailDialog.cpp:78
+#: src/FileDetailDialog.cpp
 msgid "File Details"
 msgstr "檔案詳細資訊"
 
-#: src/FileDetailDialog.cpp:188
+#: src/FileDetailDialog.cpp
 #, c-format
 msgid "%.1f%% done"
 msgstr "完成 %.1f%%"
 
-#: src/FileDetailDialog.cpp:190 src/FileDetailDialog.cpp:230
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
 
-#: src/FirstRunWizard.cpp:91
+#: src/FirstRunWizard.cpp
 msgid "Mobile / 4G-5G (20 / 5 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:92
+#: src/FirstRunWizard.cpp
 msgid "ADSL (24 / 1 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:93
+#: src/FirstRunWizard.cpp
 msgid "VDSL (50 / 10 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:94
+#: src/FirstRunWizard.cpp
 msgid "Cable (200 / 20 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:95
+#: src/FirstRunWizard.cpp
 msgid "Fibre 300 (300 / 100 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:96
+#: src/FirstRunWizard.cpp
 msgid "Fibre Gigabit (1000 / 1000 Mbit)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:224
+#: src/FirstRunWizard.cpp
 msgid "aMule first-run setup"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:252
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Welcome to aMule!"
 msgstr "歡迎！"
 
-#: src/FirstRunWizard.cpp:255
+#: src/FirstRunWizard.cpp
 msgid ""
 "This short setup will get you connected. You can change\n"
 "any of these settings later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:261
+#: src/FirstRunWizard.cpp
 msgid "Choose a nickname other peers will see:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:277
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection & bandwidth"
 msgstr "正在與好友連線"
 
-#: src/FirstRunWizard.cpp:280
+#: src/FirstRunWizard.cpp
 msgid ""
 "Pick the option that best matches your Internet connection,\n"
 "or set the upload and download limits directly below."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:286
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Connection speed:"
 msgstr "連線狀態："
 
-#: src/FirstRunWizard.cpp:291
+#: src/FirstRunWizard.cpp
 msgid "Other / set manually"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:298
+#: src/FirstRunWizard.cpp
 msgid "Upload limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:306
+#: src/FirstRunWizard.cpp
 msgid "Download limit (kB/s, 0 = unlimited):"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:332
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Networks & ports"
 msgstr "網路"
 
-#: src/FirstRunWizard.cpp:335
+#: src/FirstRunWizard.cpp
 msgid "aMule can use two networks. We recommend keeping both enabled."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:345 src/TextClient.cpp:894
+#: src/FirstRunWizard.cpp src/TextClient.cpp
 msgid "eD2k"
 msgstr "eD2k"
 
-#: src/FirstRunWizard.cpp:349 src/muuli_wdr.cpp:1495
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/FirstRunWizard.cpp:359 src/muuli_wdr.cpp:1423
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Standard TCP Port "
 msgstr "標準 TCP 埠"
 
-#: src/FirstRunWizard.cpp:365 src/muuli_wdr.cpp:1435
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Extended UDP port (Kad / global search) "
 msgstr "擴充 UDP 埠 (Kad / 全球搜尋)"
 
-#: src/FirstRunWizard.cpp:377 src/muuli_wdr.cpp:1442
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Enable UPnP for router port forwarding"
 msgstr "啟用 UPnP 的路由通訊埠轉向"
 
-#: src/FirstRunWizard.cpp:382
+#: src/FirstRunWizard.cpp
 msgid ""
 "Lets aMule ask your router to forward the ports above so other\n"
 "peers can reach you (a \"HighID\"). Turn off if your router\n"
 "doesn't support UPnP or you forward ports manually."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:399
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Bootstrap files"
 msgstr "啓動"
 
-#: src/FirstRunWizard.cpp:404
+#: src/FirstRunWizard.cpp
 msgid ""
 "To get started, aMule needs to know about some peers.\n"
 "Select which lists to download now:"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:423
+#: src/FirstRunWizard.cpp
 #, fuzzy
 msgid "Your peer lists are already in place - nothing to download."
 msgstr "您已經在下載檔案 %s 了"
 
-#: src/FirstRunWizard.cpp:434 src/muuli_wdr.cpp:1540
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Auto-update server list at startup"
 msgstr "啟動時自動更新伺服器清單"
 
-#: src/FirstRunWizard.cpp:447
+#: src/FirstRunWizard.cpp
 msgid "Integrations (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:450
+#: src/FirstRunWizard.cpp
 msgid ""
 "Choose how aMule integrates with your system. You can\n"
 "change any of these later in Preferences."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:460 src/muuli_wdr.cpp:1273
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:484 src/muuli_wdr.cpp:1281
-#: packaging/windows/installer_strings.c:39
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:492 src/muuli_wdr.cpp:1285
-#: packaging/windows/installer_strings.c:40
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:504
+#: src/FirstRunWizard.cpp
 msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:522 src/muuli_wdr.cpp:1292
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Open .emulecollection files with aMule"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:538
+#: src/FirstRunWizard.cpp
 msgid "Folders (optional)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:541
+#: src/FirstRunWizard.cpp
 msgid ""
 "The defaults are fine for most people. Change them if you\n"
 "want downloads on a different (e.g. larger) disk."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:549 src/FirstRunWizard.cpp:611 src/muuli_wdr.cpp:1716
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/FirstRunWizard.cpp:553 src/FirstRunWizard.cpp:569 src/muuli_wdr.cpp:1349
-#: src/muuli_wdr.cpp:1366 src/muuli_wdr.cpp:1691 src/muuli_wdr.cpp:1722
-#: src/muuli_wdr.cpp:1734 src/muuli_wdr.cpp:2816
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/FirstRunWizard.cpp:559 src/muuli_wdr.cpp:1727
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "(All files in this folder are shared with other peers)"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:565 src/FirstRunWizard.cpp:624 src/muuli_wdr.cpp:1729
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
 msgid "Folder for temporary download files"
 msgstr "暫存資料夾"
 
-#: src/FirstRunWizard.cpp:586
+#: src/FirstRunWizard.cpp
 #, c-format
 msgid ""
 "Based on this, aMule will allow up to %i sources per file\n"
 "and %i client connections."
 msgstr ""
 
-#: src/FirstRunWizard.cpp:771
+#: src/FirstRunWizard.cpp
 msgid "Show this setup wizard again the next time you start aMule?"
 msgstr ""
 
-#: src/FirstRunWizard.cpp:772
+#: src/FirstRunWizard.cpp
 msgid "Setup not finished"
 msgstr ""
 
-#: src/FriendList.cpp:120
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
 msgstr "無法開啟好友清單檔案 emfriends.met 供讀取！"
 
-#: src/FriendList.cpp:145
+#: src/FriendList.cpp
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 
-#: src/FriendList.cpp:265
+#: src/FriendList.cpp
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2722 src/muuli_wdr.cpp:3399
+#: src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Friends"
 msgstr "好友"
 
-#: src/FriendListCtrl.cpp:132 src/GenericClientListCtrl.cpp:654
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Show &Details"
 msgstr "顯示詳細資訊(&D)"
 
-#: src/FriendListCtrl.cpp:136
+#: src/FriendListCtrl.cpp
 msgid "Add a friend"
 msgstr "加入好友"
 
-#: src/FriendListCtrl.cpp:139
+#: src/FriendListCtrl.cpp
 msgid "Remove Friend"
 msgstr "移除好友"
 
-#: src/FriendListCtrl.cpp:140
+#: src/FriendListCtrl.cpp
 msgid "Send &Message"
 msgstr "傳送訊息(&M)"
 
-#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:665
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "View Files"
 msgstr "檢視檔案"
 
-#: src/FriendListCtrl.cpp:142 src/GenericClientListCtrl.cpp:657
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Establish Friend Slot"
 msgstr "建立好友位置"
 
-#: src/FriendListCtrl.cpp:175
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr "您確定要刪除這個好友嗎？"
 
-#: src/FriendListCtrl.cpp:177
+#: src/FriendListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr "您確定要刪除這些好友嗎？"
 
-#: src/FriendListCtrl.cpp:248
+#: src/FriendListCtrl.cpp
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
@@ -2497,11 +2446,11 @@ msgstr ""
 "不允許設定超過一個好友位置。\n"
 " 只設定了一個位置。"
 
-#: src/FriendListCtrl.cpp:250 src/GenericClientListCtrl.cpp:599
+#: src/FriendListCtrl.cpp src/GenericClientListCtrl.cpp
 msgid "Multiple selection"
 msgstr "多重選取"
 
-#: src/GenericClientListCtrl.cpp:597
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
@@ -2510,1076 +2459,1043 @@ msgstr ""
 "不允許設定超過一個好友位置。\n"
 " 只設定了一個位置。"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Send message to user"
 msgstr "傳送訊息給使用者"
 
-#: src/GenericClientListCtrl.cpp:617
+#: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "傳送訊息："
 
-#: src/GenericClientListCtrl.cpp:655
+#: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
 msgstr "從好友中刪除"
 
-#: src/GenericClientListCtrl.cpp:666
+#: src/GenericClientListCtrl.cpp
 msgid "Send message"
 msgstr "傳送訊息"
 
-#: src/GenericClientListCtrl.cpp:668
+#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "轉移到這個檔案"
 
-#: src/GenericClientListCtrl.cpp:1053
+#: src/GenericClientListCtrl.cpp
 msgid "A4AF"
 msgstr "A4AF"
 
-#: src/GenericClientListCtrl.cpp:1117
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR：%u (%i)"
 
-#: src/GenericClientListCtrl.cpp:1127 src/GenericClientListCtrl.cpp:1155
+#: src/GenericClientListCtrl.cpp
 msgid "Asked for another file"
 msgstr "已要求其它檔案 (A4AF)"
 
-#: src/GenericClientListCtrl.cpp:1145
+#: src/GenericClientListCtrl.cpp
 msgid "Waiting for upload slot"
 msgstr "正在等待上傳位置"
 
-#: src/GenericClientListCtrl.cpp:1147
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u"
 msgstr "QR：%u"
 
-#: src/GenericClientListCtrl.cpp:1150 src/muuli_wdr.cpp:630
+#: src/GenericClientListCtrl.cpp src/muuli_wdr.cpp
 msgid "Uploading"
 msgstr "正在上傳"
 
-#: src/GenericClientListCtrl.cpp:1152
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "無"
 
-#: src/GenericClientListCtrl.cpp:1214 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp:1216 src/PrefsUnifiedDlg.cpp:2948
-#: src/PrefsUnifiedDlg.cpp:2998 src/ServerListCtrl.cpp:276
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Yes"
 msgstr "是"
 
-#: src/HTTPDownload.cpp:59
+#: src/HTTPDownload.cpp
 msgid "Downloading..."
 msgstr "正在下載..."
 
-#: src/HTTPDownload.cpp:126
+#: src/HTTPDownload.cpp
 msgid "HTTP download cancelled"
 msgstr "已取消 HTTP 下載"
 
-#: src/HTTPDownload.cpp:341
+#: src/HTTPDownload.cpp
 msgid "The URL to download can't be empty"
 msgstr "要下載的網址不可空白"
 
-#: src/HTTPDownload.cpp:352
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Failed to create HTTP request for %s"
 msgstr "無法從使用者 %s 取得分享檔案清單"
 
-#: src/HTTPDownload.cpp:431
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP download: empty response body for %s"
 msgstr ""
 
-#: src/HTTPDownload.cpp:443
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Could not move downloaded file to %s"
 msgstr "暫存資料夾"
 
-#: src/HTTPDownload.cpp:447
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "Downloaded %s (%llu bytes)"
 msgstr "已下載 %d B"
 
-#: src/HTTPDownload.cpp:452
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "The URL %s returned: %i"
 msgstr "網址 %s 傳回：%i - 錯誤 (%i)！"
 
-#: src/HTTPDownload.cpp:460
+#: src/HTTPDownload.cpp
 #, fuzzy, c-format
 msgid "HTTP download failed for %s: %s"
 msgstr "已取消 HTTP 下載"
 
-#: src/HTTPDownload.cpp:474
+#: src/HTTPDownload.cpp
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
 msgstr ""
 
-#: src/IP2Country.cpp:59
+#: src/IP2Country.cpp
 #, c-format
 msgid "Migrated existing GeoLite2-Country.mmdb to %s"
 msgstr ""
 
-#: src/IP2Country.cpp:106
+#: src/IP2Country.cpp
 msgid "IP2Country: MaxMind selected as the GeoIP source but no License Key configured. Open Preferences -> IP2Country, paste your free MaxMind License Key and click 'Update now'."
 msgstr ""
 
-#: src/IP2Country.cpp:111
+#: src/IP2Country.cpp
 msgid "IP2Country: Custom URL selected as the GeoIP source but no URL configured. Open Preferences -> IP2Country and supply a URL that points to an .mmdb (or .gz / .tar.gz containing one)."
 msgstr ""
 
-#: src/IP2Country.cpp:116
+#: src/IP2Country.cpp
 msgid "IP2Country: failed to resolve a GeoIP download URL."
 msgstr ""
 
-#: src/IP2Country.cpp:129
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download new %s from %s"
 msgstr "從 %s 下載新的 GeoIP.dat"
 
-#: src/IP2Country.cpp:169
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Download of %s file failed, aborting update."
 msgstr "無法下載 GeoIP.dat，停止更新。"
 
-#: src/IP2Country.cpp:180 src/IPFilter.cpp:503
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Failed to remove %s file, aborting update."
 msgstr "無法移除 %s 檔案，停止更新。"
 
-#: src/IP2Country.cpp:192
+#: src/IP2Country.cpp
 #, c-format
 msgid "Failed to rename %s file, aborting update."
 msgstr "無法重新命名 %s 檔案，停止更新。"
 
-#: src/IP2Country.cpp:202 src/IPFilter.cpp:509
+#: src/IP2Country.cpp src/IPFilter.cpp
 #, c-format
 msgid "Successfully updated %s"
 msgstr "成功更新 %s"
 
-#: src/IP2Country.cpp:211
+#: src/IP2Country.cpp
 #, fuzzy, c-format
 msgid "Error updating %s"
 msgstr "GeoIP.dat 更新錯誤"
 
-#: src/IP2Country.cpp:235
+#: src/IP2Country.cpp
 msgid "DB-IP download failed for the current month - retrying with the previous month's URL."
 msgstr ""
 
-#: src/IP2Country.cpp:240 src/IPFilter.cpp:516 src/ServerList.cpp:878
+#: src/IP2Country.cpp src/IPFilter.cpp src/ServerList.cpp
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr "無法下載 %s (從 %s)"
 
-#: src/IPFilter.cpp:108
+#: src/IPFilter.cpp
 msgid "Loading IP filters 'ipfilter.dat' and 'ipfilter_static.dat'."
 msgstr "正在載入 IP 過濾檔 ipfilter.dat 與 ipfilter_static.dat 。"
 
-#: src/IPFilter.cpp:295
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', unknown format encountered."
 msgstr "無法載入 ipfilter.dat 檔案 %s，為不明格式。"
 
-#: src/IPFilter.cpp:325
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to load ipfilter.dat file '%s', could not open file."
 msgstr "無法載入 ipfilter.dat 檔案 %s，無法開啟檔案。"
 
-#: src/IPFilter.cpp:330
+#: src/IPFilter.cpp
 #, c-format
 msgid "Loaded %u IP-range from '%s'."
 msgid_plural "Loaded %u IP-ranges from '%s'."
 msgstr[0] "已載入 %u 個 IP 區段 (從 %s )。"
 
-#: src/IPFilter.cpp:336
+#: src/IPFilter.cpp
 #, c-format
 msgid "%u malformed line was discarded."
 msgid_plural "%u malformed lines were discarded."
 msgstr[0] "放棄 %u 行錯誤資料。"
 
-#: src/IPFilter.cpp:506
+#: src/IPFilter.cpp
 #, c-format
 msgid "Failed to rename new %s file, aborting update."
 msgstr "無法重新命名新的 %s 檔案，停止更新。"
 
-#: src/IPFilter.cpp:537
+#: src/IPFilter.cpp
 msgid "IP filter is ready"
 msgstr "IP 過濾表已備妥"
 
-#: src/KadDlg.cpp:82
+#: src/KadDlg.cpp
 msgid ""
 "Bootstrap from \n"
 "known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/KadDlg.cpp:164
+#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "節點 (%u)"
 
-#: src/KadDlg.cpp:195
+#: src/KadDlg.cpp
 msgid "Invalid ip to bootstrap"
 msgstr "無效 IP"
 
-#: src/KadDlg.cpp:203
+#: src/KadDlg.cpp
 msgid "Invalid port to bootstrap"
 msgstr "無效的通訊埠"
 
-#: src/KadDlg.cpp:211
+#: src/KadDlg.cpp
 msgid "Please fill all fields required"
 msgstr "請填寫所有必要資訊"
 
-#: src/KadDlg.cpp:211 src/PartFile.cpp:1031 src/PrefsUnifiedDlg.cpp:1169
-#: src/PrefsUnifiedDlg.cpp:1239 src/PrefsUnifiedDlg.cpp:1440
-#: src/PrefsUnifiedDlg.cpp:1698 src/PrefsUnifiedDlg.cpp:1708
-#: src/PrefsUnifiedDlg.cpp:1725 src/PrefsUnifiedDlg.cpp:1773
+#: src/KadDlg.cpp src/PartFile.cpp src/PrefsUnifiedDlg.cpp
 msgid "Message"
 msgstr "訊息"
 
-#: src/KadDlg.cpp:235
+#: src/KadDlg.cpp
 msgid "Are you sure you want to download a new nodes.dat file?\n"
 msgstr "確定要下載新的 node.dat 檔案嗎？\n"
 
-#: src/KadDlg.cpp:236
+#: src/KadDlg.cpp
 msgid "Doing so will remove your current nodes and restart Kademlia connection."
 msgstr "這樣將會刪除您現有節點並重新啓動 Kad 連線。"
 
-#: src/KadDlg.cpp:237
+#: src/KadDlg.cpp
 msgid "Continue?"
 msgstr "繼續？"
 
-#: src/kademlia/kademlia/SearchManager.cpp:156
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: search keyword too short"
 msgstr "Kad：關鍵字太短"
 
-#: src/kademlia/kademlia/SearchManager.cpp:169
+#: src/kademlia/kademlia/SearchManager.cpp
 msgid "Kademlia: Search keyword is already on search list: "
 msgstr "Kad：關鍵字已在搜尋清單中："
 
-#: src/kademlia/routing/RoutingZone.cpp:175
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "Failed to read nodes.dat file - too old. This version (0) is not supported anymore."
 msgstr "無法讀取 nodes.dat 檔案 - 版本 (0) 太舊，已經不再支援了。"
 
-#: src/kademlia/routing/RoutingZone.cpp:226
-#: src/kademlia/routing/RoutingZone.cpp:323
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Read %u Kad contact"
 msgid_plural "Read %u Kad contacts"
 msgstr[0] "讀取 %u 個 Kad 聯絡人"
 
-#: src/kademlia/routing/RoutingZone.cpp:244
-#: src/kademlia/routing/RoutingZone.cpp:332
+#: src/kademlia/routing/RoutingZone.cpp
 msgid "No contacts found, please bootstrap, or download a nodes.dat file."
 msgstr "找不到聯絡人，請設啟動節點、或下載一個 nodes.dat 檔案。"
 
-#: src/kademlia/routing/RoutingZone.cpp:353
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Only %d Kad contact available, nodes.dat not written"
 msgid_plural "Only %d Kad contacts available, nodes.dat not written"
 msgstr[0] "只有 %d 個 Kad 聯絡人，nods.dat 未寫入"
 
-#: src/kademlia/routing/RoutingZone.cpp:389
+#: src/kademlia/routing/RoutingZone.cpp
 #, c-format
 msgid "Wrote %d Kad contact"
 msgid_plural "Wrote %d Kad contacts"
 msgstr[0] "已寫入 %d 個 Kad 聯絡人"
 
-#: src/KnownFile.cpp:336
+#: src/KnownFile.cpp
 #, fuzzy
 msgid "Kad user"
 msgstr "kad 網路"
 
-#: src/KnownFile.cpp:1534
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1569
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1578
+#: src/KnownFile.cpp
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp src/PartFileConvertDlg.cpp
 msgid "File name"
 msgstr "檔案名稱"
 
-#: src/KnownFile.cpp:1880
+#: src/KnownFile.cpp
 msgid "File size"
 msgstr "檔案大小"
 
-#: src/KnownFile.cpp:1881
+#: src/KnownFile.cpp
 msgid "Share ratio"
 msgstr "分享率"
 
-#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
-#: src/SourceListCtrl.cpp:31
+#: src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3279
+#: src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "Requested"
 msgstr "已要求"
 
-#: src/KnownFile.cpp:1887
+#: src/KnownFile.cpp
 msgid "Accepted"
 msgstr "已接受"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp
 msgid "Complete sources"
 msgstr "完整來源"
 
-#: src/KnownFileList.cpp:109
+#: src/KnownFileList.cpp
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr "警告：已知檔案清單損壞，內有無效標頭。"
 
-#: src/KnownFileList.cpp:138
+#: src/KnownFileList.cpp
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr "無法載入已知檔案清單內的項目，檔案可能有損壞"
 
-#: src/KnownFileList.cpp:147
+#: src/KnownFileList.cpp
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "已知檔案清單內有無效的項目，檔案可能有損壞： "
 
-#: src/libs/common/Format.cpp:382
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
 msgstr "不明的錯誤 %d"
 
-#: src/libs/common/Format.cpp:391 src/libs/common/Format.cpp:405
+#: src/libs/common/Format.cpp
 #, c-format
 msgid "Unable to get error description for error %d"
 msgstr "無法取得關於錯誤 %d 的說明"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:39 src/PartFile.cpp:4361
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Hashing"
 msgstr "正在計算 hash 值"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:43 src/PartFile.cpp:4367
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Completing"
 msgstr "正在完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:45 src/PartFile.cpp:4370
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/PartFile.cpp
 msgid "Complete"
 msgstr "完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:47 src/OtherFunctions.cpp:701
-#: src/PartFile.cpp:4373 src/TransferWnd.cpp:353
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:49 src/OtherFunctions.cpp:699
-#: src/PartFile.cpp:4376 src/TransferWnd.cpp:352
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "錯誤的"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:54 src/OtherFunctions.cpp:695
-#: src/PartFile.cpp:4385 src/TransferWnd.cpp:350
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "正在等候"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:191 src/libs/ec/cpp/RemoteConnect.cpp:199
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "You must specify a non-empty password."
 msgstr "您必須輸入密碼。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:196
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Invalid password, not a MD5 hash!"
 msgstr "無效的密碼，不是 MD5 hash 值！"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:310
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Connection failure"
 msgstr "無法連線"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:321
+#: src/libs/ec/cpp/RemoteConnect.cpp
 #, fuzzy
 msgid "External Connection lost - exiting."
 msgstr "已關閉外部連線。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:412
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "EC connection failed. Empty reply."
 msgstr "無法外部連線，無回應。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:424
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr "外部連線：回應不正確、訊號交換失敗，已關閉連線。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:435
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established to aMule "
 msgstr "已成功連線到 aMule "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:437
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "Succeeded! Connection established."
 msgstr "連線成功。"
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:483
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Access denied because: "
 msgstr "外部連線：拒絕存取，原因： "
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:486
+#: src/libs/ec/cpp/RemoteConnect.cpp
 msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
-#: src/LibSocketAsio.cpp:1998
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"
 
-#: src/ListenSocket.cpp:62
+#: src/ListenSocket.cpp
 msgid "ListenSocket: Ok."
 msgstr "監聽連接端點：OK。"
 
-#: src/ListenSocket.cpp:64
+#: src/ListenSocket.cpp
 msgid "ERROR: Could not listen to TCP port."
 msgstr "錯誤：無法監聽 TCP 埠。"
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "ERROR: "
 msgstr "錯誤： "
 
-#: src/Logger.cpp:318
+#: src/Logger.cpp
 msgid "WARNING: "
 msgstr "警告："
 
-#: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:817 src/muuli_wdr.cpp:1229
-#: src/muuli_wdr.cpp:3183 src/muuli_wdr.cpp:3439
+#: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"
 msgstr "關閉"
 
-#: src/MuleTextCtrl.cpp:86
+#: src/MuleTextCtrl.cpp
 msgid "Cut"
 msgstr "剪下"
 
-#: src/MuleTextCtrl.cpp:87 src/PartFileConvert.cpp:407 src/ServerWnd.cpp:440
-#: src/utils/aLinkCreator/src/alcframe.cpp:250
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "複製"
 
-#: src/MuleTextCtrl.cpp:88 src/SearchDlg.cpp:261
+#: src/MuleTextCtrl.cpp src/SearchDlg.cpp
 msgid "Paste"
 msgstr "貼上"
 
-#: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:757
-#: src/muuli_wdr.cpp:2394 src/muuli_wdr.cpp:2413 src/muuli_wdr.cpp:2435
-#: src/utils/aLinkCreator/src/alcframe.cpp:142
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
-#: src/MuleTextCtrl.cpp:93
+#: src/MuleTextCtrl.cpp
 msgid "Select All"
 msgstr "全選"
 
-#: src/MuleTrayIcon.cpp:381
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
 
-#: src/MuleTrayIcon.cpp:383
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (LowID)"
 msgstr "已連線"
 
-#: src/MuleTrayIcon.cpp:384
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (HighID)"
 msgstr "已連線"
 
-#: src/MuleTrayIcon.cpp:393
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Kad: "
 msgstr " Kad："
 
-#: src/MuleTrayIcon.cpp:395
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Connected (firewalled)"
 msgstr "已連線到 Kad 網路 (防火牆內)"
 
-#: src/MuleTrayIcon.cpp:405
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server: "
 msgstr "伺服器 IP："
 
-#: src/MuleTrayIcon.cpp:406
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "Server IP: "
 msgstr "伺服器 IP："
 
-#: src/MuleTrayIcon.cpp:411 src/MuleTrayIcon.cpp:412 src/MuleTrayIcon.cpp:823
-#: src/MuleTrayIcon.cpp:837 src/TextClient.cpp:909 src/TextClient.cpp:922
+#: src/MuleTrayIcon.cpp src/TextClient.cpp
 msgid "Not connected"
 msgstr "未連線"
 
-#: src/MuleTrayIcon.cpp:420 src/MuleTrayIcon.cpp:846
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "IP: %s"
 msgstr "IP：%s"
 
-#: src/MuleTrayIcon.cpp:426 src/MuleTrayIcon.cpp:857
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "TCP port: %d"
 msgstr "TCP 埠：%d"
 
-#: src/MuleTrayIcon.cpp:427 src/MuleTrayIcon.cpp:859
+#: src/MuleTrayIcon.cpp
 msgid "TCP port: Not ready"
 msgstr "TCP 埠：尚未就緒"
 
-#: src/MuleTrayIcon.cpp:431 src/MuleTrayIcon.cpp:868
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UDP port: %d"
 msgstr "UDP 埠：%d"
 
-#: src/MuleTrayIcon.cpp:432 src/MuleTrayIcon.cpp:870
+#: src/MuleTrayIcon.cpp
 msgid "UDP port: Not ready"
 msgstr "UDP 埠：尚未就緒"
 
-#: src/MuleTrayIcon.cpp:436 src/MuleTrayIcon.cpp:805
+#: src/MuleTrayIcon.cpp
 msgid "Client Information"
 msgstr "客戶端資訊"
 
-#: src/MuleTrayIcon.cpp:454 src/MuleTrayIcon.cpp:925
+#: src/MuleTrayIcon.cpp
 msgid "Upload limit"
 msgstr "上傳限制"
 
-#: src/MuleTrayIcon.cpp:468 src/MuleTrayIcon.cpp:929
+#: src/MuleTrayIcon.cpp
 msgid "Download limit"
 msgstr "下載限制"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976 src/muuli_wdr.cpp:5968
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979 src/muuli_wdr.cpp:2492
-#: src/muuli_wdr.cpp:2647 src/muuli_wdr.cpp:2660 src/muuli_wdr.cpp:3108
-#: src/muuli_wdr.cpp:3463 src/muuli_wdr.cpp:5972
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "連線"
 
-#: src/MuleTrayIcon.cpp:493 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:989
+#: src/MuleTrayIcon.cpp
 msgid "Show aMule"
 msgstr "顯示 aMule"
 
-#: src/MuleTrayIcon.cpp:498 src/MuleTrayIcon.cpp:506 src/MuleTrayIcon.cpp:987
+#: src/MuleTrayIcon.cpp
 msgid "Hide aMule"
 msgstr "隱藏 aMule"
 
-#: src/MuleTrayIcon.cpp:514 src/MuleTrayIcon.cpp:996
-#: src/utils/aLinkCreator/src/alcframe.cpp:222
+#: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "離開"
 
-#: src/MuleTrayIcon.cpp:579 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:965
-#: src/muuli_wdr.cpp:1398 src/muuli_wdr.cpp:1406 src/muuli_wdr.cpp:1413
-#: src/muuli_wdr.cpp:1850 src/muuli_wdr.cpp:1856 src/OtherFunctions.cpp:91
-#: src/StatisticsDlg.cpp:93 src/StatisticsDlg.cpp:95
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "kB/s"
 msgstr "KB/s"
 
-#: src/MuleTrayIcon.cpp:595 src/MuleTrayIcon.cpp:614 src/MuleTrayIcon.cpp:933
-#: src/MuleTrayIcon.cpp:953
+#: src/MuleTrayIcon.cpp
 msgid "Unlimited"
 msgstr "無限制"
 
-#: src/MuleTrayIcon.cpp:769
+#: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"
 msgstr "aMule 狀態列選單"
 
-#: src/MuleTrayIcon.cpp:775
+#: src/MuleTrayIcon.cpp
 msgid "Speed limits:"
 msgstr "速度限制："
 
-#: src/MuleTrayIcon.cpp:780
+#: src/MuleTrayIcon.cpp
 msgid "UL: None"
 msgstr "上傳：無"
 
-#: src/MuleTrayIcon.cpp:782
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "UL: %u"
 msgstr "上傳：%u"
 
-#: src/MuleTrayIcon.cpp:789
+#: src/MuleTrayIcon.cpp
 msgid "DL: None"
 msgstr "下載：無"
 
-#: src/MuleTrayIcon.cpp:791
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "DL: %u"
 msgstr "下載：%u"
 
-#: src/MuleTrayIcon.cpp:795
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Download speed: %.1f%s"
 msgstr "下載速度：%.1f"
 
-#: src/MuleTrayIcon.cpp:798
+#: src/MuleTrayIcon.cpp
 #, fuzzy, c-format
 msgid "Upload speed: %.1f%s"
 msgstr "上傳速度：%.1f"
 
-#: src/MuleTrayIcon.cpp:809
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Nickname: %s"
 msgstr "暱稱：%s"
 
-#: src/MuleTrayIcon.cpp:810
+#: src/MuleTrayIcon.cpp
 msgid "No Nickname Selected!"
 msgstr "未選取暱稱！"
 
-#: src/MuleTrayIcon.cpp:818
+#: src/MuleTrayIcon.cpp
 msgid "ClientID: "
 msgstr "客戶端 ID："
 
-#: src/MuleTrayIcon.cpp:830
+#: src/MuleTrayIcon.cpp
 msgid "ServerName: "
 msgstr "伺服器名稱："
 
-#: src/MuleTrayIcon.cpp:831
+#: src/MuleTrayIcon.cpp
 msgid "ServerIP: "
 msgstr "伺服器 IP："
 
-#: src/MuleTrayIcon.cpp:838 src/ServerWnd.cpp:235
-#: src/utils/wxCas/src/onlinesig.cpp:248
+#: src/MuleTrayIcon.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "Not Connected"
 msgstr "未連線"
 
-#: src/MuleTrayIcon.cpp:879
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Enabled"
 msgstr "線上簽名識別：啟用"
 
-#: src/MuleTrayIcon.cpp:881
+#: src/MuleTrayIcon.cpp
 msgid "Online Signature: Disabled"
 msgstr "線上簽名識別：停用"
 
-#: src/MuleTrayIcon.cpp:888 src/Statistics.cpp:785
+#: src/MuleTrayIcon.cpp src/Statistics.cpp
 #, c-format
 msgid "Uptime: %s"
 msgstr "已執行時間：%s"
 
-#: src/MuleTrayIcon.cpp:894
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Shared files: %d"
 msgstr "已分享檔案：%d"
 
-#: src/MuleTrayIcon.cpp:900
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Queued clients: %d"
 msgstr "等候中客戶端：%d"
 
-#: src/MuleTrayIcon.cpp:907
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total DL: %s"
 msgstr "總下載：%s"
 
-#: src/MuleTrayIcon.cpp:914
+#: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
 msgstr "總上傳：%s"
 
-#: src/muuli_wdr.cpp:105
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Paste eD2k or magnet links here"
 msgstr "加入 eD2k 或 magnet 連結到主程式。"
 
-#: src/muuli_wdr.cpp:107
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Add links"
 msgstr "加入好友"
 
-#: src/muuli_wdr.cpp:108
+#: src/muuli_wdr.cpp
 msgid "Click here to add the eD2k link in the text control to your download queue."
 msgstr "點選這裏將欄內的 eD2k 連結加入下載等候區。"
 
-#: src/muuli_wdr.cpp:114
+#: src/muuli_wdr.cpp
 msgid "Events are displayed here. For a complete list of events, refer to the log in the Servers-tab."
 msgstr "此處顯示系統事件。如需完整事件記錄，請到伺服器分頁。"
 
-#: src/muuli_wdr.cpp:117
+#: src/muuli_wdr.cpp
 msgid "Loading ..."
 msgstr "正在載入..."
 
-#: src/muuli_wdr.cpp:124
+#: src/muuli_wdr.cpp
 msgid "Number of users on the server you are connected to ..."
 msgstr "目前伺服器上使用者數 ..."
 
-#: src/muuli_wdr.cpp:127
+#: src/muuli_wdr.cpp
 msgid "Users: 0"
 msgstr "使用者數：0"
 
-#: src/muuli_wdr.cpp:128
+#: src/muuli_wdr.cpp
 msgid "Users connected to the current server and an estimate of the total number of users."
 msgstr "目前伺服器上的連線使用者和估計的總使用者數。"
 
-#: src/muuli_wdr.cpp:136
+#: src/muuli_wdr.cpp
 msgid "Up: 0.0 | Down: 0.0"
 msgstr "上傳：0.0 | 下載：0.0"
 
-#: src/muuli_wdr.cpp:137
+#: src/muuli_wdr.cpp
 msgid "Current average upload and download rates. If enabled the numbers in the braces signify the overhead from client communication."
 msgstr "目前平均上傳下載速度。括號中的爲與其他客戶端連線所消耗的頻寬。"
 
-#: src/muuli_wdr.cpp:144
+#: src/muuli_wdr.cpp
 msgid "Displays the connected status and active transfers. Red arrows signifies that you are currently not connected, yellow arrows signify that you have low ID (firewalled) and green arrows signify that you have high ID (The optimal connection type)."
 msgstr "顯示目前連線與傳輸狀態。紅色箭頭表示未連線，黃色箭頭表示 LowID (防火牆內)，綠色箭頭表示正常連線。"
 
-#: src/muuli_wdr.cpp:147
+#: src/muuli_wdr.cpp
 msgid "Not Connected ..."
 msgstr "未連線..."
 
-#: src/muuli_wdr.cpp:148
+#: src/muuli_wdr.cpp
 msgid "Currently connected server."
 msgstr "目前連線的伺服器。"
 
-#: src/muuli_wdr.cpp:199
+#: src/muuli_wdr.cpp
 msgid "Search"
 msgstr "搜尋"
 
-#: src/muuli_wdr.cpp:205
+#: src/muuli_wdr.cpp
 msgid "Name:"
 msgstr "名稱："
 
-#: src/muuli_wdr.cpp:211 src/SearchListCtrl.cpp:100 src/SharedFilesCtrl.cpp:111
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "類型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:118 src/SearchListCtrl.cpp:853
+#: src/muuli_wdr.cpp src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Local"
 msgstr "本地"
 
-#: src/muuli_wdr.cpp:216
+#: src/muuli_wdr.cpp
 msgid "Global"
 msgstr "全球"
 
-#: src/muuli_wdr.cpp:223
+#: src/muuli_wdr.cpp
 msgid "Extended Parameters"
 msgstr "擴充參數"
 
-#: src/muuli_wdr.cpp:227
+#: src/muuli_wdr.cpp
 msgid "Filtering"
 msgstr "過濾"
 
-#: src/muuli_wdr.cpp:236
+#: src/muuli_wdr.cpp
 msgid "File Type"
 msgstr "檔案類型"
 
-#: src/muuli_wdr.cpp:240 src/OtherFunctions.cpp:252
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Any"
 msgstr "任何"
 
-#: src/muuli_wdr.cpp:241 src/OtherFunctions.cpp:217
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Archives"
 msgstr "壓縮檔"
 
-#: src/muuli_wdr.cpp:242 src/OtherFunctions.cpp:210 src/OtherFunctions.cpp:707
-#: src/TransferWnd.cpp:360
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Audio"
 msgstr "音樂"
 
-#: src/muuli_wdr.cpp:243 src/OtherFunctions.cpp:224 src/OtherFunctions.cpp:711
-#: src/TransferWnd.cpp:362
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "CD-Images"
 msgstr "光碟映像"
 
-#: src/muuli_wdr.cpp:244 src/OtherFunctions.cpp:231 src/OtherFunctions.cpp:713
-#: src/TransferWnd.cpp:363
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Pictures"
 msgstr "圖片"
 
-#: src/muuli_wdr.cpp:245 src/OtherFunctions.cpp:245
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Programs"
 msgstr "程式"
 
-#: src/muuli_wdr.cpp:246 src/OtherFunctions.cpp:238
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Texts"
 msgstr "文件"
 
-#: src/muuli_wdr.cpp:247 src/OtherFunctions.cpp:203
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Videos"
 msgstr "影片"
 
-#: src/muuli_wdr.cpp:260
+#: src/muuli_wdr.cpp
 msgid "Extension"
 msgstr "副檔名"
 
-#: src/muuli_wdr.cpp:264
+#: src/muuli_wdr.cpp
 msgid "Min Size"
 msgstr "大小下限"
 
-#: src/muuli_wdr.cpp:272 src/muuli_wdr.cpp:291
+#: src/muuli_wdr.cpp
 msgid "Bytes"
 msgstr "B"
 
-#: src/muuli_wdr.cpp:273 src/muuli_wdr.cpp:292
+#: src/muuli_wdr.cpp
 msgid "KB"
 msgstr "KB"
 
-#: src/muuli_wdr.cpp:274 src/muuli_wdr.cpp:293 src/muuli_wdr.cpp:1635
-#: src/OtherFunctions.cpp:64
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "MB"
 msgstr "MB"
 
-#: src/muuli_wdr.cpp:275 src/muuli_wdr.cpp:294 src/OtherFunctions.cpp:66
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "GB"
 msgstr "GB"
 
-#: src/muuli_wdr.cpp:283
+#: src/muuli_wdr.cpp
 msgid "Max Size"
 msgstr "大小上限"
 
-#: src/muuli_wdr.cpp:302
+#: src/muuli_wdr.cpp
 msgid "Availability"
 msgstr "最小來源數"
 
-#: src/muuli_wdr.cpp:312 src/muuli_wdr.cpp:398 src/muuli_wdr.cpp:3344
+#: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "過濾："
 
-#: src/muuli_wdr.cpp:318
+#: src/muuli_wdr.cpp
 msgid "Filter Results"
 msgstr "過濾結果"
 
-#: src/muuli_wdr.cpp:322
+#: src/muuli_wdr.cpp
 msgid "Invert Result"
 msgstr "反向排序結果"
 
-#: src/muuli_wdr.cpp:326
+#: src/muuli_wdr.cpp
 msgid "Hide Known Files"
 msgstr "隱藏已知檔案"
 
-#: src/muuli_wdr.cpp:332 src/utils/aLinkCreator/src/alcframe.cpp:219
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Start"
 msgstr "開始"
 
-#: src/muuli_wdr.cpp:337
+#: src/muuli_wdr.cpp
 msgid "More"
 msgstr "其他"
 
-#: src/muuli_wdr.cpp:338
+#: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:343
+#: src/muuli_wdr.cpp
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1392 src/SearchListCtrl.cpp:732
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "下載"
 
-#: src/muuli_wdr.cpp:353
+#: src/muuli_wdr.cpp
 msgid "Reset Fields"
 msgstr "清空欄位"
 
-#: src/muuli_wdr.cpp:363
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "搜尋結果"
 
-#: src/muuli_wdr.cpp:389
+#: src/muuli_wdr.cpp
 msgid "Clears completed downloads"
 msgstr "清除已完成的檔案"
 
-#: src/muuli_wdr.cpp:432
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "檔案來源："
 
-#: src/muuli_wdr.cpp:495 src/muuli_wdr.cpp:516 src/muuli_wdr.cpp:524
-#: src/muuli_wdr.cpp:532 src/muuli_wdr.cpp:544 src/muuli_wdr.cpp:582
-#: src/muuli_wdr.cpp:586 src/muuli_wdr.cpp:651 src/muuli_wdr.cpp:658
-#: src/muuli_wdr.cpp:665 src/muuli_wdr.cpp:672 src/muuli_wdr.cpp:679
-#: src/muuli_wdr.cpp:686 src/muuli_wdr.cpp:1080 src/muuli_wdr.cpp:1083
-#: src/muuli_wdr.cpp:1095 src/muuli_wdr.cpp:1102 src/muuli_wdr.cpp:1107
-#: src/muuli_wdr.cpp:1114 src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1126
-#: src/muuli_wdr.cpp:1131 src/muuli_wdr.cpp:1138 src/muuli_wdr.cpp:1150
-#: src/muuli_wdr.cpp:1160 src/muuli_wdr.cpp:1167 src/muuli_wdr.cpp:1172
-#: src/muuli_wdr.cpp:1179 src/muuli_wdr.cpp:1184 src/muuli_wdr.cpp:1191
-#: src/muuli_wdr.cpp:1205 src/muuli_wdr.cpp:1212 src/muuli_wdr.cpp:1217
-#: src/muuli_wdr.cpp:1224 src/muuli_wdr.cpp:3281 src/muuli_wdr.cpp:3289
-#: src/muuli_wdr.cpp:3297
+#: src/muuli_wdr.cpp
 msgid "N/A"
 msgstr "N/A"
 
-#: src/muuli_wdr.cpp:508 src/muuli_wdr.cpp:1065 src/PrefsUnifiedDlg.cpp:302
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"
 msgstr "一般"
 
-#: src/muuli_wdr.cpp:513
+#: src/muuli_wdr.cpp
 msgid "Full Name :"
 msgstr "全名︰"
 
-#: src/muuli_wdr.cpp:522
+#: src/muuli_wdr.cpp
 msgid "met-File :"
 msgstr "met 檔"
 
-#: src/muuli_wdr.cpp:530
+#: src/muuli_wdr.cpp
 msgid "Hash :"
 msgstr "hash 值："
 
-#: src/muuli_wdr.cpp:542
+#: src/muuli_wdr.cpp
 msgid "Filesize :"
 msgstr "檔案大小："
 
-#: src/muuli_wdr.cpp:559 src/Statistics.cpp:788
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "傳輸"
 
-#: src/muuli_wdr.cpp:568
+#: src/muuli_wdr.cpp
 msgid "Partfilestatus :"
 msgstr "暫存檔狀態："
 
-#: src/muuli_wdr.cpp:569
+#: src/muuli_wdr.cpp
 msgid "Last seen complete :"
 msgstr "最後看到完整檔案："
 
-#: src/muuli_wdr.cpp:570
+#: src/muuli_wdr.cpp
 msgid "Found Sources :"
 msgstr "找到的來源："
 
-#: src/muuli_wdr.cpp:571
+#: src/muuli_wdr.cpp
 msgid "Transferring Sources :"
 msgstr "正在傳輸的來源："
 
-#: src/muuli_wdr.cpp:572
+#: src/muuli_wdr.cpp
 msgid "Filepart-Count :"
 msgstr "檔案分段數："
 
-#: src/muuli_wdr.cpp:573
+#: src/muuli_wdr.cpp
 msgid "Available :"
 msgstr "可用："
 
-#: src/muuli_wdr.cpp:574
+#: src/muuli_wdr.cpp
 msgid "Datarate :"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:575
+#: src/muuli_wdr.cpp
 msgid "Download Active Time: "
 msgstr "下載時間："
 
-#: src/muuli_wdr.cpp:576
+#: src/muuli_wdr.cpp
 msgid "Transferred :"
 msgstr "已傳輸："
 
-#: src/muuli_wdr.cpp:580
+#: src/muuli_wdr.cpp
 msgid "Completed Size :"
 msgstr "已完成："
 
-#: src/muuli_wdr.cpp:596
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "智慧資料損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:601
+#: src/muuli_wdr.cpp
 msgid "Lost to corruption :"
 msgstr "因資料損壞而損失："
 
-#: src/muuli_wdr.cpp:602
+#: src/muuli_wdr.cpp
 msgid "Gained by compression :"
 msgstr "壓縮量："
 
-#: src/muuli_wdr.cpp:603
+#: src/muuli_wdr.cpp
 msgid "Packages saved by I.C.H. :"
 msgstr "由 I.C.H. 救回的封包："
 
-#: src/muuli_wdr.cpp:615
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Sharing"
 msgstr "分享： "
 
-#: src/muuli_wdr.cpp:622 src/SharedFilesCtrl.cpp:113
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Requests"
 msgstr "要求"
 
-#: src/muuli_wdr.cpp:623 src/SharedFilesCtrl.cpp:114
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Accepted Requests"
 msgstr "已接受要求"
 
-#: src/muuli_wdr.cpp:624 src/SharedFilesCtrl.cpp:115
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Transferred Data"
 msgstr "已傳輸資料"
 
-#: src/muuli_wdr.cpp:625 src/SharedFilesCtrl.cpp:116
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Share Ratio"
 msgstr "分享率"
 
-#: src/muuli_wdr.cpp:626 src/SharedFilesCtrl.cpp:118
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 msgid "Complete Sources"
 msgstr "完整來源"
 
-#: src/muuli_wdr.cpp:631 src/SharedFilesCtrl.cpp:123
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Shared since"
 msgstr "檔案分享"
 
-#: src/muuli_wdr.cpp:632 src/SharedFilesCtrl.cpp:124
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Last upload"
 msgstr "，上傳："
 
-#: src/muuli_wdr.cpp:643
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Media Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:650
+#: src/muuli_wdr.cpp
 msgid "Length :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:657
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bitrate :"
 msgstr "未評價"
 
-#: src/muuli_wdr.cpp:664
+#: src/muuli_wdr.cpp
 msgid "Codec :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:671
+#: src/muuli_wdr.cpp
 msgid "Artist :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:678
+#: src/muuli_wdr.cpp
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:685 src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp
 msgid "Title :"
 msgstr "標題："
 
-#: src/muuli_wdr.cpp:694
+#: src/muuli_wdr.cpp
 msgid "File Names"
 msgstr "檔案名稱"
 
-#: src/muuli_wdr.cpp:702
+#: src/muuli_wdr.cpp
 msgid "Takeover"
 msgstr "取用"
 
-#: src/muuli_wdr.cpp:709
+#: src/muuli_wdr.cpp
 msgid "Cleanup"
 msgstr "清除"
 
-#: src/muuli_wdr.cpp:723 src/muuli_wdr.cpp:779
+#: src/muuli_wdr.cpp
 msgid "Apply"
 msgstr "套用"
 
-#: src/muuli_wdr.cpp:727
+#: src/muuli_wdr.cpp
 msgid "Ok"
 msgstr "確定"
 
-#: src/muuli_wdr.cpp:749
+#: src/muuli_wdr.cpp
 msgid "Comment/Rate file (Text will be visible to all users)"
 msgstr "註解/評價 檔案 (所有使用者都可看到)"
 
-#: src/muuli_wdr.cpp:755
+#: src/muuli_wdr.cpp
 msgid ""
 "For a film you can say its length, its story, language ...\n"
 "and if it's a fake, you can tell that to other users of aMule."
@@ -3587,1269 +3503,1265 @@ msgstr ""
 "針對影片，您可以留下片長、故事、語言...等資訊\n"
 "或是提出假檔警告，以供其他 aMule 使用者注意。"
 
-#: src/muuli_wdr.cpp:763
+#: src/muuli_wdr.cpp
 msgid "File Quality"
 msgstr "檔案品質"
 
-#: src/muuli_wdr.cpp:768 src/OtherFunctions.cpp:272 src/OtherFunctions.cpp:284
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Not rated"
 msgstr "未評價"
 
-#: src/muuli_wdr.cpp:769 src/OtherFunctions.cpp:274
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Invalid / Corrupt / Fake"
 msgstr "無效 / 損壞 / 假檔"
 
-#: src/muuli_wdr.cpp:770 src/OtherFunctions.cpp:276
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Poor"
 msgstr "差"
 
-#: src/muuli_wdr.cpp:771 src/OtherFunctions.cpp:278
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Fair"
 msgstr "一般"
 
-#: src/muuli_wdr.cpp:772 src/OtherFunctions.cpp:280
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Good"
 msgstr "好"
 
-#: src/muuli_wdr.cpp:773 src/OtherFunctions.cpp:282
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
 msgid "Excellent"
 msgstr "優良"
 
-#: src/muuli_wdr.cpp:776
+#: src/muuli_wdr.cpp
 msgid "Choose the file rating or advice users if the file is invalid ..."
 msgstr "選擇檔案評價或者提醒其它使用者該檔案是無效的..."
 
-#: src/muuli_wdr.cpp:813
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Get from Kad"
 msgstr "已中斷 Kad 網路連線"
 
-#: src/muuli_wdr.cpp:815
+#: src/muuli_wdr.cpp
 msgid "Refresh"
 msgstr "重新整理"
 
-#: src/muuli_wdr.cpp:838
+#: src/muuli_wdr.cpp
 msgid "Downloading, please wait ..."
 msgstr "正在下載，請稍待..."
 
-#: src/muuli_wdr.cpp:842
+#: src/muuli_wdr.cpp
 msgid "Unknown size"
 msgstr "不明大小"
 
-#: src/muuli_wdr.cpp:863
+#: src/muuli_wdr.cpp
 msgid "Required Information"
 msgstr "必要資訊"
 
-#: src/muuli_wdr.cpp:868
+#: src/muuli_wdr.cpp
 msgid "IP Address :"
 msgstr "IP 位址︰"
 
-#: src/muuli_wdr.cpp:872
+#: src/muuli_wdr.cpp
 msgid "Port :"
 msgstr "通訊埠︰"
 
-#: src/muuli_wdr.cpp:878
+#: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "附加資訊"
 
-#: src/muuli_wdr.cpp:883
+#: src/muuli_wdr.cpp
 msgid "Username :"
 msgstr "使用者名稱︰"
 
-#: src/muuli_wdr.cpp:887
+#: src/muuli_wdr.cpp
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:895 src/muuli_wdr.cpp:1756 src/muuli_wdr.cpp:2484
-#: src/utils/aLinkCreator/src/alcframe.cpp:137
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:938
+#: src/muuli_wdr.cpp
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:954 src/muuli_wdr.cpp:989 src/muuli_wdr.cpp:2591
+#: src/muuli_wdr.cpp
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:962 src/muuli_wdr.cpp:997 src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:970 src/muuli_wdr.cpp:1005 src/muuli_wdr.cpp:2607
+#: src/muuli_wdr.cpp
 msgid "Session average"
 msgstr "本次平均值"
 
-#: src/muuli_wdr.cpp:975
+#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "上傳速度"
 
-#: src/muuli_wdr.cpp:1010
+#: src/muuli_wdr.cpp
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp:1024 src/muuli_wdr.cpp:1875
+#: src/muuli_wdr.cpp
 msgid "Active downloads"
 msgstr "目前下載數"
 
-#: src/muuli_wdr.cpp:1032
+#: src/muuli_wdr.cpp
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp:1040 src/muuli_wdr.cpp:1876
+#: src/muuli_wdr.cpp
 msgid "Active uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:1045
+#: src/muuli_wdr.cpp
 msgid "Statistics Tree"
 msgstr "統計資訊"
 
-#: src/muuli_wdr.cpp:1072
+#: src/muuli_wdr.cpp
 msgid "Username:"
 msgstr "使用者名稱︰"
 
-#: src/muuli_wdr.cpp:1074
+#: src/muuli_wdr.cpp
 msgid "Userhash:"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:1093
+#: src/muuli_wdr.cpp
 msgid "Client software:"
 msgstr "客戶端軟體："
 
-#: src/muuli_wdr.cpp:1100
+#: src/muuli_wdr.cpp
 msgid "Client version:"
 msgstr "版本："
 
-#: src/muuli_wdr.cpp:1105 src/ServerWnd.cpp:312
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP address:"
 msgstr "IP 位址："
 
-#: src/muuli_wdr.cpp:1112
+#: src/muuli_wdr.cpp
 msgid "User ID:"
 msgstr "使用者 ID："
 
-#: src/muuli_wdr.cpp:1117
+#: src/muuli_wdr.cpp
 msgid "Server IP:"
 msgstr "伺服器 IP："
 
-#: src/muuli_wdr.cpp:1124
+#: src/muuli_wdr.cpp
 msgid "Server name:"
 msgstr "伺服器名稱："
 
-#: src/muuli_wdr.cpp:1129
+#: src/muuli_wdr.cpp
 msgid "Obfuscation:"
 msgstr "模糊協定："
 
-#: src/muuli_wdr.cpp:1136
+#: src/muuli_wdr.cpp
 msgid "Kad:"
 msgstr "Kad："
 
-#: src/muuli_wdr.cpp:1143
+#: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "傳輸"
 
-#: src/muuli_wdr.cpp:1148
+#: src/muuli_wdr.cpp
 msgid "Current request:"
 msgstr "目前要求："
 
-#: src/muuli_wdr.cpp:1158
+#: src/muuli_wdr.cpp
 msgid "Average upload rate:"
 msgstr "平均上傳速度："
 
-#: src/muuli_wdr.cpp:1165
+#: src/muuli_wdr.cpp
 msgid "Average download rate:"
 msgstr "平均下載速度："
 
-#: src/muuli_wdr.cpp:1170
+#: src/muuli_wdr.cpp
 msgid "Uploaded (session):"
 msgstr "本次上傳："
 
-#: src/muuli_wdr.cpp:1177
+#: src/muuli_wdr.cpp
 msgid "Downloaded (session):"
 msgstr "本次下載："
 
-#: src/muuli_wdr.cpp:1182
+#: src/muuli_wdr.cpp
 msgid "Uploaded (total):"
 msgstr "總計上傳："
 
-#: src/muuli_wdr.cpp:1189
+#: src/muuli_wdr.cpp
 msgid "Downloaded (total):"
 msgstr "總計下載："
 
-#: src/muuli_wdr.cpp:1196
+#: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "分數"
 
-#: src/muuli_wdr.cpp:1203
+#: src/muuli_wdr.cpp
 msgid "DL/UP modifier:"
 msgstr "下載/上傳 比率："
 
-#: src/muuli_wdr.cpp:1210
+#: src/muuli_wdr.cpp
 msgid "Secure ident:"
 msgstr "安全驗證："
 
-#: src/muuli_wdr.cpp:1215
+#: src/muuli_wdr.cpp
 msgid "Queue rank:"
 msgstr "等候排名："
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp
 msgid "Queue score:"
 msgstr "得分："
 
-#: src/muuli_wdr.cpp:1246
+#: src/muuli_wdr.cpp
 msgid "Nick"
 msgstr "暱稱"
 
-#: src/muuli_wdr.cpp:1249
+#: src/muuli_wdr.cpp
 msgid "https://amule-org.github.io - the multi-platform Mule"
 msgstr "https://amule-org.github.io - 跨平台的騾子"
 
-#: src/muuli_wdr.cpp:1250
+#: src/muuli_wdr.cpp
 msgid "This is the name that other users will see when connecting to you."
 msgstr "這是其他使用者與您連線時能看到的名字。"
 
-#: src/muuli_wdr.cpp:1256
+#: src/muuli_wdr.cpp
 msgid "Language: "
 msgstr "語言："
 
-#: src/muuli_wdr.cpp:1257 src/muuli_wdr.cpp:1330 src/muuli_wdr.cpp:1334
-#: src/muuli_wdr.cpp:1337
+#: src/muuli_wdr.cpp
 msgid "The delay before showing tool-tips."
 msgstr "顯示提示的延遲時間。"
 
-#: src/muuli_wdr.cpp:1262
+#: src/muuli_wdr.cpp
 msgid "This specifies the language used on controls."
 msgstr "選擇界面語言。"
 
-#: src/muuli_wdr.cpp:1265
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Periodically check for a new version"
 msgstr "啓動時檢查新版本"
 
-#: src/muuli_wdr.cpp:1266
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "啟用後使 aMule 在啓動時檢查新版本"
 
-#: src/muuli_wdr.cpp:1274
+#: src/muuli_wdr.cpp
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1282 packaging/windows/installer_strings.c:49
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1286 packaging/windows/installer_strings.c:50
+#: src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1293
+#: src/muuli_wdr.cpp
 msgid "Opening a collection queues every eD2k link it contains. On Windows this adds aMule to the \"Open with\" list and takes the default only when no other program has claimed the file type."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1296
+#: src/muuli_wdr.cpp
 msgid "Start minimized"
 msgstr "啟動後縮到最小"
 
-#: src/muuli_wdr.cpp:1297
+#: src/muuli_wdr.cpp
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr "啓用後使 aMule 啓動後立即最小化。"
 
-#: src/muuli_wdr.cpp:1300
+#: src/muuli_wdr.cpp
 msgid "Prompt on exit"
 msgstr "離開前先確認"
 
-#: src/muuli_wdr.cpp:1302
+#: src/muuli_wdr.cpp
 msgid "Makes aMule prompt before exiting."
 msgstr "離開 aMule 前要先確認。"
 
-#: src/muuli_wdr.cpp:1305
+#: src/muuli_wdr.cpp
 msgid "Enable Tray Icon"
 msgstr "啟用狀態列圖示"
 
-#: src/muuli_wdr.cpp:1306
+#: src/muuli_wdr.cpp
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr "啓用/停用系統狀態列圖示。"
 
-#: src/muuli_wdr.cpp:1309
+#: src/muuli_wdr.cpp
 msgid "Hide application window when close button is pressed"
 msgstr "按下關閉按鈕後隱藏應用程式視窗"
 
-#: src/muuli_wdr.cpp:1312
+#: src/muuli_wdr.cpp
 msgid "Minimize to Tray Icon"
 msgstr "縮小到狀態列圖示"
 
-#: src/muuli_wdr.cpp:1313
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule minimize to the System Tray, rather than the taskbar."
 msgstr "開啓此選項將使 aMule 最小化到系統狀態列，而不是工作列。"
 
-#: src/muuli_wdr.cpp:1316
+#: src/muuli_wdr.cpp
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1317
+#: src/muuli_wdr.cpp
 msgid "Enabling this will make aMule to show notifications when finished downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1323
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Remember search history"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:1324
+#: src/muuli_wdr.cpp
 msgid "Keeps a dropdown list of your past search terms in the Search tab's Name field. This remembers the queries you typed, not the results they returned."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1329
+#: src/muuli_wdr.cpp
 msgid "Tooltip delay time: "
 msgstr "工具提示延遲："
 
-#: src/muuli_wdr.cpp:1336
+#: src/muuli_wdr.cpp
 msgid "seconds"
 msgstr "秒"
 
-#: src/muuli_wdr.cpp:1340
+#: src/muuli_wdr.cpp
 msgid "Browser Selection"
 msgstr "瀏覽器設定"
 
-#: src/muuli_wdr.cpp:1346
+#: src/muuli_wdr.cpp
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp
 msgid "Open in new tab if possible"
 msgstr "在新分頁中開啟"
 
-#: src/muuli_wdr.cpp:1355
+#: src/muuli_wdr.cpp
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr "如果可能，在新的分頁中打開而不是新的視窗"
 
-#: src/muuli_wdr.cpp:1359
+#: src/muuli_wdr.cpp
 msgid "Video Player"
 msgstr "影片播放器"
 
-#: src/muuli_wdr.cpp:1386
+#: src/muuli_wdr.cpp
 msgid "Bandwidth limits"
 msgstr "頻寬限制"
 
-#: src/muuli_wdr.cpp:1400
+#: src/muuli_wdr.cpp
 msgid "Upload"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1408
+#: src/muuli_wdr.cpp
 msgid "Slot Allocation"
 msgstr "位置分配"
 
-#: src/muuli_wdr.cpp:1417
+#: src/muuli_wdr.cpp
 msgid "Ports"
 msgstr "通訊埠"
 
-#: src/muuli_wdr.cpp:1427
+#: src/muuli_wdr.cpp
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "標準 eD2k 通訊埠，不可停用。"
 
-#: src/muuli_wdr.cpp:1430
+#: src/muuli_wdr.cpp
 msgid "UDP port for server requests (TCP+3):"
 msgstr "伺服器要求 UDP 埠 (TCP+3)："
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1439
+#: src/muuli_wdr.cpp
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "這個 UDP 埠用於 eD2k 擴充要求與 Kad 網路"
 
-#: src/muuli_wdr.cpp:1446
+#: src/muuli_wdr.cpp
 msgid "UPnP TCP Port (Optional):"
 msgstr "UPnP TCP 埠 (選用)："
 
-#: src/muuli_wdr.cpp:1456
+#: src/muuli_wdr.cpp
 msgid "Bind local address to IP (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1459
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1462 src/muuli_wdr.cpp:2069
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
 
-#: src/muuli_wdr.cpp:1475
+#: src/muuli_wdr.cpp
 msgid "Advanced users only: pin all of aMule's traffic to one network interface, chosen from the list or typed in by name (e.g. tun0, eth0, en0) or index. Unlike binding to an IP, this stops traffic leaking out via the default route - useful with a VPN. Requires no elevated privileges."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
+#: src/muuli_wdr.cpp
 msgid "Max sources per downloading file:"
 msgstr "每個檔案最大來源數："
 
-#: src/muuli_wdr.cpp:1485
+#: src/muuli_wdr.cpp
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1498 src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
-#: src/muuli_wdr.cpp:1505
+#: src/muuli_wdr.cpp
 msgid "Autoconnect on startup"
 msgstr "啟動後自動連線"
 
-#: src/muuli_wdr.cpp:1508
+#: src/muuli_wdr.cpp
 msgid "Reconnect on loss"
 msgstr "斷線後自動重新連線"
 
-#: src/muuli_wdr.cpp:1530
+#: src/muuli_wdr.cpp
 msgid "Remove dead server after"
 msgstr "移除無法連線伺服器：如果"
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp
 msgid "Static servers are never removed, even when unreachable."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535
+#: src/muuli_wdr.cpp
 msgid "retries"
 msgstr "次重試"
 
-#: src/muuli_wdr.cpp:1543
+#: src/muuli_wdr.cpp
 msgid "List"
 msgstr "清單"
 
-#: src/muuli_wdr.cpp:1546
+#: src/muuli_wdr.cpp
 msgid "Update server list when connecting to a server"
 msgstr "連線到伺服器時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1549
+#: src/muuli_wdr.cpp
 msgid "Update server list when a client connects"
 msgstr "連線到客戶端時更新伺服器清單"
 
-#: src/muuli_wdr.cpp:1552
+#: src/muuli_wdr.cpp
 msgid "Use priority system"
 msgstr "啟用優先等級系統"
 
-#: src/muuli_wdr.cpp:1556
+#: src/muuli_wdr.cpp
 msgid "Use smart LowID check on connect"
 msgstr "連線時啟用智慧 LowID 偵測"
 
-#: src/muuli_wdr.cpp:1560
+#: src/muuli_wdr.cpp
 msgid "Safe connect"
 msgstr "安全連線"
 
-#: src/muuli_wdr.cpp:1564
+#: src/muuli_wdr.cpp
 msgid "Autoconnect to servers in static list only"
 msgstr "只自動連線到靜態伺服器清單裏的伺服器"
 
-#: src/muuli_wdr.cpp:1567
+#: src/muuli_wdr.cpp
 msgid "Set manually added servers to High Priority"
 msgstr "手動輸入的伺服器設為高優先等級"
 
-#: src/muuli_wdr.cpp:1588
+#: src/muuli_wdr.cpp
 msgid "Add files to download in pause mode"
 msgstr "加入新下載檔案時設為暫停狀態"
 
-#: src/muuli_wdr.cpp:1590
+#: src/muuli_wdr.cpp
 msgid "Add files to download with auto priority"
 msgstr "加入新下載檔案時設定優先等級為自動狀態"
 
-#: src/muuli_wdr.cpp:1593
+#: src/muuli_wdr.cpp
 msgid "Try to download first and last chunks first"
 msgstr "嘗試先下載檔案的第一段和最後一段"
 
-#: src/muuli_wdr.cpp:1597
+#: src/muuli_wdr.cpp
 msgid "Endgame mode: rotate to faster sources for the final blocks"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1600
+#: src/muuli_wdr.cpp
 msgid "Start next paused file when a file completes"
 msgstr "完成後自動傳輸下一個暫停的檔案"
 
-#: src/muuli_wdr.cpp:1603
+#: src/muuli_wdr.cpp
 msgid "From the same category"
 msgstr "同一分類檔案"
 
-#: src/muuli_wdr.cpp:1605
+#: src/muuli_wdr.cpp
 msgid "In alphabetic order"
 msgstr "依字母順序"
 
-#: src/muuli_wdr.cpp:1607
+#: src/muuli_wdr.cpp
 msgid "Preallocate disk space for new files"
 msgstr "新檔案預先分配磁碟空間"
 
-#: src/muuli_wdr.cpp:1608
+#: src/muuli_wdr.cpp
 msgid "For new files preallocates disk space for the whole file, thus reduces fragmentation"
 msgstr "新檔案預先分配所需的完整磁碟空間，這樣可以減少檔案分散度"
 
-#: src/muuli_wdr.cpp:1621
+#: src/muuli_wdr.cpp
 msgid "Create new files as sparse files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1622
+#: src/muuli_wdr.cpp
 msgid "Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1627
+#: src/muuli_wdr.cpp
 msgid "Stop downloads when free disk space reaches "
 msgstr "磁碟可用空間不足時停止下載"
 
-#: src/muuli_wdr.cpp:1628
+#: src/muuli_wdr.cpp
 msgid "Select this if you want aMule to check your disk space"
 msgstr "讓 aMule 檢查磁碟可用空間"
 
-#: src/muuli_wdr.cpp:1632
+#: src/muuli_wdr.cpp
 msgid "Enter here the min disk space desired."
 msgstr "請輸入最小磁碟可用空間。"
 
-#: src/muuli_wdr.cpp:1638
+#: src/muuli_wdr.cpp
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr "為來源稀少 (< 20) 的檔案儲存 10 個來源"
 
-#: src/muuli_wdr.cpp:1642 src/Statistics.cpp:790
+#: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Uploads"
 msgstr "上傳"
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp
 msgid "Add new shared files with auto priority"
 msgstr "新加入分享檔案優先等級設定為自動"
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr "智慧型損壞處理 (I.C.H.)"
 
-#: src/muuli_wdr.cpp:1654
+#: src/muuli_wdr.cpp
 msgid "Enable"
 msgstr "啟用"
 
-#: src/muuli_wdr.cpp:1657
+#: src/muuli_wdr.cpp
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr "進階 I.C.H. 信任所有 hash 值 (不建議)"
 
-#: src/muuli_wdr.cpp:1669 src/PrefsUnifiedDlg.cpp:2025
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Media metadata extraction"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1673
+#: src/muuli_wdr.cpp
 msgid "Extract length / bitrate / codec from shared audio and video files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1675
+#: src/muuli_wdr.cpp
 msgid "When enabled, aMule runs ffprobe on each shared media file to fill in the Length / Bitrate / Codec columns other clients see when they find the file in a search. Requires ffmpeg (the ffprobe binary) to be installed."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1682
+#: src/muuli_wdr.cpp
 msgid "Path to ffprobe:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1687
+#: src/muuli_wdr.cpp
 msgid "Full path to the ffprobe binary. Leave empty to have aMule auto-detect it on startup."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1695
+#: src/muuli_wdr.cpp
 msgid "Detect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1720
+#: src/muuli_wdr.cpp
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
 "If this folder also holds files you don't want to share, point it at an aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1723
+#: src/muuli_wdr.cpp
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1737
+#: src/muuli_wdr.cpp
 msgid "Shared folders"
 msgstr "分享資料夾"
 
-#: src/muuli_wdr.cpp:1743
+#: src/muuli_wdr.cpp
 msgid "(Folders shared by the core. Enter a path to add one.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1751
+#: src/muuli_wdr.cpp
 msgid "Absolute path of a folder on the core's machine, e.g. /home/user/shared"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753 src/PrefsUnifiedDlg.cpp:2924
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "Recursive"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1754
+#: src/muuli_wdr.cpp
 msgid "Share every sub-folder underneath this one, including ones created later."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1758 src/utils/aLinkCreator/src/alcframe.cpp:141
+#: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Remove"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:1762
+#: src/muuli_wdr.cpp
 msgid "(Right click on folder icon for recursive share)"
 msgstr "(滑鼠右鍵點選檔案夾圖示可全部遞迴分享)"
 
-#: src/muuli_wdr.cpp:1769
+#: src/muuli_wdr.cpp
 msgid "Share hidden files"
 msgstr "分享隱藏檔"
 
-#: src/muuli_wdr.cpp:1775
+#: src/muuli_wdr.cpp
 msgid "Automatically rescan shared folders for changes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1781
+#: src/muuli_wdr.cpp
 msgid "Follow symbolic links in shared folders"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1787
+#: src/muuli_wdr.cpp
 msgid "Exclude files matching:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1790
+#: src/muuli_wdr.cpp
 msgid "Wildcard patterns separated by '|', e.g. .DS_Store|Thumbs.db|*.tmp. Files whose name matches are not shared. Matching is case-insensitive."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1794
+#: src/muuli_wdr.cpp
 msgid "Patterns are regular expressions"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp
 msgid "When set, the whole field is one regular expression ('|' is alternation). When unset, it is a list of '|'-separated wildcards."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1805
+#: src/muuli_wdr.cpp
 msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1826
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "圖表"
 
-#: src/muuli_wdr.cpp:1829 src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp
 msgid "Update delay : 5 secs"
 msgstr "更新延遲時間：5 秒"
 
-#: src/muuli_wdr.cpp:1833
+#: src/muuli_wdr.cpp
 msgid "Time for average graph: 100 mins"
 msgstr "平均圖表顯示時間：100 分鐘"
 
-#: src/muuli_wdr.cpp:1837
+#: src/muuli_wdr.cpp
 msgid "Connections Graph Scale: 100 "
 msgstr "連線圖表比例：100 "
 
-#: src/muuli_wdr.cpp:1844
+#: src/muuli_wdr.cpp
 msgid "Download graph scale:"
 msgstr "下載統計圖比例："
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp
 msgid "Upload graph scale:"
 msgstr "上傳統計圖比例："
 
-#: src/muuli_wdr.cpp:1862
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Colors: "
 msgstr "顏色："
 
-#: src/muuli_wdr.cpp:1866
+#: src/muuli_wdr.cpp
 msgid "Background"
 msgstr "背景"
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp
 msgid "Grid"
 msgstr "格線"
 
-#: src/muuli_wdr.cpp:1868
+#: src/muuli_wdr.cpp
 msgid "Download current"
 msgstr "目前下載"
 
-#: src/muuli_wdr.cpp:1869
+#: src/muuli_wdr.cpp
 msgid "Download running average"
 msgstr "執行中平均下載"
 
-#: src/muuli_wdr.cpp:1870
+#: src/muuli_wdr.cpp
 msgid "Download session average"
 msgstr "本次平均下載"
 
-#: src/muuli_wdr.cpp:1871
+#: src/muuli_wdr.cpp
 msgid "Upload current"
 msgstr "目前上傳"
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp
 msgid "Upload running average"
 msgstr "執行中平均上傳"
 
-#: src/muuli_wdr.cpp:1873
+#: src/muuli_wdr.cpp
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp:1874
+#: src/muuli_wdr.cpp
 msgid "Active connections"
 msgstr "目前連線數"
 
-#: src/muuli_wdr.cpp:1877
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "狀態列圖示顯示速度"
 
-#: src/muuli_wdr.cpp:1878
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes current"
 msgstr "目前 Kad 節點"
 
-#: src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes running"
 msgstr "執行中 Kad 節點"
 
-#: src/muuli_wdr.cpp:1880
+#: src/muuli_wdr.cpp
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1884 src/muuli_wdr.cpp:2338
+#: src/muuli_wdr.cpp
 msgid "Select"
 msgstr "選取"
 
-#: src/muuli_wdr.cpp:1888
+#: src/muuli_wdr.cpp
 msgid "Tree"
 msgstr "樹狀"
 
-#: src/muuli_wdr.cpp:1898
+#: src/muuli_wdr.cpp
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr "顯示客戶端版本的數量 ( 0 代表不限制)"
 
-#: src/muuli_wdr.cpp:1923
+#: src/muuli_wdr.cpp
 msgid "!!! WARNING !!!"
 msgstr "!!! 警告 !!!"
 
-#: src/muuli_wdr.cpp:1938
+#: src/muuli_wdr.cpp
 msgid "Max new connections / 5 secs"
 msgstr "5 秒內最大新連線數"
 
-#: src/muuli_wdr.cpp:1940
+#: src/muuli_wdr.cpp
 msgid "Concurrent Kad source lookups"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Kad source re-search interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1944
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source re-ask interval (minutes)"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/muuli_wdr.cpp:1948
+#: src/muuli_wdr.cpp
 msgid "File Buffer Size: 240000 bytes"
 msgstr "檔案緩衝區：240.000 KB"
 
-#: src/muuli_wdr.cpp:1952
+#: src/muuli_wdr.cpp
 msgid "Use MMAP: memory-mapped file access (lower memory use)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1953
+#: src/muuli_wdr.cpp
 msgid "Maps part files into memory instead of buffering them on the heap, lowering the process memory footprint. May reduce download speed on some disks; best for memory-constrained or upload-heavy hosts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1955
+#: src/muuli_wdr.cpp
 msgid "Upload Queue Size: 5000 clients"
 msgstr "上傳等候區大小：5000 "
 
-#: src/muuli_wdr.cpp:1959
+#: src/muuli_wdr.cpp
 msgid "Server connection refresh interval: Disable"
 msgstr "伺服器連線更新間隔時間：停用"
 
-#: src/muuli_wdr.cpp:1963
+#: src/muuli_wdr.cpp
 msgid "Disable computer's timed standby mode"
 msgstr "停用電腦的自動進入待命模式功能"
 
-#: src/muuli_wdr.cpp:1982
+#: src/muuli_wdr.cpp
 msgid "Skin to use: "
 msgstr "使用面板："
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr "在每個視窗顯示「eD2k 連結快速處理器」。"
 
-#: src/muuli_wdr.cpp:1994
+#: src/muuli_wdr.cpp
 msgid "Show extended info on categories tabs"
 msgstr "在分類頁中顯示擴充資訊"
 
-#: src/muuli_wdr.cpp:1997
+#: src/muuli_wdr.cpp
 msgid "Show application version on title"
 msgstr "在標題顯示應用程式版本"
 
-#: src/muuli_wdr.cpp:1999
+#: src/muuli_wdr.cpp
 msgid "Show transfer rates on title"
 msgstr "標題列顯示傳輸速度"
 
-#: src/muuli_wdr.cpp:2001
+#: src/muuli_wdr.cpp
 msgid "Before application name"
 msgstr "在程式名稱前"
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp
 msgid "After application name"
 msgstr "在程式名稱後"
 
-#: src/muuli_wdr.cpp:2006
+#: src/muuli_wdr.cpp
 msgid "Show overhead bandwidth"
 msgstr "顯示額外支出頻寬"
 
-#: src/muuli_wdr.cpp:2010
+#: src/muuli_wdr.cpp
 msgid "Vertical toolbar orientation"
 msgstr "垂直顯示工具列"
 
-#: src/muuli_wdr.cpp:2012
+#: src/muuli_wdr.cpp
 msgid "Live column sorting (auto-reorder rows as their values change)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2019
+#: src/muuli_wdr.cpp
 msgid "Download Queue Files"
 msgstr "下載等候區檔案"
 
-#: src/muuli_wdr.cpp:2022
+#: src/muuli_wdr.cpp
 msgid "Show progress percentage"
 msgstr "顯示進度百分比"
 
-#: src/muuli_wdr.cpp:2028
+#: src/muuli_wdr.cpp
 msgid "Show progress bar"
 msgstr "顯示進度條"
 
-#: src/muuli_wdr.cpp:2031
+#: src/muuli_wdr.cpp
 msgid "Flat"
 msgstr "扁平"
 
-#: src/muuli_wdr.cpp:2035
+#: src/muuli_wdr.cpp
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2053
+#: src/muuli_wdr.cpp
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2056
+#: src/muuli_wdr.cpp
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2063 src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2066
+#: src/muuli_wdr.cpp
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2198
+#: src/muuli_wdr.cpp
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2097 src/muuli_wdr.cpp:3095
-#: src/utils/wxCas/src/wxcasprefs.cpp:167
+#: src/muuli_wdr.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2103
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2106
+#: src/muuli_wdr.cpp
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2125
+#: src/muuli_wdr.cpp
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2130
+#: src/muuli_wdr.cpp
 msgid "Type a password to set or change it. Stored passwords cannot be shown, so leaving this empty keeps the current one."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2144 src/muuli_wdr.cpp:2161 src/PrefsUnifiedDlg.cpp:1138
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "A password is set."
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2148
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Enable guest access"
 msgstr "拒絕訪客連線"
 
-#: src/muuli_wdr.cpp:2149
+#: src/muuli_wdr.cpp
 msgid "Guest sessions may read status and listings but cannot change anything. Turning this off clears the stored guest password."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2153
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Guest password"
 msgstr "網站伺服器的 訪客密碼"
 
-#: src/muuli_wdr.cpp:2168
+#: src/muuli_wdr.cpp
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2171
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2177
+#: src/muuli_wdr.cpp
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2186
+#: src/muuli_wdr.cpp
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2191
+#: src/muuli_wdr.cpp
 msgid "Low rights password"
 msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2205
+#: src/muuli_wdr.cpp
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2259
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2260
+#: src/muuli_wdr.cpp
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2262 src/muuli_wdr.cpp:2348 src/ServerWnd.cpp:277
-#: src/ServerWnd.cpp:285
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2267
+#: src/muuli_wdr.cpp
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2296
+#: src/muuli_wdr.cpp
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2312
+#: src/muuli_wdr.cpp
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2316
+#: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2328
+#: src/muuli_wdr.cpp
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2395 src/muuli_wdr.cpp:2414 src/muuli_wdr.cpp:2436
+#: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2455
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2459
+#: src/muuli_wdr.cpp
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2463
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2468
+#: src/muuli_wdr.cpp
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2471
+#: src/muuli_wdr.cpp
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2473 src/ServerWnd.cpp:209
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2485
+#: src/muuli_wdr.cpp
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2517
+#: src/muuli_wdr.cpp
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2529
+#: src/muuli_wdr.cpp
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2561
+#: src/muuli_wdr.cpp
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2565
+#: src/muuli_wdr.cpp
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2569
+#: src/muuli_wdr.cpp
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2572
+#: src/muuli_wdr.cpp
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2614
+#: src/muuli_wdr.cpp
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2617
+#: src/muuli_wdr.cpp
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2622
+#: src/muuli_wdr.cpp
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2642
+#: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2655
+#: src/muuli_wdr.cpp
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2702
+#: src/muuli_wdr.cpp
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2704
+#: src/muuli_wdr.cpp
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2707
+#: src/muuli_wdr.cpp
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2709
+#: src/muuli_wdr.cpp
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2711
+#: src/muuli_wdr.cpp
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2713
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2715
+#: src/muuli_wdr.cpp
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2716
+#: src/muuli_wdr.cpp
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2721
+#: src/muuli_wdr.cpp
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2723
+#: src/muuli_wdr.cpp
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2725
+#: src/muuli_wdr.cpp
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2726
+#: src/muuli_wdr.cpp
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2728
+#: src/muuli_wdr.cpp
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2737
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2739
+#: src/muuli_wdr.cpp
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2745
+#: src/muuli_wdr.cpp
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2746
+#: src/muuli_wdr.cpp
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2752
+#: src/muuli_wdr.cpp
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2756 src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2763
+#: src/muuli_wdr.cpp
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2769
+#: src/muuli_wdr.cpp
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2772
+#: src/muuli_wdr.cpp
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2776
+#: src/muuli_wdr.cpp
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2777
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2794
+#: src/muuli_wdr.cpp
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2803
+#: src/muuli_wdr.cpp
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2811
+#: src/muuli_wdr.cpp
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2817
+#: src/muuli_wdr.cpp
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2850
+#: src/muuli_wdr.cpp
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2851
+#: src/muuli_wdr.cpp
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2856
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2872
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2875
+#: src/muuli_wdr.cpp
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2880
+#: src/muuli_wdr.cpp
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2897
+#: src/muuli_wdr.cpp
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4857,11 +4769,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2910
+#: src/muuli_wdr.cpp
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4871,823 +4783,823 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2931
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2937
+#: src/muuli_wdr.cpp
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2950
+#: src/muuli_wdr.cpp
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2952
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2953
+#: src/muuli_wdr.cpp
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2978
+#: src/muuli_wdr.cpp
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2980
+#: src/muuli_wdr.cpp
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2982
+#: src/muuli_wdr.cpp
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2984
+#: src/muuli_wdr.cpp
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2987 src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2989
+#: src/muuli_wdr.cpp
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2992
+#: src/muuli_wdr.cpp
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2995
+#: src/muuli_wdr.cpp
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:3020
+#: src/muuli_wdr.cpp
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:3021
+#: src/muuli_wdr.cpp
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:3024
+#: src/muuli_wdr.cpp
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:3035
+#: src/muuli_wdr.cpp
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:3038
+#: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:3040
+#: src/muuli_wdr.cpp
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:3043
+#: src/muuli_wdr.cpp
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:3045
+#: src/muuli_wdr.cpp
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:3046
+#: src/muuli_wdr.cpp
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:3049
+#: src/muuli_wdr.cpp
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:3057
+#: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:3076
+#: src/muuli_wdr.cpp
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3085
+#: src/muuli_wdr.cpp
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3090
+#: src/muuli_wdr.cpp
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3104
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3128
+#: src/muuli_wdr.cpp
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3130
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3132
+#: src/muuli_wdr.cpp
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3156 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp src/PartFileConvertDlg.cpp
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3176
+#: src/muuli_wdr.cpp
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3179
+#: src/muuli_wdr.cpp
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3181
+#: src/muuli_wdr.cpp
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3244
+#: src/muuli_wdr.cpp
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3287
+#: src/muuli_wdr.cpp
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3301
+#: src/muuli_wdr.cpp
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3353
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3355
+#: src/muuli_wdr.cpp
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3358
+#: src/muuli_wdr.cpp
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3361
+#: src/muuli_wdr.cpp
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3368
+#: src/muuli_wdr.cpp
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3372
+#: src/muuli_wdr.cpp
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3435
+#: src/muuli_wdr.cpp
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3436
+#: src/muuli_wdr.cpp
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3440
+#: src/muuli_wdr.cpp
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3463
+#: src/muuli_wdr.cpp
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3469 src/SharedFilesCtrl.cpp:142 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "分享檔案"
 
-#: src/OScopeCtrl.cpp:239
+#: src/OScopeCtrl.cpp
 #, c-format
 msgid "Disabled [%s]"
 msgstr "已停用 [%s]"
 
-#: src/OtherFunctions.cpp:60
+#: src/OtherFunctions.cpp
 msgid "byte"
 msgid_plural "bytes"
 msgstr[0] "B"
 
-#: src/OtherFunctions.cpp:62
+#: src/OtherFunctions.cpp
 msgid "kB"
 msgstr "KB"
 
-#: src/OtherFunctions.cpp:68
+#: src/OtherFunctions.cpp
 msgid "TB"
 msgstr "TB"
 
-#: src/OtherFunctions.cpp:77
+#: src/OtherFunctions.cpp
 msgid "k"
 msgstr "K"
 
-#: src/OtherFunctions.cpp:79
+#: src/OtherFunctions.cpp
 msgid "M"
 msgstr "M"
 
-#: src/OtherFunctions.cpp:81
+#: src/OtherFunctions.cpp
 msgid "G"
 msgstr "G"
 
-#: src/OtherFunctions.cpp:83
+#: src/OtherFunctions.cpp
 msgid "T"
 msgstr "T"
 
-#: src/OtherFunctions.cpp:89
+#: src/OtherFunctions.cpp
 msgid "byte/sec"
 msgid_plural "bytes/sec"
 msgstr[0] "B/s"
 
-#: src/OtherFunctions.cpp:93
+#: src/OtherFunctions.cpp
 msgid "MB/s"
 msgstr "MB/s"
 
-#: src/OtherFunctions.cpp:101 src/OtherFunctions.cpp:103
+#: src/OtherFunctions.cpp
 msgid "secs"
 msgstr "秒"
 
-#: src/OtherFunctions.cpp:106
+#: src/OtherFunctions.cpp
 msgid "mins"
 msgstr "分"
 
-#: src/OtherFunctions.cpp:108 src/OtherFunctions.cpp:111
+#: src/OtherFunctions.cpp
 msgid "hours"
 msgstr "時"
 
-#: src/OtherFunctions.cpp:110
+#: src/OtherFunctions.cpp
 msgid "days"
 msgstr "天"
 
-#: src/OtherFunctions.cpp:687
+#: src/OtherFunctions.cpp
 msgid "all"
 msgstr "全部"
 
-#: src/OtherFunctions.cpp:689
+#: src/OtherFunctions.cpp
 msgid "all others"
 msgstr "其它"
 
-#: src/OtherFunctions.cpp:691 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Incomplete"
 msgstr "不完整"
 
-#: src/OtherFunctions.cpp:703 src/PartFile.cpp:4390 src/TransferWnd.cpp:354
+#: src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Stopped"
 msgstr "已停止"
 
-#: src/OtherFunctions.cpp:705 src/TransferWnd.cpp:359
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Video"
 msgstr "影片"
 
-#: src/OtherFunctions.cpp:709 src/TransferWnd.cpp:361
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Archive"
 msgstr "壓縮檔"
 
-#: src/OtherFunctions.cpp:715 src/TransferWnd.cpp:364
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Text"
 msgstr "文件"
 
-#: src/OtherFunctions.cpp:717 src/TransferWnd.cpp:355
+#: src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Active"
 msgstr "啟動"
 
-#: src/OtherFunctions.cpp:1509
+#: src/OtherFunctions.cpp
 #, c-format
 msgid "Using config dir: %s"
 msgstr "使用設定目錄：%s"
 
-#: src/PartFileConvert.cpp:165
+#: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "正在等候暫存檔轉換執行緒終止..."
 
-#: src/PartFileConvert.cpp:209
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Importing %s: %s"
 msgstr "正在匯入 %s：%s"
 
-#: src/PartFileConvert.cpp:246
+#: src/PartFileConvert.cpp
 msgid "Reading temp folder"
 msgstr "正在讀取暫存資料夾"
 
-#: src/PartFileConvert.cpp:250
+#: src/PartFileConvert.cpp
 msgid "Retrieving basic information from download info file"
 msgstr "正在從下載資訊檔取得基本資訊"
 
-#: src/PartFileConvert.cpp:329
+#: src/PartFileConvert.cpp
 msgid "Creating destination file"
 msgstr "正在建立目標檔案"
 
-#: src/PartFileConvert.cpp:340
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Loading data from old download file (%u of %u)"
 msgstr "正在從舊下載檔案載入資料 (%u / %u)"
 
-#: src/PartFileConvert.cpp:360
+#: src/PartFileConvert.cpp
 #, c-format
 msgid "Saving data block into new single download file (%u of %u)"
 msgstr "正在將資料區塊儲存到新的單一下載檔案 (%u / %u)"
 
-#: src/PartFileConvert.cpp:426
+#: src/PartFileConvert.cpp
 msgid "Retrieving source downloadfile information"
 msgstr "正在取得來源下載檔案資訊"
 
-#: src/PartFileConvert.cpp:449
+#: src/PartFileConvert.cpp
 msgid "Adding download and saving new partfile"
 msgstr "正在加入下載和儲存新暫存檔"
 
-#: src/PartFileConvertDlg.cpp:86
+#: src/PartFileConvertDlg.cpp
 msgid "Import partfiles"
 msgstr "匯入暫存檔"
 
-#: src/PartFileConvertDlg.cpp:97
+#: src/PartFileConvertDlg.cpp
 msgid "State"
 msgstr "狀態"
 
-#: src/PartFileConvertDlg.cpp:99
+#: src/PartFileConvertDlg.cpp
 msgid "Filehash"
 msgstr "檔案 hash 值"
 
-#: src/PartFileConvertDlg.cpp:190
+#: src/PartFileConvertDlg.cpp
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr "%s (磁碟：%s)"
 
-#: src/PartFileConvertDlg.cpp:216
+#: src/PartFileConvertDlg.cpp
 msgid "Please choose a folder to search for temporary downloads! (subfolders will be included)"
 msgstr "請選擇要搜尋暫存檔的資料夾！ (底下的子資料夾將一併處理)"
 
-#: src/PartFileConvertDlg.cpp:223
+#: src/PartFileConvertDlg.cpp
 #, fuzzy
 msgid "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "要刪除已成功匯入下載的來源檔嗎？"
 
-#: src/PartFileConvertDlg.cpp:224
+#: src/PartFileConvertDlg.cpp
 msgid "Remove sources?"
 msgstr "刪除來源？"
 
-#: src/PartFile.cpp:367
+#: src/PartFile.cpp
 msgid "ERROR: Failed to create partfile"
 msgstr "錯誤：無法建立暫存檔"
 
-#: src/PartFile.cpp:406
+#: src/PartFile.cpp
 #, c-format
 msgid "Trying to load backup of met-file from %s"
 msgstr "嘗試使用在 %s 的 met 設定檔備份檔"
 
-#: src/PartFile.cpp:412
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open part.met file: %s ==> %s"
 msgstr "錯誤：無法開啟 part.met 檔案：%s ==> %s"
 
-#: src/PartFile.cpp:417
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: part.met file is 0 size: %s ==> %s"
 msgstr "錯誤：part.met 檔案大小為 0：%s ==> %s"
 
-#: src/PartFile.cpp:428
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr "錯誤：無效的 part.met 檔案版本：%s ==> %s"
 
-#: src/PartFile.cpp:668
+#: src/PartFile.cpp
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr "錯誤：%s (%s) 已經損壞 (錯誤的標記：%s )，無法載入檔案。"
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr "錯誤：%s (%s) 已經損壞 (標記數錯誤)，無法載入。"
 
-#: src/PartFile.cpp:678
+#: src/PartFile.cpp
 msgid "Trying to recover file info..."
 msgstr "嘗試復原檔案資訊中..."
 
-#: src/PartFile.cpp:692
+#: src/PartFile.cpp
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr "嘗試復原無名檔案 - 將存爲 RecoveredFile.dat"
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr "已復原所有檔案資訊 :D - 嘗試使用中..."
 
-#: src/PartFile.cpp:699
+#: src/PartFile.cpp
 msgid "Unable to recover file info :("
 msgstr "無法復原檔案資訊 :("
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr "無法開啟 %s (%s)"
 
-#: src/PartFile.cpp:786
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr "警告：%s 可能已經損壞 (%i)"
 
-#: src/PartFile.cpp:1007
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr "儲存暫存檔時發生錯誤：%s (%s => %s)"
 
-#: src/PartFile.cpp:1014
+#: src/PartFile.cpp
 msgid "IO failure while saving partfile: "
 msgstr "儲存暫存檔時發生 IO 錯誤："
 
-#: src/PartFile.cpp:1029
+#: src/PartFile.cpp
 #, c-format
 msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:1109
+#: src/PartFile.cpp
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr "無法儲存 %s 的 part.met.seeds 檔案"
 
-#: src/PartFile.cpp:1140
+#: src/PartFile.cpp
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "已儲存 %i 個來源種子給暫存檔 %s (%s)"
 
-#: src/PartFile.cpp:1170
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr "已儲存 %i 個來源種子給暫存檔 %s (%s)"
 
-#: src/PartFile.cpp:1228
+#: src/PartFile.cpp
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr "讀取暫存檔的種子檔案 (%s - %s) 時出錯：%s"
 
-#: src/PartFile.cpp:1254 src/PartFile.cpp:1278
+#: src/PartFile.cpp
 #, c-format
 msgid "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |%s|"
 msgid_plural "Found corrupted part (%d) in %d parts file %s - FileResultHash |%s| FileHash |%s|"
 msgstr[0] "找到損壞 (%d) 的 %d 個暫存檔 %s - 檔案結果 hash 值 |%s| 檔案 hash 值 |%s|"
 
-#: src/PartFile.cpp:1303
+#: src/PartFile.cpp
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr "找到已完成的暫存檔 %i 在 %s"
 
-#: src/PartFile.cpp:1332
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished rehashing %s"
 msgstr "已重新計算完成 %s 的 hash 值"
 
-#: src/PartFile.cpp:2349
+#: src/PartFile.cpp
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr "計算 %s 時發生意外的錯誤，暫停檔案處理"
 
-#: src/PartFile.cpp:2393
+#: src/PartFile.cpp
 #, c-format
 msgid "Finished downloading: %s"
 msgstr "下載完成：%s"
 
-#: src/PartFile.cpp:2398
+#: src/PartFile.cpp
 #, fuzzy, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr "下載完成：%s"
 
-#: src/PartFile.cpp:2457
+#: src/PartFile.cpp
 #, c-format
 msgid "Deleting file: %s"
 msgstr "正刪除檔案：%s "
 
-#: src/PartFile.cpp:2536
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr "警告：無法計算已下載部份的 hash 值 - %s 的 hash 值組不完整"
 
-#: src/PartFile.cpp:2541
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should never happen"
 msgstr "錯誤：無法計算已下載部分的 hash 值 - %s 的 hash 值組不完整，這個狀況不該發生"
 
-#: src/PartFile.cpp:2564
+#: src/PartFile.cpp
 #, c-format
 msgid "Part %u of '%s' marked complete but partfile is shorter than expected (have %llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2576 src/PartFile.cpp:2583
+#: src/PartFile.cpp
 #, c-format
 msgid "EOF while hashing downloaded part %u with length %u (max %u) of partfile '%s' with length %u: %s"
 msgstr "計算下載部份 %u (長度 %u / 最大 %u) - 暫存檔 %s (長度 %u) 的 hash 值時出現檔案結束碼：%s"
 
-#: src/PartFile.cpp:3342
+#: src/PartFile.cpp
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr "警告：磁碟可用空間不足！暫停檔案：%s "
 
-#: src/PartFile.cpp:3676
+#: src/PartFile.cpp
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr "已下載的部份 %i 已損壞 (檔案：%s)"
 
-#: src/PartFile.cpp:3724
+#: src/PartFile.cpp
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr "ICH：已修復損壞的部份 %i (%s) -> 救回 %s"
 
-#: src/PartFile.cpp:4363
+#: src/PartFile.cpp
 msgid "Allocating"
 msgstr "正在分配"
 
-#: src/PartFile.cpp:4379
+#: src/PartFile.cpp
 msgid "Insufficient disk space"
 msgstr "磁碟空間不足"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
-#: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
+#: src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下載"
 
-#: src/PartFile.cpp:4693
+#: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:713
+#: src/Preferences.cpp
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:714
+#: src/Preferences.cpp
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:715
+#: src/Preferences.cpp
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:716
+#: src/Preferences.cpp
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:717
+#: src/Preferences.cpp
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:718
+#: src/Preferences.cpp
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:719
+#: src/Preferences.cpp
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:720
+#: src/Preferences.cpp
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:721
+#: src/Preferences.cpp
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:722
+#: src/Preferences.cpp
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:723
+#: src/Preferences.cpp
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:724
+#: src/Preferences.cpp
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:725
+#: src/Preferences.cpp
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:726
+#: src/Preferences.cpp
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:727
+#: src/Preferences.cpp
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:729
+#: src/Preferences.cpp
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:730
+#: src/Preferences.cpp
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:731
+#: src/Preferences.cpp
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:732
+#: src/Preferences.cpp
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:733
+#: src/Preferences.cpp
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:734
+#: src/Preferences.cpp
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:735
+#: src/Preferences.cpp
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:736
+#: src/Preferences.cpp
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:737
+#: src/Preferences.cpp
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:738
+#: src/Preferences.cpp
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:739
+#: src/Preferences.cpp
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:842
+#: src/Preferences.cpp
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:906
+#: src/Preferences.cpp
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:907
+#: src/Preferences.cpp
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:1038
+#: src/Preferences.cpp
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:2227
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2396
+#: src/Preferences.cpp
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2397
+#: src/Preferences.cpp
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
 
-#: src/PrefsUnifiedDlg.cpp:303 src/Statistics.cpp:866
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Connection"
 msgstr "連線"
 
-#: src/PrefsUnifiedDlg.cpp:304 src/SearchListCtrl.cpp:117
+#: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "目錄"
 
-#: src/PrefsUnifiedDlg.cpp:305 src/Statistics.cpp:917
+#: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:306 src/ServerListCtrl.cpp:96
+#: src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
 msgid "Files"
 msgstr "檔案"
 
-#: src/PrefsUnifiedDlg.cpp:307
+#: src/PrefsUnifiedDlg.cpp
 msgid "Security"
 msgstr "安全"
 
-#: src/PrefsUnifiedDlg.cpp:308
+#: src/PrefsUnifiedDlg.cpp
 msgid "Interface"
 msgstr "介面"
 
-#: src/PrefsUnifiedDlg.cpp:315
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:318
+#: src/PrefsUnifiedDlg.cpp
 msgid "Proxy"
 msgstr "代理伺服器"
 
-#: src/PrefsUnifiedDlg.cpp:319
+#: src/PrefsUnifiedDlg.cpp
 msgid "Filters"
 msgstr "過濾"
 
-#: src/PrefsUnifiedDlg.cpp:320
+#: src/PrefsUnifiedDlg.cpp
 msgid "Remote Controls"
 msgstr "遠端控制"
 
-#: src/PrefsUnifiedDlg.cpp:321
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signature"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:322
+#: src/PrefsUnifiedDlg.cpp
 msgid "Advanced"
 msgstr "進階"
 
-#: src/PrefsUnifiedDlg.cpp:323
+#: src/PrefsUnifiedDlg.cpp
 msgid "Events"
 msgstr "事件"
 
-#: src/PrefsUnifiedDlg.cpp:326
+#: src/PrefsUnifiedDlg.cpp
 msgid "Debugging"
 msgstr "除錯"
 
-#: src/PrefsUnifiedDlg.cpp:476
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
@@ -5697,15 +5609,15 @@ msgstr ""
 "    %PARTFILE - 檔案的完整路徑\n"
 "    %PARTNAME - 只有檔案名稱"
 
-#: src/PrefsUnifiedDlg.cpp:497
+#: src/PrefsUnifiedDlg.cpp
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:513
+#: src/PrefsUnifiedDlg.cpp
 msgid "Not available on Wayland: the protocol does not report when a window is minimized, so this option cannot intercept the system minimize button. Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:559
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5720,35 +5632,35 @@ msgstr ""
 "\n"
 "即使不變更這些設定，aMule 一樣可以正常運作。"
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將 Cfg 與 widget 相連"
 
-#: src/PrefsUnifiedDlg.cpp:730
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 將資料 Cfg 與 widget 連線"
 
-#: src/PrefsUnifiedDlg.cpp:836
+#: src/PrefsUnifiedDlg.cpp
 msgid "The type of proxy you are connecting to"
 msgstr "正在連線的代理伺服器類型"
 
-#: src/PrefsUnifiedDlg.cpp:1055
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr "無法以 ID %d、key %s 從 Cfg 傳輸資料到 Widget"
 
-#: src/PrefsUnifiedDlg.cpp:1138
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "No password set."
 msgstr "正在檢查密碼\n"
 
-#: src/PrefsUnifiedDlg.cpp:1167
+#: src/PrefsUnifiedDlg.cpp
 msgid "Guest access needs a password. Type one in the guest password field, or untick Enable guest access."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1179
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
@@ -5756,42 +5668,42 @@ msgstr ""
 "請重新啟動 aMule，變更的設定才能生效：\n"
 "\n"
 
-#: src/PrefsUnifiedDlg.cpp:1186
+#: src/PrefsUnifiedDlg.cpp
 msgid "- TCP port changed.\n"
 msgstr "- TCP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1191
+#: src/PrefsUnifiedDlg.cpp
 msgid "- UDP port changed.\n"
 msgstr "- UDP 埠已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1196
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Network interface binding changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1201
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect port changed.\n"
 msgstr "- 已變更外部連線埠設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1205
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect acceptance changed.\n"
 msgstr "- 已變更外部連線設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1209
+#: src/PrefsUnifiedDlg.cpp
 msgid "- External connect interface changed.\n"
 msgstr "- 已變更外部連線介面設定。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
 msgstr "模糊協定"
 
-#: src/PrefsUnifiedDlg.cpp:1228
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "- amuleapi settings changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1237
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
@@ -5799,7 +5711,7 @@ msgstr ""
 "您的自動更新伺服器清單是空的。\n"
 "「啟動時自動更新伺服器清單」功能將被停用。"
 
-#: src/PrefsUnifiedDlg.cpp:1248
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
@@ -5807,33 +5719,33 @@ msgstr ""
 "您已經設定啓用外部連線但還沒有輸入密碼，\n"
 "輸入有效密碼之後，外部連線才能開始使用。"
 
-#: src/PrefsUnifiedDlg.cpp:1281
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "The amuleapi password could not be saved: %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Language changed.\n"
 msgstr "- 語言已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1316
+#: src/PrefsUnifiedDlg.cpp
 msgid "- Temp folder changed.\n"
 msgstr "- 暫存資料夾已變更。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1321
+#: src/PrefsUnifiedDlg.cpp
 msgid "- ED2K network enabled.\n"
 msgstr "- ED2K 網路已啟用。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1354
+#: src/PrefsUnifiedDlg.cpp
 msgid "The shared-file exclusion pattern is not a valid regular expression. The filter has been left disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1356 src/PrefsUnifiedDlg.cpp:1956
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Invalid regular expression"
 msgstr "協定版本無效。"
 
-#: src/PrefsUnifiedDlg.cpp:1433
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
@@ -5841,7 +5753,7 @@ msgstr ""
 "eD2k 與 Kad 網路都已停用。\n"
 "請至少啟用一種，否則您將無法連線。"
 
-#: src/PrefsUnifiedDlg.cpp:1438
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
@@ -5849,7 +5761,7 @@ msgstr ""
 "如果您停用 UDP 埠，Kad 將無法啓動。\n"
 "請啟用 UDP 埠或停用 Kad。"
 
-#: src/PrefsUnifiedDlg.cpp:1494
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
@@ -5859,69 +5771,69 @@ msgstr ""
 "您必須立即重新啟動 aMule，\n"
 "如果現在不重啟動，可能會發生不可預期的問題。\n"
 
-#: src/PrefsUnifiedDlg.cpp:1559
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for autostart at login. The autostart store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1561
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the autostart-at-login entry."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1562
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Autostart"
 msgstr "已開始自動更新顯示"
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register file type"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1577
+#: src/PrefsUnifiedDlg.cpp
 msgid "Register URL handler"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1585
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "aMule only handles eD2k-compatible magnets. If you replace the current magnet handler (%s), BitTorrent magnet links will stop working - aMule cannot download BitTorrent content. Continue?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1590
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application currently opens .emulecollection files (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1595
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Another application is currently the default handler for these links (%s). Replace it with aMule?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1620
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule for .emulecollection files. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1622
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Could not remove the file type registration."
 msgstr "暫存資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1624
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not register aMule as the URL handler. The registration store may be read-only."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1626
+#: src/PrefsUnifiedDlg.cpp
 msgid "Could not remove the URL handler registration."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1696 src/PrefsUnifiedDlg.cpp:1723
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "The web server and aMule API require external connections to be enabled."
 msgstr "密碼已設定，外部連線已啟用。"
 
-#: src/PrefsUnifiedDlg.cpp:1706
+#: src/PrefsUnifiedDlg.cpp
 msgid "The aMule web server is deprecated. Consider running the aMule API instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1770
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
@@ -5931,65 +5843,65 @@ msgstr ""
 "請至少輸入一個能取得有效 server.met 檔案的網址。\n"
 "請點選旁邊的「清單」按鈕後輸入。"
 
-#: src/PrefsUnifiedDlg.cpp:1911
+#: src/PrefsUnifiedDlg.cpp
 msgid "Temporary files"
 msgstr "暫存檔"
 
-#: src/PrefsUnifiedDlg.cpp:1916
+#: src/PrefsUnifiedDlg.cpp
 msgid "Incoming files"
 msgstr "新進檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1921
+#: src/PrefsUnifiedDlg.cpp
 msgid "Online Signatures"
 msgstr "線上簽名識別"
 
-#: src/PrefsUnifiedDlg.cpp:1934
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Choose a folder for %s"
 msgstr "爲 %s 選擇資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:1958
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Would exclude %u of %u shared file"
 msgid_plural "Would exclude %u of %u shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
 
-#: src/PrefsUnifiedDlg.cpp:1975
+#: src/PrefsUnifiedDlg.cpp
 msgid "Browse for videoplayer"
 msgstr "瀏覽尋找影片播放器"
 
-#: src/PrefsUnifiedDlg.cpp:1979
+#: src/PrefsUnifiedDlg.cpp
 msgid "Select browser"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1983
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Select ffprobe binary"
 msgstr "設定瀏覽器"
 
-#: src/PrefsUnifiedDlg.cpp:1989
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Executable%s"
 msgstr "可執行%s"
 
-#: src/PrefsUnifiedDlg.cpp:2023
+#: src/PrefsUnifiedDlg.cpp
 msgid "ffprobe not found on PATH or in the standard install locations. Install ffmpeg (which ships ffprobe) or use Browse to pick a binary manually."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2035
+#: src/PrefsUnifiedDlg.cpp
 msgid "Reset the settings on this page to their default values?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2036
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reset to defaults"
 msgstr "系統預設"
 
-#: src/PrefsUnifiedDlg.cpp:2063
+#: src/PrefsUnifiedDlg.cpp
 msgid "Edit server list"
 msgstr "編輯伺服器清單"
 
-#: src/PrefsUnifiedDlg.cpp:2064
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
@@ -5997,1200 +5909,1199 @@ msgstr ""
 "加入可下載 server.met 檔案的網址。\n"
 "每一行一個網址。"
 
-#: src/PrefsUnifiedDlg.cpp:2119
+#: src/PrefsUnifiedDlg.cpp
 msgid "IP2Country update failed"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2264 src/PrefsUnifiedDlg.cpp:2295
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by MaxMind GeoLite2"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2266 src/PrefsUnifiedDlg.cpp:2297
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Custom source"
 msgstr "完整來源"
 
-#: src/PrefsUnifiedDlg.cpp:2268 src/PrefsUnifiedDlg.cpp:2299
+#: src/PrefsUnifiedDlg.cpp
 msgid "Data by DB-IP.com"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2319
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2321
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Status: Loaded%s - %s"
 msgstr "狀態："
 
-#: src/PrefsUnifiedDlg.cpp:2325
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Failed to load - click 'Update now' to refresh."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2327
+#: src/PrefsUnifiedDlg.cpp
 msgid "Status: Not found - click 'Update now' to download."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2400 src/PrefsUnifiedDlg.cpp:2424
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] "更新延遲時間：%d 秒"
 
-#: src/PrefsUnifiedDlg.cpp:2408
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] "平均值圖表顯示時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2417
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr "網路連線圖表比例：%d"
 
-#: src/PrefsUnifiedDlg.cpp:2432
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] "檔案緩衝區大小：%d B"
 
-#: src/PrefsUnifiedDlg.cpp:2442
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] "上傳等候區大小：%d "
 
-#: src/PrefsUnifiedDlg.cpp:2452
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] "伺服器連線更新間隔時間：%d 分鐘"
 
-#: src/PrefsUnifiedDlg.cpp:2457
+#: src/PrefsUnifiedDlg.cpp
 msgid "Server connection refresh interval: Disabled"
 msgstr "伺服器連線更新間隔時間：已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2501
+#: src/PrefsUnifiedDlg.cpp
 msgid "disabled"
 msgstr "已停用"
 
-#: src/PrefsUnifiedDlg.cpp:2527
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr "發生 %s 事件時執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2534
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on core"
 msgstr "啓用在主程式端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2546
+#: src/PrefsUnifiedDlg.cpp
 msgid "Core command:"
 msgstr "主程式端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2562
+#: src/PrefsUnifiedDlg.cpp
 msgid "Enable command execution on GUI"
 msgstr "啓用在圖形界面端執行指令"
 
-#: src/PrefsUnifiedDlg.cpp:2574
+#: src/PrefsUnifiedDlg.cpp
 msgid "GUI command:"
 msgstr "圖形界面端指令："
 
-#: src/PrefsUnifiedDlg.cpp:2590
+#: src/PrefsUnifiedDlg.cpp
 msgid "The following variables will be replaced:"
 msgstr ""
 "使用以下變數：\n"
 " "
 
-#: src/PrefsUnifiedDlg.cpp:2758
+#: src/PrefsUnifiedDlg.cpp
 msgid ""
 "The following folders look like system or sensitive locations:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2763
+#: src/PrefsUnifiedDlg.cpp
 msgid "Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2766
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2794
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
 
-#: src/PrefsUnifiedDlg.cpp:2795
+#: src/PrefsUnifiedDlg.cpp
 msgid "Scanning for subdirectories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2796
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Updating shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp:2823
+#: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:2873
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"
 
-#: src/PrefsUnifiedDlg.cpp:2923
+#: src/PrefsUnifiedDlg.cpp
 #, fuzzy
 msgid "Shared folder"
 msgstr "分享資料夾"
 
-#: src/SearchDlg.cpp:280
+#: src/SearchDlg.cpp
 msgid "Clear search history"
 msgstr ""
 
-#: src/SearchDlg.cpp:584
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:585 src/SearchListCtrl.cpp:858
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
 
-#: src/SearchDlg.cpp:929
+#: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必須小於最大值，最大值已被忽略。"
 
-#: src/SearchDlg.cpp:930 src/SearchDlg.cpp:1012
+#: src/SearchDlg.cpp
 msgid "Search warning"
 msgstr "搜尋警告"
 
-#: src/SearchDlg.cpp:1092 src/SearchListCtrl.cpp:735
+#: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"
 msgstr "主要"
 
-#: src/SearchList.cpp:319
+#: src/SearchList.cpp
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k 網路尚未連線，無法使用 eD2k 搜尋"
 
-#: src/SearchList.cpp:340
+#: src/SearchList.cpp
 #, fuzzy
 msgid "No keyword for Kad search - aborting"
 msgstr "搜尋的關鍵字：%s "
 
-#: src/SearchList.cpp:416
+#: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "試圖 Kad 搜尋時發生無法預料的錯誤："
 
-#: src/SearchList.cpp:925
+#: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchList.cpp:926
+#: src/SearchList.cpp
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
-#: src/SearchListCtrl.cpp:104
+#: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "檔案 ID"
 
-#: src/SearchListCtrl.cpp:110
+#: src/SearchListCtrl.cpp
 msgid "Length"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:111
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Bitrate"
 msgstr "未評價"
 
-#: src/SearchListCtrl.cpp:112
+#: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:740
+#: src/SearchListCtrl.cpp
 msgid "Download in category"
 msgstr "分類下載"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp
 #, c-format
 msgid "Get %s for this file"
 msgstr "取得這個檔案的 %s"
 
-#: src/SearchListCtrl.cpp:749
+#: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"
 msgstr "搜尋相關檔案 (eD2k，本地伺服器)"
 
-#: src/SearchListCtrl.cpp:756
+#: src/SearchListCtrl.cpp
 msgid "Mark as known file"
 msgstr "標記為已知檔案"
 
-#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
 msgid "Copy eD2k link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
-#: src/SearchListCtrl.cpp:856
+#: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "現在正連線到要刪除的伺服器。請先中斷連線。"
 
-#: src/SearchListCtrl.cpp:1163
+#: src/SearchListCtrl.cpp
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1166
+#: src/SearchListCtrl.cpp
 msgid "New"
 msgstr "新"
 
-#: src/ServerConnect.cpp:76
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "無法與清單中的模糊伺服器連線，嘗試不使用模糊協定。"
 
-#: src/ServerConnect.cpp:80
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated servers listed. Making another pass without obfuscation."
 msgstr "無法與清單中的模糊伺服器連線，嘗試不使用模糊協定。"
 
-#: src/ServerConnect.cpp:89
+#: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all static servers listed. Making another pass."
 msgstr "無法與清單中的模糊伺服器連線，開始下一輪嘗試。"
 
-#: src/ServerConnect.cpp:91
+#: src/ServerConnect.cpp
 msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "無法與清單中的模糊伺服器連線，開始下一輪嘗試。"
 
-#: src/ServerConnect.cpp:107 src/ServerConnect.cpp:160
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k 網路已在偏好設定中被停用了，未連線。"
 
-#: src/ServerConnect.cpp:135 src/ServerConnect.cpp:148
+#: src/ServerConnect.cpp
 msgid "No valid servers to which to connect found in server list"
 msgstr "在伺服器清單中找不到有效的伺服器可連線"
 
-#: src/ServerConnect.cpp:208
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connected to %s (%s:%i)"
 msgstr "已連線到 %s (%s:%i)"
 
-#: src/ServerConnect.cpp:277
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection established on: %s"
 msgstr "已連線到：%s"
 
-#: src/ServerConnect.cpp:348
+#: src/ServerConnect.cpp
 msgid "Fatal Error while trying to connect. Internet connection might be down"
 msgstr "連線時發生嚴重錯誤. 網路連線可能有問題"
 
-#: src/ServerConnect.cpp:352
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Lost connection to %s (%s:%i)"
 msgstr "已與 %s (%s:%i) 失去連線"
 
-#: src/ServerConnect.cpp:360
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be dead."
 msgstr "%s (%s:%i) 可能已當機。"
 
-#: src/ServerConnect.cpp:371
+#: src/ServerConnect.cpp
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) 可能已客滿。"
 
-#: src/ServerConnect.cpp:388
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Automatic connection to server will retry in %d second"
 msgid_plural "Automatic connection to server will retry in %d seconds"
 msgstr[0] "在 %d 秒後自動連線到伺服器"
 
-#: src/ServerConnect.cpp:418
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connecting to %s (%s:%i) failed."
 msgstr "無法連線到 %s (%s:%i)。"
 
-#: src/ServerConnect.cpp:460
+#: src/ServerConnect.cpp
 msgid "ERROR: Socket invalid at timeout check"
 msgstr "錯誤：連接端點於逾時查驗時失效"
 
-#: src/ServerConnect.cpp:470
+#: src/ServerConnect.cpp
 #, c-format
 msgid "Connection attempt to %s (%s:%i) timed out."
 msgstr "連線到 %s (%s:%i) 時逾時。"
 
-#: src/ServerConnect.cpp:659
+#: src/ServerConnect.cpp
 msgid "Received late result of DNS lookup, discarding."
 msgstr "接收到過期的 DNS 查閱，放棄中。"
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr "正在載入 server.met 檔案：%s"
 
-#: src/ServerList.cpp:98
+#: src/ServerList.cpp
 msgid "Server.met file not found!"
 msgstr "找不到 server.met 檔案！"
 
-#: src/ServerList.cpp:106
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr "無法載入 server.met 檔案 %s，為不明格式。"
 
-#: src/ServerList.cpp:113
+#: src/ServerList.cpp
 msgid "Failed to open server.met!"
 msgstr "無法開啟 server.met ！"
 
-#: src/ServerList.cpp:125
+#: src/ServerList.cpp
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr "server.met 檔案損壞，發現無效的版本標記：0x%x, 大小 %i"
 
-#: src/ServerList.cpp:181
+#: src/ServerList.cpp
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] "在 server.met 中找到 %i 個伺服器"
 
-#: src/ServerList.cpp:186
+#: src/ServerList.cpp
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] "已加入 %d 個伺服器"
 
-#: src/ServerList.cpp:190
+#: src/ServerList.cpp
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr "錯誤:  server.met 檔案已經損壞: "
 
-#: src/ServerList.cpp:194
+#: src/ServerList.cpp
 msgid "IO error while reading 'server.met': "
 msgstr "讀取 server.met 時發生 IO 錯誤："
 
-#: src/ServerList.cpp:206
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr "未加入伺服器：[%s:%d] 的通訊埠無效。"
 
-#: src/ServerList.cpp:219
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr "未加入伺服器：[%s:%d] 已被過濾或無效。"
 
-#: src/ServerList.cpp:236
+#: src/ServerList.cpp
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr "未加入伺服器：%s:%d 已在伺服器清單中。"
 
-#: src/ServerList.cpp:253
+#: src/ServerList.cpp
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr "已加入伺服器：[%s:%d]  名稱 %s 。"
 
-#: src/ServerList.cpp:364
+#: src/ServerList.cpp
 msgid "You are connected to the server you are trying to delete. please disconnect first."
 msgstr "現在正連線到要刪除的伺服器。請先中斷連線。"
 
-#: src/ServerList.cpp:530
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to open '%s'"
 msgstr "無法開啟 %s"
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "無法儲存 server.met ！"
 
-#: src/ServerList.cpp:844
+#: src/ServerList.cpp
 msgid "Invalid URL"
 msgstr "無效網址"
 
-#: src/ServerList.cpp:871
+#: src/ServerList.cpp
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr "完成從 %s 下載伺服器清單"
 
-#: src/ServerList.cpp:889
+#: src/ServerList.cpp
 msgid "No server list address entry in 'addresses.dat' found. Please paste a valid server list address into this file in order to auto-update your server list"
 msgstr "在 addresses.dat 中找不到伺服器清單檔位址。請在檔案中貼上有效的伺服器清單檔位址，以自動更新您的伺服器清單"
 
-#: src/ServerList.cpp:907
+#: src/ServerList.cpp
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr "開始從 %s下載伺服器清單"
 
-#: src/ServerList.cpp:921
+#: src/ServerList.cpp
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr "警告：自動更新伺服器的網址無效 - %s"
 
-#: src/ServerList.cpp:926
+#: src/ServerList.cpp
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr "addresses.dat 檔案中沒有有效的自動更新伺服器清單網址"
 
-#: src/ServerList.cpp:941
+#: src/ServerList.cpp
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr "無法從 %s 下載伺服器清單"
 
-#: src/ServerList.cpp:1011
+#: src/ServerList.cpp
 msgid "Local server is filtered by the IPFilters, reconnecting to a different server!"
 msgstr "本地伺服器被 IP 過濾器過濾掉了，正在重新連線到其他伺服器！"
 
-#: src/ServerListCtrl.cpp:90
+#: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "伺服器名稱"
 
-#: src/ServerListCtrl.cpp:91
+#: src/ServerListCtrl.cpp
 msgid "Address"
 msgstr "位址"
 
-#: src/ServerListCtrl.cpp:92
+#: src/ServerListCtrl.cpp
 msgid "Port"
 msgstr "通訊埠"
 
-#: src/ServerListCtrl.cpp:93
+#: src/ServerListCtrl.cpp
 msgid "Description"
 msgstr "說明"
 
-#: src/ServerListCtrl.cpp:94
+#: src/ServerListCtrl.cpp
 msgid "Ping"
 msgstr "Ping"
 
-#: src/ServerListCtrl.cpp:95
+#: src/ServerListCtrl.cpp
 msgid "Users"
 msgstr "使用者"
 
-#: src/ServerListCtrl.cpp:99
+#: src/ServerListCtrl.cpp
 msgid "Static"
 msgstr "靜態"
 
-#: src/ServerListCtrl.cpp:100 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1141
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
-#: src/ServerListCtrl.cpp:103
+#: src/ServerListCtrl.cpp
 msgid "TCP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:104
+#: src/ServerListCtrl.cpp
 msgid "UDP Flags"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:150
+#: src/ServerListCtrl.cpp
 msgid "You are connected to a server you are trying to delete. Please disconnect first. The server was NOT deleted."
 msgstr "您現在正和要刪除的伺服器連線，該伺服器暫時無法刪除。請先中斷連線。"
 
-#: src/ServerListCtrl.cpp:157
+#: src/ServerListCtrl.cpp
 msgid "(Unknown name)"
 msgstr "(不明名稱)"
 
-#: src/ServerListCtrl.cpp:161
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "您確定要刪除靜態伺服器 %s"
 
-#: src/ServerListCtrl.cpp:379
+#: src/ServerListCtrl.cpp
 #, c-format
 msgid "Servers (%i)"
 msgstr "伺服器 (%i)"
 
-#: src/ServerListCtrl.cpp:454 src/ServerSocket.cpp:182 src/ServerSocket.cpp:198
-#: src/ServerSocket.cpp:331 src/ServerWnd.cpp:213
+#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
 msgid "Server"
 msgstr "伺服器"
 
-#: src/ServerListCtrl.cpp:459
+#: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "連線到伺服器"
 
-#: src/ServerListCtrl.cpp:465
+#: src/ServerListCtrl.cpp
 msgid "Mark server as static"
 msgstr "標記爲靜態伺服器"
 
-#: src/ServerListCtrl.cpp:466
+#: src/ServerListCtrl.cpp
 msgid "Mark server as non-static"
 msgstr "標記爲非靜態伺服器"
 
-#: src/ServerListCtrl.cpp:468
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "標記爲靜態伺服器"
 
-#: src/ServerListCtrl.cpp:469
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "標記爲非靜態伺服器"
 
-#: src/ServerListCtrl.cpp:475
+#: src/ServerListCtrl.cpp
 msgid "Remove server"
 msgstr "移除伺服器"
 
-#: src/ServerListCtrl.cpp:477
+#: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "移除伺服器"
 
-#: src/ServerListCtrl.cpp:479
+#: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "移除所有伺服器"
 
-#: src/ServerListCtrl.cpp:486
+#: src/ServerListCtrl.cpp
 msgid "Copy eD2k links to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
-#: src/ServerListCtrl.cpp:494
+#: src/ServerListCtrl.cpp
 msgid "Reconnect to server"
 msgstr "重新連線到伺服器"
 
-#: src/ServerListCtrl.cpp:582
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete all servers?"
 msgstr "您確定要刪除所有伺服器嗎？"
 
-#: src/ServerListCtrl.cpp:600
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected server?"
 msgstr "您確定要刪除選取的伺服器嗎？"
 
-#: src/ServerListCtrl.cpp:602
+#: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "您確定要刪除選取的伺服器嗎？"
 
-#: src/ServerSocket.cpp:184
+#: src/ServerSocket.cpp
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr "錯誤：%s (%s) - %s"
 
-#: src/ServerSocket.cpp:200
+#: src/ServerSocket.cpp
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr "警告：%s (%s) - %s"
 
-#: src/ServerSocket.cpp:329
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server %s (%s) rejected our login (no client ID assigned). Disconnecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:373
+#: src/ServerSocket.cpp
 #, c-format
 msgid "New clientid is %u"
 msgstr "新客戶端 ID：%u"
 
-#: src/ServerSocket.cpp:375
+#: src/ServerSocket.cpp
 msgid "WARNING: You have received Low-ID!"
 msgstr "警告：您現在是 Low-ID！"
 
-#: src/ServerSocket.cpp:377
+#: src/ServerSocket.cpp
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t可能是因爲受到防火牆或網路分享器影響。"
 
-#: src/ServerSocket.cpp:378
+#: src/ServerSocket.cpp
 msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr "\t請參考 https://amule-org.github.io/docs 的資訊"
 
-#: src/ServerSocket.cpp:440
+#: src/ServerSocket.cpp
 msgid "Unknown server info received! - too short"
 msgstr "收到不明伺服器資訊 ! - 長度過短"
 
-#: src/ServerSocket.cpp:520
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] "收到 %d 個新伺服器"
 
-#: src/ServerSocket.cpp:526
+#: src/ServerSocket.cpp
 msgid "Saving of server-list completed."
 msgstr "伺服器清單儲存完畢。"
 
-#: src/ServerSocket.cpp:579
+#: src/ServerSocket.cpp
 msgid "Server rejected last command"
 msgstr "伺服器已拒絕上一個指令"
 
-#: src/ServerSocket.cpp:588 src/ServerSocket.cpp:590
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr "從伺服器收到偽裝封包：%s"
 
-#: src/ServerSocket.cpp:592
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr "處理伺服器傳來的封包時發生無法處理的錯誤：%s "
 
-#: src/ServerSocket.cpp:632 src/ServerSocket.cpp:637
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr "無法送出 DNS 解析執行緒以連線到 %s"
 
-#: src/ServerSocket.cpp:729
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr "伺服器 IP %s (%s) 已被過濾。未連線。"
 
-#: src/ServerSocket.cpp:741
+#: src/ServerSocket.cpp
 msgid "using protocol obfuscation."
 msgstr "，使用模糊協定。"
 
-#: src/ServerSocket.cpp:750
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr "正在連線到 %s (%s - %s:%i) %s"
 
-#: src/ServerSocket.cpp:760
+#: src/ServerSocket.cpp
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr "無法解析伺服器 %s 的 DNS 資訊：無法連線！"
 
-#: src/ServerWnd.cpp:77
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "aMuleGUI Log"
 msgstr "aMule 記錄"
 
-#: src/ServerWnd.cpp:139
+#: src/ServerWnd.cpp
 msgid "Server not added: No IP or hostname specified."
 msgstr "伺服器未加入：沒有 IP 或主機名稱。"
 
-#: src/ServerWnd.cpp:144
+#: src/ServerWnd.cpp
 msgid "Server not added: Invalid server-port specified."
 msgstr "伺服器未加入：無效的伺服器通訊埠。"
 
-#: src/ServerWnd.cpp:203
+#: src/ServerWnd.cpp
 msgid "eD2k Status:"
 msgstr "eD2k 狀態："
 
-#: src/ServerWnd.cpp:216
+#: src/ServerWnd.cpp
 msgid "ID"
 msgstr "ID"
 
-#: src/ServerWnd.cpp:223
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connection Type:"
 msgstr "連線狀態："
 
-#: src/ServerWnd.cpp:230 src/ServerWnd.cpp:266
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Connected since:"
 msgstr "已連線"
 
-#: src/ServerWnd.cpp:249
+#: src/ServerWnd.cpp
 msgid "Kademlia Status:"
 msgstr "Kad 狀態："
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running in LAN mode"
 msgstr "在區域網路模式下執行"
 
-#: src/ServerWnd.cpp:254
+#: src/ServerWnd.cpp
 msgid "Running"
 msgstr "執行中"
 
-#: src/ServerWnd.cpp:257
+#: src/ServerWnd.cpp
 #, fuzzy
 msgid "Kademlia client ID:"
 msgstr "Kad 狀態："
 
-#: src/ServerWnd.cpp:259
+#: src/ServerWnd.cpp
 msgid "Status:"
 msgstr "狀態："
 
-#: src/ServerWnd.cpp:270
+#: src/ServerWnd.cpp
 msgid "Connection State:"
 msgstr "連線狀態："
 
-#: src/ServerWnd.cpp:274
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "防火牆內 - 請設定您的路由器或防火牆開啟 TCP 埠 %d "
 
-#: src/ServerWnd.cpp:278
+#: src/ServerWnd.cpp
 msgid "UDP Connection State:"
 msgstr "UDP 連線狀態："
 
-#: src/ServerWnd.cpp:282
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "防火牆內 - 請設定您的路由器或防火牆開啟 UDP 埠 %d "
 
-#: src/ServerWnd.cpp:288
+#: src/ServerWnd.cpp
 msgid "Firewalled state: "
 msgstr "防火牆狀態："
 
-#: src/ServerWnd.cpp:293
+#: src/ServerWnd.cpp
 msgid "No buddy required - TCP port open"
 msgstr "沒有好友要求 - TCP 埠開啟"
 
-#: src/ServerWnd.cpp:295
+#: src/ServerWnd.cpp
 msgid "No buddy required - UDP port open"
 msgstr "沒有好友要求 - UDP 埠開啟"
 
-#: src/ServerWnd.cpp:297
+#: src/ServerWnd.cpp
 msgid "No buddy"
 msgstr "沒有好友"
 
-#: src/ServerWnd.cpp:301
+#: src/ServerWnd.cpp
 msgid "Connecting to buddy"
 msgstr "正在與好友連線"
 
-#: src/ServerWnd.cpp:304
+#: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "已與在 %s 的好友連線"
 
-#: src/ServerWnd.cpp:316
+#: src/ServerWnd.cpp
 msgid "Indexed sources:"
 msgstr "索引來源："
 
-#: src/ServerWnd.cpp:318
+#: src/ServerWnd.cpp
 msgid "Indexed keywords:"
 msgstr "索引關鍵字："
 
-#: src/ServerWnd.cpp:320
+#: src/ServerWnd.cpp
 msgid "Indexed notes:"
 msgstr "索引註釋："
 
-#: src/ServerWnd.cpp:322
+#: src/ServerWnd.cpp
 msgid "Indexed load:"
 msgstr "索引負載："
 
-#: src/ServerWnd.cpp:325
+#: src/ServerWnd.cpp
 msgid "Average Users:"
 msgstr "平均使用者數："
 
-#: src/ServerWnd.cpp:328
+#: src/ServerWnd.cpp
 msgid "Average Files:"
 msgstr "平均檔案數："
 
-#: src/ServerWnd.cpp:333 src/TextClient.cpp:925
+#: src/ServerWnd.cpp src/TextClient.cpp
 msgid "Not running"
 msgstr "未執行"
 
-#: src/SharedFileList.cpp:407
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Adding file %s to shares"
 msgstr "正在加入分享檔案 %s"
 
-#: src/SharedFileList.cpp:452
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
 
-#: src/SharedFileList.cpp:463
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "發現 %i 個已知、%i 個不明的分享檔案"
 
-#: src/SharedFileList.cpp:470
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Excluded %i file from sharing by filter"
 msgid_plural "Excluded %i files from sharing by filter"
 msgstr[0] ""
 
-#: src/SharedFileList.cpp:481
+#: src/SharedFileList.cpp
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr "錯誤：試圖分享 %s"
 
-#: src/SharedFileList.cpp:510
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr "找不到分享目錄，略過：%s"
 
-#: src/SharedFileList.cpp:561
+#: src/SharedFileList.cpp
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "目錄中找不到可分享的檔案：%s"
 
-#: src/SharedFilePeersListCtrl.cpp:28 src/SourceListCtrl.cpp:28
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
 msgstr "使用者名稱"
 
-#: src/SharedFilePeersListCtrl.cpp:30
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下載速度"
 
-#: src/SharedFilePeersListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上傳速度"
 
-#: src/SharedFilePeersListCtrl.cpp:33 src/SourceListCtrl.cpp:32
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Available Parts"
 msgstr "可取得的部份"
 
-#: src/SharedFilePeersListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
 msgstr "上傳狀態"
 
-#: src/SharedFilePeersListCtrl.cpp:36 src/SourceListCtrl.cpp:34
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Download Status"
 msgstr "下載狀態"
 
-#: src/SharedFilePeersListCtrl.cpp:37 src/SourceListCtrl.cpp:35
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "來源"
 
-#: src/SharedFilePeersListCtrl.cpp:38 src/SourceListCtrl.cpp:36
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Local File Name"
 msgstr "本地檔案名稱"
 
-#: src/SharedFilePeersListCtrl.cpp:39 src/SourceListCtrl.cpp:38
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Shares File List"
 msgstr "分享檔案清單"
 
-#: src/SharedFilesCtrl.cpp:117
+#: src/SharedFilesCtrl.cpp
 msgid "Obtained Parts"
 msgstr "已獲得部分"
 
-#: src/SharedFilesCtrl.cpp:125
+#: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
 msgstr "所在目錄"
 
-#: src/SharedFilesCtrl.cpp:160
+#: src/SharedFilesCtrl.cpp
 msgid "Add Comment/Rating"
 msgstr "加入註解/評價"
 
-#: src/SharedFilesCtrl.cpp:162
+#: src/SharedFilesCtrl.cpp
 msgid "Edit Comment/Rating"
 msgstr "編輯註解/評價"
 
-#: src/SharedFilesCtrl.cpp:166
+#: src/SharedFilesCtrl.cpp
 msgid "Rename"
 msgstr "重新命名"
 
-#: src/SharedFilesCtrl.cpp:169
+#: src/SharedFilesCtrl.cpp
 msgid "Verify Local Data"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:173
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "加入收藏中的檔案到傳輸清單"
 
-#: src/SharedFilesCtrl.cpp:176
+#: src/SharedFilesCtrl.cpp
 msgid "Copy magnet &URI to clipboard"
 msgstr "複製 magnet 網址到剪貼簿(&U)"
 
-#: src/SharedFilesCtrl.cpp:178
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Source)"
 msgstr "複製 eD2k 連結到剪貼簿 (來源) (&S)"
 
-#: src/SharedFilesCtrl.cpp:180
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Source) (&With Crypt options)"
 msgstr "複製 eD2k 連結到剪貼簿 (來源，加密) (&W)"
 
-#: src/SharedFilesCtrl.cpp:181
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&Hostname)"
 msgstr "複製 eD2k 連結到剪貼簿 (主機名稱) (&H)"
 
-#: src/SharedFilesCtrl.cpp:183
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (Hostname) (With &Crypt options)"
 msgstr "複製 eD2k 連結到剪貼簿 (主機名稱，加密) (&C)"
 
-#: src/SharedFilesCtrl.cpp:184
+#: src/SharedFilesCtrl.cpp
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "複製 eD2k 連結到剪貼簿 (AICH 資訊) (&A)"
 
-#: src/SharedFilesCtrl.cpp:185
+#: src/SharedFilesCtrl.cpp
 #, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
 msgstr "複製 eD2k 連結到剪貼簿 (AICH 資訊) (&A)"
 
-#: src/SharedFilesCtrl.cpp:250
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:469
+#: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"
 msgstr "您需要一個 HighID 才能建立有效來源連結"
 
-#: src/SharedFilesCtrl.cpp:662
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
 
-#: src/SourceListCtrl.cpp:37
+#: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "遠端檔案名稱"
 
-#: src/Statistics.cpp:792
+#: src/Statistics.cpp
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr "本次上傳量/總計上傳量：%s"
 
-#: src/Statistics.cpp:797 src/Statistics.cpp:836
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr "額外支出傳輸量/封包： %s"
 
-#: src/Statistics.cpp:799 src/Statistics.cpp:838
+#: src/Statistics.cpp
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr "  檔案要求支出傳輸量/封包：%s"
 
-#: src/Statistics.cpp:802 src/Statistics.cpp:841
+#: src/Statistics.cpp
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr "  來源交換支出傳輸量/封包： %s"
 
-#: src/Statistics.cpp:805 src/Statistics.cpp:844
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr "  伺服器支出傳輸量/封包： %s"
 
-#: src/Statistics.cpp:808 src/Statistics.cpp:847
+#: src/Statistics.cpp
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr "  Kad 網路支出傳輸量/封包： %s"
 
-#: src/Statistics.cpp:811 src/Statistics.cpp:850
+#: src/Statistics.cpp
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr "  加密支出傳輸量/封包： %s"
 
-#: src/Statistics.cpp:814
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Uploads: %s"
 msgstr "目前上傳數：%s"
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr "等候中：%s"
 
-#: src/Statistics.cpp:818
+#: src/Statistics.cpp
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr "上傳成功總次數：%s"
 
-#: src/Statistics.cpp:820
+#: src/Statistics.cpp
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr "上傳失敗總次數：%s"
 
-#: src/Statistics.cpp:822
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload time: %s"
 msgstr "平均上傳時間：%s"
 
-#: src/Statistics.cpp:831
+#: src/Statistics.cpp
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr "本次下載量/總計下載量：%s"
 
-#: src/Statistics.cpp:853
+#: src/Statistics.cpp
 #, c-format
 msgid "Found Sources: %s"
 msgstr "找到的來源數：%s"
 
-#: src/Statistics.cpp:855
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr "目前下載中區塊數：%s"
 
-#: src/Statistics.cpp:857
+#: src/Statistics.cpp
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr "本次上傳下載比率 (總計)：%s"
 
-#: src/Statistics.cpp:869
+#: src/Statistics.cpp
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr "本次平均下載速度：%s"
 
-#: src/Statistics.cpp:873
+#: src/Statistics.cpp
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr "本次平均上傳速度：%s"
 
-#: src/Statistics.cpp:876
+#: src/Statistics.cpp
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr "本次最大下載速度：%s"
 
-#: src/Statistics.cpp:878
+#: src/Statistics.cpp
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr "本次最大上傳速度：%s"
 
-#: src/Statistics.cpp:880
+#: src/Statistics.cpp
 #, c-format
 msgid "Reconnects: %i"
 msgstr "重新連線次數：%i"
 
-#: src/Statistics.cpp:882
+#: src/Statistics.cpp
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr "首次傳輸至今時間：%s"
 
-#: src/Statistics.cpp:884
+#: src/Statistics.cpp
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr "與伺服器連線時間：%s"
 
-#: src/Statistics.cpp:886
+#: src/Statistics.cpp
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr "目前連線數 (估計值)：%i"
 
-#: src/Statistics.cpp:888
+#: src/Statistics.cpp
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr "達到最大連線量次數：%s"
 
-#: src/Statistics.cpp:890
+#: src/Statistics.cpp
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr "平均連線數 (估計值)：%g"
 
-#: src/Statistics.cpp:892
+#: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "最高連線數 (估計值)：%i"
 
-#: src/Statistics.cpp:896
+#: src/Statistics.cpp
 msgid "Clients"
 msgstr "客戶端"
 
-#: src/Statistics.cpp:898
+#: src/Statistics.cpp
 #, c-format
 msgid "Unknown: %s"
 msgstr "不明：%s"
 
-#: src/Statistics.cpp:908
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered: %s"
 msgstr "已過濾：%s"
 
-#: src/Statistics.cpp:910
+#: src/Statistics.cpp
 #, c-format
 msgid "Banned: %s"
 msgstr "已封鎖：%s"
 
-#: src/Statistics.cpp:912
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr "總計：%i  -  已知：%i"
 
-#: src/Statistics.cpp:919
+#: src/Statistics.cpp
 #, c-format
 msgid "Working Servers: %i"
 msgstr "有效：%i"
 
-#: src/Statistics.cpp:921
+#: src/Statistics.cpp
 #, c-format
 msgid "Failed Servers: %i"
 msgstr "無效：%i"
 
-#: src/Statistics.cpp:923
+#: src/Statistics.cpp
 #, c-format
 msgid "Total: %s"
 msgstr "總計：%s"
 
-#: src/Statistics.cpp:925
+#: src/Statistics.cpp
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr "已刪除：%s"
 
-#: src/Statistics.cpp:927
+#: src/Statistics.cpp
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr "已過濾：%s"
 
-#: src/Statistics.cpp:929
+#: src/Statistics.cpp
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr "有效使用者數：%llu"
 
-#: src/Statistics.cpp:931
+#: src/Statistics.cpp
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr "有效檔案數：%llu"
 
-#: src/Statistics.cpp:933
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Users: %llu"
 msgstr "使用者總數：%llu"
 
-#: src/Statistics.cpp:935
+#: src/Statistics.cpp
 #, c-format
 msgid "Total Files: %llu"
 msgstr "檔案總數：%llu"
 
-#: src/Statistics.cpp:937
+#: src/Statistics.cpp
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr "伺服器使用率：%.2f%%"
 
-#: src/Statistics.cpp:943
+#: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "檔案數：%s"
 
-#: src/Statistics.cpp:945
+#: src/Statistics.cpp
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr "檔案總容量：%s"
 
-#: src/Statistics.cpp:949
+#: src/Statistics.cpp
 #, c-format
 msgid "Average file size: %s"
 msgstr "平均檔案大小：%s"
 
-#: src/Statistics.cpp:1144
+#: src/Statistics.cpp
 msgid "Operating System"
 msgstr "作業系統"
 
-#: src/Statistics.cpp:1181
+#: src/Statistics.cpp
 msgid "Not Received"
 msgstr "未收到"
 
-#: src/StatisticsDlg.cpp:199
+#: src/StatisticsDlg.cpp
 #, c-format
 msgid "Active connections (1:%u)"
 msgstr "目前連線數 (1:%u)"
 
-#: src/StatTree.cpp:564
+#: src/StatTree.cpp
 msgid "Not available"
 msgstr "不可用"
 
-#: src/StatTree.cpp:648 src/StatTree.cpp:660
+#: src/StatTree.cpp
 msgid "Never"
 msgstr "無"
 
-#: src/TerminationProcess.cpp:41
+#: src/TerminationProcess.cpp
 #, c-format
 msgid "Command '%s' with pid '%d' has finished with status code '%d'."
 msgstr "指令「 %s 」(pid %d) 的傳回狀態值爲「%d」。 "
 
-#: src/TextClient.cpp:224
+#: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "執行 <str> 後離開。"
 
-#: src/TextClient.cpp:310
+#: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"
 msgstr "IP 格式無效。請使用 xxx.xxx.xxx.xxx:xxxx\n"
 
-#: src/TextClient.cpp:427
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: 'all', filename, or a number.\n"
 msgstr "這個指令需要引數，有效引數為：「all」、「檔案名」或「數字」。\n"
 
-#: src/TextClient.cpp:473
+#: src/TextClient.cpp
 msgid "Processing by hash: "
 msgstr "正在依 hash 值處理："
 
-#: src/TextClient.cpp:492
+#: src/TextClient.cpp
 msgid "Processing by filename: "
 msgstr "正在依檔名處理："
 
-#: src/TextClient.cpp:516
+#: src/TextClient.cpp
 msgid "This command requires an argument. Valid arguments: a file hash.\n"
 msgstr "這個指令需要引數，有效引數為：「檔案 hash 值」。\n"
 
-#: src/TextClient.cpp:544
+#: src/TextClient.cpp
 msgid "Not a valid number\n"
 msgstr "不是有效的數字\n"
 
-#: src/TextClient.cpp:548
+#: src/TextClient.cpp
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "不是有效的 hash 值 (必須爲 32 碼)\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:681
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "Invalid search filter syntax.\n"
@@ -7199,7 +7110,7 @@ msgstr "輸入「 %s 」顯示更多協助資訊。\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:688
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search keyword provided.\n"
@@ -7208,89 +7119,87 @@ msgstr "輸入「 %s 」顯示更多協助資訊。\n"
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:702
+#: src/TextClient.cpp
 #, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
 msgstr "輸入「 %s 」顯示更多協助資訊。\n"
 
-#: src/TextClient.cpp:733
+#: src/TextClient.cpp
 #, fuzzy, c-format
 msgid "Download File: %lu %s\n"
 msgstr "下載大小：%i "
 
-#: src/TextClient.cpp:828 src/webserver/src/WebServer.cpp:400
+#: src/TextClient.cpp src/webserver/src/WebServer.cpp
 msgid "Request failed with an unknown error."
 msgstr "要求失敗，不明的錯誤。"
 
-#: src/TextClient.cpp:832
+#: src/TextClient.cpp
 msgid "Operation was successful."
 msgstr "操作成功。"
 
-#: src/TextClient.cpp:837
+#: src/TextClient.cpp
 #, c-format
 msgid "Request failed with the following error: %s"
 msgstr "要求失敗，錯誤：%s"
 
-#: src/TextClient.cpp:850
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for clients is %s.\n"
 msgstr "對客戶端的 IP 過濾：%s 。\n"
 
-#: src/TextClient.cpp:851 src/TextClient.cpp:858 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "OFF"
 msgstr "關"
 
-#: src/TextClient.cpp:852 src/TextClient.cpp:859 src/TextClient.cpp:875
+#: src/TextClient.cpp
 msgid "ON"
 msgstr "開"
 
-#: src/TextClient.cpp:857
+#: src/TextClient.cpp
 #, c-format
 msgid "IP filtering for servers is %s.\n"
 msgstr "對伺服器的 IP 過濾：%s 。\n"
 
-#: src/TextClient.cpp:863
+#: src/TextClient.cpp
 #, c-format
 msgid "Current IPFilter Level is %d.\n"
 msgstr "目前的 IP 過濾等級：%d 。\n"
 
-#: src/TextClient.cpp:870
+#: src/TextClient.cpp
 #, c-format
 msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
 msgstr "頻寬限制：上傳 %u KB/s、下載 %u KB/s 。\n"
 
-#: src/TextClient.cpp:874
+#: src/TextClient.cpp
 #, c-format
 msgid "Endgame source rotation is %s.\n"
 msgstr ""
 
-#: src/TextClient.cpp:884
+#: src/TextClient.cpp
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
 
-#: src/TextClient.cpp:900
+#: src/TextClient.cpp
 #, c-format
 msgid "Connected to %s %s %s"
 msgstr "已連線到 %s %s %s"
 
-#: src/TextClient.cpp:907
+#: src/TextClient.cpp
 msgid "Now connecting"
 msgstr "正在連線"
 
-#: src/TextClient.cpp:916 src/utils/wxCas/src/wxcasframe.cpp:1002
-#: src/utils/wxCas/src/wxcasframe.cpp:1014
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "firewalled"
 msgstr "防火牆內"
 
-#: src/TextClient.cpp:918 src/utils/wxCas/src/wxcasframe.cpp:1000
-#: src/utils/wxCas/src/wxcasframe.cpp:1012
+#: src/TextClient.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "ok"
 msgstr "ok"
 
-#: src/TextClient.cpp:931
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7299,7 +7208,7 @@ msgstr ""
 "\n"
 "下載：\t%s"
 
-#: src/TextClient.cpp:934
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7308,7 +7217,7 @@ msgstr ""
 "\n"
 "上傳：\t%s"
 
-#: src/TextClient.cpp:937
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7317,7 +7226,7 @@ msgstr ""
 "\n"
 "等候區內人數：\t%d\n"
 
-#: src/TextClient.cpp:940
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "\n"
@@ -7326,46 +7235,46 @@ msgstr ""
 "\n"
 "來源總數：\t%d\n"
 
-#: src/TextClient.cpp:1032
+#: src/TextClient.cpp
 msgid "[PartFile]"
 msgstr "[--暫存檔--]"
 
-#: src/TextClient.cpp:1060 src/TextClient.cpp:1076
+#: src/TextClient.cpp
 msgid "Search expired or unknown ID. Start a new search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1065
+#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "搜尋結果：%i\n"
 
-#: src/TextClient.cpp:1082
+#: src/TextClient.cpp
 #, c-format
 msgid "Search progress: %u %% \n"
 msgstr "搜尋進度：%u %% \n"
 
-#: src/TextClient.cpp:1084
+#: src/TextClient.cpp
 msgid "Search progress not available"
 msgstr "沒有進行中的搜尋"
 
-#: src/TextClient.cpp:1089
+#: src/TextClient.cpp
 #, c-format
 msgid "Received an unknown reply from the server, OpCode = %#x."
 msgstr "從伺服器收到不明的回應，指令碼是 %#x 。"
 
-#: src/TextClient.cpp:1105
+#: src/TextClient.cpp
 msgid "Show short status information."
 msgstr "顯示簡短狀態資訊。"
 
-#: src/TextClient.cpp:1106
+#: src/TextClient.cpp
 msgid "Show connection status, current up/download speeds, etc.\n"
 msgstr "顯示連線狀態、目前上傳下載速度等等。\n"
 
-#: src/TextClient.cpp:1111
+#: src/TextClient.cpp
 msgid "Show full statistics tree."
 msgstr "顯示完整統計資料。"
 
-#: src/TextClient.cpp:1112
+#: src/TextClient.cpp
 msgid ""
 "Optionally, a number in the range 0-255 can be passed as an argument to this\n"
 "command, which tells how many entries of the client version subtrees should be\n"
@@ -7379,11 +7288,11 @@ msgstr ""
 "例如：「 statistics 5 」則每種客戶端軟體最多會顯示 5 個版本。\n"
 "\n"
 
-#: src/TextClient.cpp:1119
+#: src/TextClient.cpp
 msgid "Shut down aMule."
 msgstr "關閉 aMule 。"
 
-#: src/TextClient.cpp:1120
+#: src/TextClient.cpp
 msgid ""
 "Shut down the remote running core (amule/amuled).\n"
 "This will also shut down the text client, since it is unusable without a\n"
@@ -7393,35 +7302,35 @@ msgstr ""
 "這會導致文字模式客戶端程式因缺少執行核心而一起被關閉。\n"
 "\n"
 
-#: src/TextClient.cpp:1125
+#: src/TextClient.cpp
 msgid "Reload the given object."
 msgstr "重新載入指定的項目。"
 
-#: src/TextClient.cpp:1128
+#: src/TextClient.cpp
 msgid "Reload shared files list."
 msgstr "重新載入分享檔案清單。"
 
-#: src/TextClient.cpp:1134
+#: src/TextClient.cpp
 msgid "Reload IP filtering table."
 msgstr "重新載入 IP 過濾表。"
 
-#: src/TextClient.cpp:1139
+#: src/TextClient.cpp
 msgid "Reload current IP filtering table."
 msgstr "重新載入現用的 IP 過濾表。"
 
-#: src/TextClient.cpp:1144
+#: src/TextClient.cpp
 msgid "Update IP filtering table from URL."
 msgstr "從網址更新 IP 過濾表。"
 
-#: src/TextClient.cpp:1145
+#: src/TextClient.cpp
 msgid "If URL is omitted the URL from the preferences is used."
 msgstr "如果網址被省略掉，則使用偏好設定中的網址。"
 
-#: src/TextClient.cpp:1150
+#: src/TextClient.cpp
 msgid "Connect to the network."
 msgstr "連線到網路。"
 
-#: src/TextClient.cpp:1152
+#: src/TextClient.cpp
 msgid ""
 "This will connect to all networks that are enabled in Preferences.\n"
 "You may also optionally specify a server address in IP:Port form, to connect to\n"
@@ -7433,35 +7342,35 @@ msgstr ""
 "此位址必須是用句點隔開的十進位 IPv4 位址，\n"
 "或者是可以解析的 DNS 網域名稱。"
 
-#: src/TextClient.cpp:1157
+#: src/TextClient.cpp
 msgid "Connect to eD2k only."
 msgstr "只連線到 eD2k 網路。"
 
-#: src/TextClient.cpp:1158
+#: src/TextClient.cpp
 msgid "Connect to Kad only."
 msgstr "只連線到 Kad 網路。"
 
-#: src/TextClient.cpp:1162
+#: src/TextClient.cpp
 msgid "Disconnect from the network."
 msgstr "中斷網路連線。"
 
-#: src/TextClient.cpp:1163
+#: src/TextClient.cpp
 msgid "This will disconnect from all networks that are currently connected.\n"
 msgstr "這將中斷目前所有已連線的網路。\n"
 
-#: src/TextClient.cpp:1167
+#: src/TextClient.cpp
 msgid "Disconnect from eD2k only."
 msgstr "只中斷 eD2k 連線。"
 
-#: src/TextClient.cpp:1171
+#: src/TextClient.cpp
 msgid "Disconnect from Kad only."
 msgstr "只中斷 Kad 連線。"
 
-#: src/TextClient.cpp:1175
+#: src/TextClient.cpp
 msgid "Add an eD2k or magnet link to core."
 msgstr "加入 eD2k 或 magnet 連結到主程式。"
 
-#: src/TextClient.cpp:1176
+#: src/TextClient.cpp
 msgid ""
 "The eD2k link to be added can be:\n"
 "*) a file link (ed2k://|file|...), it will be added to the download queue,\n"
@@ -7478,51 +7387,51 @@ msgstr ""
 "\n"
 "magnet 連結必須含有 eD2k hash 值與檔案大小資料。\n"
 
-#: src/TextClient.cpp:1184
+#: src/TextClient.cpp
 msgid "Set a preference value."
 msgstr "設定參數值。"
 
-#: src/TextClient.cpp:1188
+#: src/TextClient.cpp
 msgid "Set IP filtering preferences."
 msgstr "設定 IP 過濾參數。"
 
-#: src/TextClient.cpp:1193
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for both clients and servers."
 msgstr "開啓對客戶端和對伺服器 IP 過濾。"
 
-#: src/TextClient.cpp:1198
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for both clients and servers."
 msgstr "關閉對客戶端和對伺服器 IP 過濾。"
 
-#: src/TextClient.cpp:1203
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for clients."
 msgstr "啓用/停用對客戶端 IP 過濾。"
 
-#: src/TextClient.cpp:1208
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for clients."
 msgstr "啟動對客戶端 IP 過濾。"
 
-#: src/TextClient.cpp:1213
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for clients."
 msgstr "停用對客戶端 IP 過濾。"
 
-#: src/TextClient.cpp:1218
+#: src/TextClient.cpp
 msgid "Enable/Disable IP filtering for servers."
 msgstr "啓用/停用對伺服器 IP 過濾。"
 
-#: src/TextClient.cpp:1223
+#: src/TextClient.cpp
 msgid "Turn IP filtering on for servers."
 msgstr "啓動對伺服器 IP 過濾。"
 
-#: src/TextClient.cpp:1228
+#: src/TextClient.cpp
 msgid "Turn IP filtering off for servers."
 msgstr "停用對伺服器 IP 過濾。"
 
-#: src/TextClient.cpp:1233
+#: src/TextClient.cpp
 msgid "Select IP filtering level."
 msgstr "選取 IP 過濾等級。"
 
-#: src/TextClient.cpp:1234
+#: src/TextClient.cpp
 msgid ""
 "Valid filtering levels are in the range 0-255, and it's default (initial)\n"
 "value is 127.\n"
@@ -7530,74 +7439,74 @@ msgstr ""
 "有效的 IP 過濾等級是在 0 到 255 之間，\n"
 "初始預設值是 127。\n"
 
-#: src/TextClient.cpp:1240
+#: src/TextClient.cpp
 msgid "Set bandwidth limits."
 msgstr "設定頻寬限制。"
 
-#: src/TextClient.cpp:1241
+#: src/TextClient.cpp
 msgid "The value given to these commands has to be in kilobytes/sec.\n"
 msgstr "給此指令的的值，單位是 KB/s 。\n"
 
-#: src/TextClient.cpp:1245
+#: src/TextClient.cpp
 msgid "Set upload bandwidth limit."
 msgstr "設定上傳頻寬限制。"
 
-#: src/TextClient.cpp:1246 src/TextClient.cpp:1251
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "給此指令的的值，單位是 KB/s 。\n"
 
-#: src/TextClient.cpp:1250
+#: src/TextClient.cpp
 msgid "Set download bandwidth limit."
 msgstr "設定下載頻寬限制。"
 
-#: src/TextClient.cpp:1255
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Enable or disable endgame source rotation."
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/TextClient.cpp:1256
+#: src/TextClient.cpp
 #, fuzzy
 msgid "The given value must be 1/ON (enable) or 0/OFF (disable).\n"
 msgstr "給此指令的的值，單位是 KB/s 。\n"
 
-#: src/TextClient.cpp:1261
+#: src/TextClient.cpp
 msgid "Get and display a preference value."
 msgstr "取得並顯示偏好設定值。"
 
-#: src/TextClient.cpp:1267
+#: src/TextClient.cpp
 msgid "Get IP filtering preferences."
 msgstr "取得 IP 過濾設定。"
 
-#: src/TextClient.cpp:1272
+#: src/TextClient.cpp
 msgid "Get IP filtering state for both clients and servers."
 msgstr "取得對客戶端和伺服器的 IP 過濾狀態。"
 
-#: src/TextClient.cpp:1277
+#: src/TextClient.cpp
 msgid "Get IP filtering state for clients only."
 msgstr "只取得對客戶端的 IP 過濾狀態。"
 
-#: src/TextClient.cpp:1282
+#: src/TextClient.cpp
 msgid "Get IP filtering state for servers only."
 msgstr "只取得對伺服器的 IP 過濾狀態。"
 
-#: src/TextClient.cpp:1287
+#: src/TextClient.cpp
 msgid "Get IP filtering level."
 msgstr "取得 IP 過濾等級。"
 
-#: src/TextClient.cpp:1292
+#: src/TextClient.cpp
 msgid "Get bandwidth limits."
 msgstr "取得頻寬限制。"
 
-#: src/TextClient.cpp:1295
+#: src/TextClient.cpp
 msgid "Get endgame source rotation state."
 msgstr ""
 
-#: src/TextClient.cpp:1301
+#: src/TextClient.cpp
 msgid "Execute a search."
 msgstr "執行搜尋。"
 
-#: src/TextClient.cpp:1302
+#: src/TextClient.cpp
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
@@ -7616,44 +7525,44 @@ msgid ""
 "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1320
+#: src/TextClient.cpp
 msgid "Execute a global search."
 msgstr "執行全球搜尋。"
 
-#: src/TextClient.cpp:1324
+#: src/TextClient.cpp
 msgid "Execute a local search"
 msgstr "執行本地搜尋"
 
-#: src/TextClient.cpp:1325
+#: src/TextClient.cpp
 msgid "Execute a kad search"
 msgstr "執行 Kad 搜尋"
 
-#: src/TextClient.cpp:1329
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show the results of a search."
 msgstr "顯示上一次的搜尋結果。"
 
-#: src/TextClient.cpp:1330
+#: src/TextClient.cpp
 msgid ""
 "Return the results of a search.\n"
 "Optionally takes a search id (from 'search ...'); with no id, returns the results of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1337
+#: src/TextClient.cpp
 msgid "Show the progress of a search."
 msgstr "顯示搜尋進度。"
 
-#: src/TextClient.cpp:1338
+#: src/TextClient.cpp
 msgid ""
 "Show the progress of a search.\n"
 "Optionally takes a search id; with no id, shows the progress of the most recently started search.\n"
 msgstr ""
 
-#: src/TextClient.cpp:1345
+#: src/TextClient.cpp
 msgid "Start downloading a file"
 msgstr "開始下載檔案"
 
-#: src/TextClient.cpp:1347
+#: src/TextClient.cpp
 msgid ""
 "The number of a file from the last search has to be given.\n"
 "Example: 'download 12' will start to download the file with the number 12 of the previous search.\n"
@@ -7661,81 +7570,81 @@ msgstr ""
 "必須指定檔案在過去搜尋中的編號。\n"
 "例如：「 download 12 」將會下載過去搜尋結果中編號 12 號的檔案。\n"
 
-#: src/TextClient.cpp:1355
+#: src/TextClient.cpp
 msgid "Pause download."
 msgstr "暫停下載。"
 
-#: src/TextClient.cpp:1357
+#: src/TextClient.cpp
 msgid "Resume download."
 msgstr "繼續下載。"
 
-#: src/TextClient.cpp:1359
+#: src/TextClient.cpp
 msgid "Cancel download."
 msgstr "取消下載。"
 
-#: src/TextClient.cpp:1363
+#: src/TextClient.cpp
 msgid "Set download priority."
 msgstr "設定下載優先等級。"
 
-#: src/TextClient.cpp:1364
+#: src/TextClient.cpp
 msgid "Set priority of a download to Low, Normal, High or Auto.\n"
 msgstr "設定下載優先等級爲：低、普通、高或自動。\n"
 
-#: src/TextClient.cpp:1367
+#: src/TextClient.cpp
 msgid "Set priority to low."
 msgstr "設爲低優先等級。"
 
-#: src/TextClient.cpp:1370
+#: src/TextClient.cpp
 msgid "Set priority to normal."
 msgstr "設爲普通優先等級。"
 
-#: src/TextClient.cpp:1374
+#: src/TextClient.cpp
 msgid "Set priority to high."
 msgstr "設爲高優先等級。"
 
-#: src/TextClient.cpp:1376
+#: src/TextClient.cpp
 msgid "Set priority to auto."
 msgstr "設爲自動優先等級。"
 
-#: src/TextClient.cpp:1380
+#: src/TextClient.cpp
 msgid "Show queues/lists."
 msgstr "顯示等候區/清單。"
 
-#: src/TextClient.cpp:1381
+#: src/TextClient.cpp
 msgid "Show upload/download queue, server list or shared files list.\n"
 msgstr "顯示上傳/下載等候區、伺服器清單或分享檔案清單。\n"
 
-#: src/TextClient.cpp:1383
+#: src/TextClient.cpp
 msgid "Show upload queue."
 msgstr "顯示上傳等候區。"
 
-#: src/TextClient.cpp:1384
+#: src/TextClient.cpp
 msgid "Show download queue."
 msgstr "顯示下載等候區。"
 
-#: src/TextClient.cpp:1385
+#: src/TextClient.cpp
 msgid "Show log."
 msgstr "顯示記錄。"
 
-#: src/TextClient.cpp:1387
+#: src/TextClient.cpp
 msgid "Show servers list."
 msgstr "顯示伺服器清單。"
 
-#: src/TextClient.cpp:1389
+#: src/TextClient.cpp
 #, fuzzy
 msgid "Show shared files list."
 msgstr "重新載入分享檔案清單。"
 
-#: src/TextClient.cpp:1391
+#: src/TextClient.cpp
 msgid "Reset log."
 msgstr "清除記錄。"
 
-#: src/TextClient.cpp:1400
+#: src/TextClient.cpp
 #, c-format
 msgid "Deprecated command, use '%s' instead."
 msgstr "已停用的指令，請改用「 %s 」。"
 
-#: src/TextClient.cpp:1401
+#: src/TextClient.cpp
 #, c-format
 msgid ""
 "This is a deprecated command, and may be removed in the future.\n"
@@ -7744,261 +7653,258 @@ msgstr ""
 "這是一個已停用的指令，將來可能被刪除，\n"
 "請改用「 %s 」。\n"
 
-#: src/TextClient.h:62
+#: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule 文字模式客戶端"
 
-#: src/ThreadTasks.cpp:484
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "將 %s 的舊 AICH hash 值組轉換為 %s 的 64b 格式。"
 
-#: src/ThreadTasks.cpp:532
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): Result OK for %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:564
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Verify Local Data (%s): ERRORS FOUND! %s Failed blocks: MD4: %s. %s %s"
 msgstr ""
 
-#: src/ThreadTasks.cpp:759
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr "警告：檔名 %s 無效，已重新命名爲 %s 。"
 
-#: src/ThreadTasks.cpp:772
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr "警告：檔案 %s 已經存在，新檔案重新命名爲 %s 。"
 
-#: src/TransferWnd.cpp:207
+#: src/TransferWnd.cpp
 msgid "Are you sure you wish to cancel and delete all files in this category?"
 msgstr "您確定要移除此分類中的所有檔案嗎？"
 
-#: src/TransferWnd.cpp:208
+#: src/TransferWnd.cpp
 msgid "Confirmation Required"
 msgstr "需要確認"
 
-#: src/TransferWnd.cpp:245
+#: src/TransferWnd.cpp
 msgid "Only 99 categories are supported."
 msgstr "最多只支援 99 個分類。"
 
-#: src/TransferWnd.cpp:246
+#: src/TransferWnd.cpp
 msgid "Too many categories!"
 msgstr "分類數過多！"
 
-#: src/TransferWnd.cpp:344
+#: src/TransferWnd.cpp
 msgid "All others"
 msgstr "其它"
 
-#: src/TransferWnd.cpp:366
+#: src/TransferWnd.cpp
 msgid "Select view filter"
 msgstr "選取顯示過濾"
 
-#: src/TransferWnd.cpp:369
+#: src/TransferWnd.cpp
 msgid "Add category"
 msgstr "加入分類"
 
-#: src/TransferWnd.cpp:372
+#: src/TransferWnd.cpp
 msgid "Edit category"
 msgstr "編輯分類"
 
-#: src/TransferWnd.cpp:373
+#: src/TransferWnd.cpp
 msgid "Remove category"
 msgstr "移除分類"
 
-#: src/UploadClient.cpp:545
+#: src/UploadClient.cpp
 #, c-format
 msgid "Hashset requested for unknown file: %s"
 msgstr "要求不明檔案 %s 的 hash 值組"
 
-#: src/UploadQueue.cpp:627
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Resuming uploads of file: %s"
 msgstr "繼續上傳檔案：%s"
 
-#: src/UploadQueue.cpp:643
+#: src/UploadQueue.cpp
 #, c-format
 msgid "Suspending upload of file: %s"
 msgstr "暫停上傳檔案：%s"
 
-#: src/UserEvents.cpp:159
+#: src/UserEvents.cpp
 #, c-format
 msgid "Failed to execute command `%s' on `%s' event."
 msgstr "無法執行指令「 %s 」(事件：%s )。"
 
-#: src/UserEvents.h:60
+#: src/UserEvents.h
 msgid "Download completed"
 msgstr "下載完畢"
 
-#: src/UserEvents.h:62 src/UserEvents.h:91
+#: src/UserEvents.h
 msgid "The full path to the file."
 msgstr "檔案的完整路徑。"
 
-#: src/UserEvents.h:66
+#: src/UserEvents.h
 msgid "The name of the file without path component."
 msgstr "不包含路徑的檔名。"
 
-#: src/UserEvents.h:69
+#: src/UserEvents.h
 msgid "The eD2k hash of the file."
 msgstr "這個檔案的 eD2k hash 值。"
 
-#: src/UserEvents.h:72
+#: src/UserEvents.h
 msgid "The size of the file in bytes."
 msgstr "檔案大小 (B)。"
 
-#: src/UserEvents.h:76
+#: src/UserEvents.h
 msgid "Cumulative download activity time."
 msgstr "累計實際下載時間。"
 
-#: src/UserEvents.h:80
+#: src/UserEvents.h
 msgid "New chat session started"
 msgstr "已開始新的交談"
 
-#: src/UserEvents.h:82
+#: src/UserEvents.h
 msgid "Message sender."
 msgstr "訊息傳送者。"
 
-#: src/UserEvents.h:84
+#: src/UserEvents.h
 msgid "Out of space"
 msgstr "空間不足"
 
-#: src/UserEvents.h:86
+#: src/UserEvents.h
 msgid "Disk partition."
 msgstr "磁碟分割區。"
 
-#: src/UserEvents.h:89
+#: src/UserEvents.h
 msgid "Error on completion"
 msgstr "有錯誤發生於完成"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:55
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, c-format
 msgid "Processing file number %u: %s"
 msgstr "a正在處理檔案編號 %u：%s "
 
-#: src/utils/aLinkCreator/src/alcc.cpp:58
+#: src/utils/aLinkCreator/src/alcc.cpp
 msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "您已要求暫存檔 hash 值 (只用於超過 9.5 MB 的檔案)"
 
-#: src/utils/aLinkCreator/src/alcc.cpp:72
+#: src/utils/aLinkCreator/src/alcc.cpp
 #, fuzzy, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> 檔案不存在！\n"
 
-#: src/utils/aLinkCreator/src/alc.cpp:48
+#: src/utils/aLinkCreator/src/alc.cpp
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr "aLinkCreator, 用以建立 aMule eD2k 連結"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:78
-#: src/utils/wxCas/src/wxcasframe.cpp:91
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasframe.cpp
 msgid "Welcome!"
 msgstr "歡迎！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:97
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Input parameters"
 msgstr "輸入參數"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:108
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "File to Hash"
 msgstr "須計算 hash 值的檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:112
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add Optional URLs for this file"
 msgstr "加入附加網址到這個檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:119
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the file you want to compute the eD2k link"
 msgstr "輸入您想要求得 eD2k 連結的檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:122
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Enter here the URL you want to add to the eD2k link: Add / at the end to let aLinkCreator append the current file name"
 msgstr "輸入您想要加入 eD2k 連結的網址：請在最後加上 '/' 以利 aLinkCreator 程式幫您輸入檔名"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:149
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Create link with part-hashes"
 msgstr "以暫存檔 hash 值建立連結"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:154
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Help to spread new and rare files faster, at the cost of an increased link size"
 msgstr "協助新檔案和稀有檔案更快散播，只是會增加連結長度"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:180
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "MD4 File Hash"
 msgstr "MD4 檔案 hash 值"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:192
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k File Hash"
 msgstr "eD2k 檔案 hash 值"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:203
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "eD2k link"
 msgstr "eD2k 連結"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:220
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save"
 msgstr "儲存"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:221
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy to clipboard"
 msgstr "複製到剪貼簿"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:245
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open"
 msgstr "開啟"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:247
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Open a file to compute its eD2k link"
 msgstr "開啟要求得 eD2k 連結的檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:252
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy computed eD2k link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:255
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save as"
 msgstr "另存為"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:257
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Save computed eD2k link to file"
 msgstr "儲存 eD2k 連結到檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:262
-#: src/utils/aLinkCreator/src/alcframe.cpp:442
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "About aLinkCreator"
 msgstr "關於 aLinkCreator"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:349
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file you want to compute the eD2k link"
 msgstr "選取要求得 eD2k 連結的檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:381
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Can't open the clipboard"
 msgstr "無法開啟剪貼簿"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:388
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to copy for now !"
 msgstr "沒有東西可複製！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:410
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Select the file to your computed eD2k link"
 msgstr "選取已求得 eD2k 連結的檔案"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:423
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Unable to open "
 msgstr "無法開啟"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:428
-#: src/utils/aLinkCreator/src/alcframe.cpp:550
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty file name"
 msgstr "請輸入一個非空白的檔名"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:431
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Nothing to save for now !"
 msgstr "沒有東西可儲存！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:438
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid ""
 "aLinkCreator, the aMule eD2k link creator\n"
 "\n"
@@ -8018,167 +7924,159 @@ msgstr ""
 "\n"
 "依據 GPL 授權散佈"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:481
-#: src/utils/aLinkCreator/src/alcframe.cpp:482
-#: src/utils/aLinkCreator/src/alcframe.cpp:491
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Hashing..."
 msgstr "正在計算 hash 值..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:486
-#: src/utils/aLinkCreator/src/alcframe.cpp:504
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "aLinkCreator is working for you"
 msgstr "aLinkCreator 正為您運作中"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:487
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing MD4 Hash..."
 msgstr "計算 MD4 hash 值中..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:505
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Computing eD2k Hashes..."
 msgstr "計算 eD2k hash 值中..."
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:538
-#: src/utils/aLinkCreator/src/alcframe.cpp:539
-#: src/utils/aLinkCreator/src/md4.cpp:333
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/aLinkCreator/src/md4.cpp
 msgid "Cancelled !"
 msgstr "已取消！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:547
+#: src/utils/aLinkCreator/src/alcframe.cpp
 #, c-format
 msgid "Done in %.2f s"
 msgstr "在 %.2f 秒內完成"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:574
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "You have already added this URL !"
 msgstr "您已經加入這個網址了！"
 
-#: src/utils/aLinkCreator/src/alcframe.cpp:577
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Please, enter a non empty URL"
 msgstr "請輸入一個非空白的網址"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:55
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 #, c-format
 msgid "Unable to open %s"
 msgstr "無法開啟 %s"
 
-#: src/utils/aLinkCreator/src/ed2khash.cpp:138
+#: src/utils/aLinkCreator/src/ed2khash.cpp
 msgid "Out of memory while calculating ed2k hash!"
 msgstr ""
 
-#: src/utils/wxCas/src/linuxmon.cpp:71
+#: src/utils/wxCas/src/linuxmon.cpp
 #, c-format
 msgid "%i day(s) %i hour(s) %i min %i s"
 msgstr "%i 天 %i 小時 %i 分鐘 %i 秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:211
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uD %02uh %02umin %02us"
 msgstr "%02u天 %02u小時 %02u分鐘 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:213
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02uh %02umin %02us"
 msgstr "%02u小時 %02u分鐘 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:215
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02umin %02us"
 msgstr "%02u分鐘 %02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:217
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%02us"
 msgstr "%02u秒"
 
-#: src/utils/wxCas/src/onlinesig.cpp:312
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.0f B"
 msgstr "%.0f B"
 
-#: src/utils/wxCas/src/onlinesig.cpp:315
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f KB"
 msgstr "%.2f KB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:318
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f MB"
 msgstr "%.2f MB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:321
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f GB"
 msgstr "%.2f GB"
 
-#: src/utils/wxCas/src/onlinesig.cpp:324
+#: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
 msgid "%.2f TB"
 msgstr "%.2f TB"
 
-#: src/utils/wxCas/src/wxcas.cpp:76
+#: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
 msgstr "wxCas, aMule 線上統計"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:115
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Maximum DL rate since wxCas is running"
 msgstr "本次 wxCas 執行後最大下載速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:120
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Absolute Maximum DL rate during wxCas previous runs"
 msgstr "過去執行 wxCas 時最大下載速度"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:133
-#: src/utils/wxCas/src/wxcasframe.cpp:136
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Reset"
 msgstr "清除"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:141
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System"
 msgstr "系統"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:202
-#: src/utils/wxCas/src/wxcasframe.cpp:321
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Stop Auto Refresh"
 msgstr "停止自動更新顯示"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:206
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Online Statistics image"
 msgstr "儲存線上統計圖表"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:208
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Print Online Statistics image"
 msgstr "列印線上統計圖表"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:210
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Preferences setting"
 msgstr "偏好設定"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:214
-#: src/utils/wxCas/src/wxcasframe.cpp:394
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "About wxCas"
 msgstr "關於 wxCas"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:308
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Start Auto Refresh"
 msgstr "開始自動更新顯示"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:310
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh stopped"
 msgstr "自動更新顯示已停止"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:323
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Auto Refresh started"
 msgstr "已開始自動更新顯示"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:333
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Save Statistics Image"
 msgstr "儲存統計圖表"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:370
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule Online Statistics"
 msgstr "aMule 線上統計"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:373
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "There was a problem printing.\n"
 "Perhaps your current printer is not set correctly?"
@@ -8186,11 +8084,11 @@ msgstr ""
 "列印時發生問題。\n"
 "可能是您的印表機沒有設定正確？"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:375
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Printing"
 msgstr "正在列印"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:391
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ""
 "wxCas, aMule OnLine Signature Statistics\n"
 "\n"
@@ -8208,403 +8106,392 @@ msgstr ""
 "\n"
 "依據 GPL 授權散佈"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:541
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule is not running..."
 msgstr "aMule 未執行..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:618
-#: src/utils/wxCas/src/wxcasframe.cpp:689
-#: src/utils/wxCas/src/wxcasframe.cpp:757
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running"
 msgstr "aMule 正在執行"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:827
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is running, but disconnected"
 msgstr "aMule 正在執行，但是已中斷連線"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:898
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule is connecting..."
 msgstr "aMule 正在連線..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:902
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Oh Oh, aMule status is unknown..."
 msgstr "aMule 狀態不明..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
-#: src/utils/wxCas/src/wxcasframe.cpp:973
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:977
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "aMule "
 msgstr "aMule "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:970
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " has been running for "
 msgstr " 已執行"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:973
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is stopped !"
 msgstr " 已停止！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:975
-#: src/utils/wxCas/src/wxcasframe.cpp:994
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is not connected !"
 msgstr "未連線！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:977
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connecting..."
 msgstr " 正在連線..."
 
-#: src/utils/wxCas/src/wxcasframe.cpp:980
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is doing something strange, check it !"
 msgstr " 狀態不正常，請檢查！"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is connected to "
 msgstr " 已連線到"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:998
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " Kad: "
 msgstr " Kad："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1004
-#: src/utils/wxCas/src/wxcasframe.cpp:1016
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "off"
 msgstr "關閉"
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1008
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " is on "
 msgstr " 是在 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1010
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " with "
 msgstr " 和 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Total Download: "
 msgstr "總下載："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1024
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid ", Upload: "
 msgstr "，上傳："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1032
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Session Download: "
 msgstr "本次下載："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Download: "
 msgstr "下載："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1040
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " kB/s, Upload: "
 msgstr " KB/s，上傳："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
 msgstr "分享： "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1048
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " file(s), Clients on queue: "
 msgstr " 個檔案、等候區人數："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1057
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Time: "
 msgstr "時間："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1064
-#: src/utils/wxCas/src/wxcasframe.cpp:1072
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid " on "
 msgstr " 在 "
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1081
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System Load Average (1-5-15 min): "
 msgstr "系統平均負載 (1-5-15 分鐘)："
 
-#: src/utils/wxCas/src/wxcasframe.cpp:1089
+#: src/utils/wxCas/src/wxcasframe.cpp
 msgid "System uptime: "
 msgstr "系統執行時間："
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:48
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Directory containing amulesig.dat file"
 msgstr "amulesig.dat 檔案所在的目錄"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:64
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where your amulesig.dat file is"
 msgstr "請輸入 amulesig.dat 所在的目錄"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:81
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Refresh rate interval in seconds"
 msgstr "更新顯示間隔 (秒)"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:95
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Generate a stat image at every refresh event"
 msgstr "每次更新顯示時都產生統計圖"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:116
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "輸入存放製成的統計圖的目錄"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp
 #, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "定期上傳統計圖到 FTP 伺服器"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:143
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Url"
 msgstr "FTP 網址"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:146
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP Path"
 msgstr "FTP 路徑"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:151
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the URL of your FTP server"
 msgstr "輸入 FTP 伺服器的網址"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:159
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the directory where putting your stat image on FTP server"
 msgstr "輸入 FTP 伺服器上存放統計圖的目錄"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:164
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "User"
 msgstr "使用者"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:173
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User name to log into your FTP server"
 msgstr "輸入登入 FTP 伺服器的使用者名稱"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:180
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Enter here the User password to log into your FTP server"
 msgstr "輸入登入 FTP 伺服器的密碼"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:196
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "FTP update rate interval in minutes"
 msgstr "FTP 上傳間隔 (分鐘)"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:234
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Validate"
 msgstr "檢測"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:265
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder containing your signature file"
 msgstr "簽名識別檔所在資料夾"
 
-#: src/utils/wxCas/src/wxcasprefs.cpp:278
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Folder where generating the statistic image"
 msgstr "統計圖存放資料夾"
 
-#: src/webserver/src/WebInterface.cpp:234
+#: src/webserver/src/WebInterface.cpp
 msgid "Loads template <str>"
 msgstr "載入模板 <str>"
 
-#: src/webserver/src/WebInterface.cpp:238
+#: src/webserver/src/WebInterface.cpp
 msgid "Web server HTTP port"
 msgstr "網站伺服器 HTTP 埠"
 
-#: src/webserver/src/WebInterface.cpp:244
+#: src/webserver/src/WebInterface.cpp
 msgid "Use UPnP port forwarding on web server port"
 msgstr "網站伺服器通訊埠使用 UPnP 通訊埠轉向"
 
-#: src/webserver/src/WebInterface.cpp:248
+#: src/webserver/src/WebInterface.cpp
 msgid "UPnP port"
 msgstr "UPnP 埠"
 
-#: src/webserver/src/WebInterface.cpp:250
+#: src/webserver/src/WebInterface.cpp
 msgid "Use gzip compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/webserver/src/WebInterface.cpp:257
+#: src/webserver/src/WebInterface.cpp
 msgid "Full access password for web server"
 msgstr "網站伺服器的 完整存取密碼"
 
-#: src/webserver/src/WebInterface.cpp:263
+#: src/webserver/src/WebInterface.cpp
 msgid "Guest password for web server"
 msgstr "網站伺服器的 訪客密碼"
 
-#: src/webserver/src/WebInterface.cpp:267
+#: src/webserver/src/WebInterface.cpp
 msgid "Allow guest access"
 msgstr "允許訪客連線"
 
-#: src/webserver/src/WebInterface.cpp:269
+#: src/webserver/src/WebInterface.cpp
 msgid "Deny guest access"
 msgstr "拒絕訪客連線"
 
-#: src/webserver/src/WebInterface.cpp:273
+#: src/webserver/src/WebInterface.cpp
 msgid "Load/save web server settings from/to remote aMule"
 msgstr "載入/儲存 遠端 aMule 的網站伺服器設定 "
 
-#: src/webserver/src/WebInterface.cpp:278
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule config file path. DO NOT USE DIRECTLY!"
 msgstr "aMule 設定檔路徑。請勿直接使用！"
 
-#: src/webserver/src/WebInterface.cpp:287
+#: src/webserver/src/WebInterface.cpp
 msgid "Disable PHP interpreter (deprecated)"
 msgstr "停用 PHP 解譯器（不建議）"
 
-#: src/webserver/src/WebInterface.cpp:294
+#: src/webserver/src/WebInterface.cpp
 msgid "Recompile PHP pages on each request"
 msgstr "爲每個要求重編譯 PHP 頁面"
 
-#: src/webserver/src/WebInterface.cpp:400
+#: src/webserver/src/WebInterface.cpp
 msgid "aMule Web Server"
 msgstr "aMule 網站伺服器"
 
-#: src/webserver/src/WebServer.cpp:348
+#: src/webserver/src/WebServer.cpp
 msgid "web client connection accepted\n"
 msgstr "已接受網頁客戶端連線\n"
 
-#: src/webserver/src/WebServer.cpp:351
+#: src/webserver/src/WebServer.cpp
 msgid "ERROR: cannot accept web client connection\n"
 msgstr "錯誤：無法接受網頁客戶端連線\n"
 
-#: src/webserver/src/WebServer.cpp:397
+#: src/webserver/src/WebServer.cpp
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr "要求失敗，錯誤爲：%s 。"
 
-#: src/webserver/src/WebServer.cpp:1841
+#: src/webserver/src/WebServer.cpp
 msgid "Index file not found: "
 msgstr "找不到索引檔："
 
-#: src/webserver/src/WebServer.cpp:1927
+#: src/webserver/src/WebServer.cpp
 msgid "Session expired - requesting login\n"
 msgstr "作業階段過期 - 正在要求登入\n"
 
-#: src/webserver/src/WebServer.cpp:1932
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, logged in\n"
 msgstr "作業階段正常，已登入\n"
 
-#: src/webserver/src/WebServer.cpp:1934
+#: src/webserver/src/WebServer.cpp
 msgid "Session ok, not logged in\n"
 msgstr "作業階段正常，未登入\n"
 
-#: src/webserver/src/WebServer.cpp:1939
+#: src/webserver/src/WebServer.cpp
 msgid "No session opened - will request login\n"
 msgstr "未開啟作業階段 - 將要求登入\n"
 
-#: src/webserver/src/WebServer.cpp:1965
+#: src/webserver/src/WebServer.cpp
 msgid "Session created - requesting login\n"
 msgstr "作業階段已建立 - 正在要求登入\n"
 
-#: src/webserver/src/WebServer.cpp:1979
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [original]: "
 msgstr "正在處理要求 [原始]："
 
-#: src/webserver/src/WebServer.cpp:2008
+#: src/webserver/src/WebServer.cpp
 msgid "Refusing to read `pass` from URL query string\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:2014
+#: src/webserver/src/WebServer.cpp
 msgid "No password specified, login will not be allowed."
 msgstr "未輸入密碼，不允許登入。"
 
-#: src/webserver/src/WebServer.cpp:2016
+#: src/webserver/src/WebServer.cpp
 msgid "Checking password\n"
 msgstr "正在檢查密碼\n"
 
-#: src/webserver/src/WebServer.cpp:2021
+#: src/webserver/src/WebServer.cpp
 msgid "Password hash invalid\n"
 msgstr "密碼 hash 值無效\n"
 
-#: src/webserver/src/WebServer.cpp:2037
+#: src/webserver/src/WebServer.cpp
 msgid "Password ok\n"
 msgstr "密碼正確\n"
 
-#: src/webserver/src/WebServer.cpp:2039
+#: src/webserver/src/WebServer.cpp
 msgid "Password bad\n"
 msgstr "密碼錯誤\n"
 
-#: src/webserver/src/WebServer.cpp:2042
+#: src/webserver/src/WebServer.cpp
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr "您沒有輸入密碼，密碼不允許空白。\n"
 
-#: src/webserver/src/WebServer.cpp:2050
+#: src/webserver/src/WebServer.cpp
 msgid "Logout requested\n"
 msgstr "已要求登出\n"
 
-#: src/webserver/src/WebServer.cpp:2055
+#: src/webserver/src/WebServer.cpp
 msgid "Processing request [redirected]: "
 msgstr "正在處理 [已重定向] 的要求："
 
-#: packaging/windows/installer_strings.c:36
+#: packaging/windows/installer_strings.c
 msgid "aMule (required)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:37
+#: packaging/windows/installer_strings.c
 msgid "Desktop shortcut"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:38
+#: packaging/windows/installer_strings.c
 msgid "Start aMule when I log in"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:41
+#: packaging/windows/installer_strings.c
 msgid "Associate .emulecollection files"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:42
+#: packaging/windows/installer_strings.c
 msgid "Uninstall"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:43
+#: packaging/windows/installer_strings.c
 msgid "Remove user data (config, ED2K servers, Kad nodes, partfiles)"
 msgstr ""
 
-#: packaging/windows/installer_strings.c:46
+#: packaging/windows/installer_strings.c
 #, fuzzy
 msgid "aMule application files (required)."
 msgstr "無法連線 "
 
-#: packaging/windows/installer_strings.c:47
+#: packaging/windows/installer_strings.c
 msgid "Place an aMule shortcut on the desktop."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:48
+#: packaging/windows/installer_strings.c
 msgid "Launch aMule automatically when the current user logs in (per-user setting)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:51
+#: packaging/windows/installer_strings.c
 msgid "Adds aMule to the \"Open with\" list for .emulecollection files, and makes it the default if no other program has claimed them. Opening a collection queues every eD2k link it contains."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:52
+#: packaging/windows/installer_strings.c
 msgid "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, URL scheme registrations, and Add/Remove Programs entry (required)."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:53
+#: packaging/windows/installer_strings.c
 msgid "Permanently delete %APPDATA%\\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:59
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule appears to be running from $INSTDIR.\r\n"
 "Please close aMule (and aMuleD / aMuleGUI) and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:60
+#: packaging/windows/installer_strings.c
 msgid ""
 "aMule daemon (amuled.exe) appears to be running from $INSTDIR.\r\n"
 "Please stop it and try again."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:61
+#: packaging/windows/installer_strings.c
 msgid "Removing previous aMule installation at $0..."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:62
+#: packaging/windows/installer_strings.c
 msgid ""
 "Could not remove the previous aMule installation at $0.\r\n"
 "Please close any running aMule processes and try again, or uninstall the previous version manually first."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:63
+#: packaging/windows/installer_strings.c
 msgid "aMule appears to be running. Please close it and re-run the uninstaller."
 msgstr ""
 
-#: packaging/windows/installer_strings.c:64
+#: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 

--- a/scripts/update-manpages-po.sh
+++ b/scripts/update-manpages-po.sh
@@ -95,7 +95,12 @@ echo "Updating po/manpages.pot and merging into po/manpages-*.po ..."
 # --no-translations: skip rendering of *.{lang}.1.in -- those are built
 # from CMake at build time, not from this script.
 # --force: regenerate the .pot even when po4a thinks it's up to date.
-po4a --no-translations --force "${TMP_CONFIG}"
+# --porefs file: record "#: amule.1.in" rather than "#: amule.1.in:42", the
+# po4a counterpart of update-po.sh's --add-location=file. Manpage sources
+# reflow constantly, so line-numbered references made every edit rewrite the
+# reference block of every manpage catalog; the file name is the part that
+# carries context for translators.
+po4a --no-translations --force --porefs file "${TMP_CONFIG}"
 die 31 "po4a failed"
 
 echo "Done."

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -66,8 +66,19 @@ echo "Extracting translatable strings into po/amule.pot ..."
 # wrapping. Keeps Weblate / msgmerge / hand-regen diffs to real content
 # changes instead of reflow noise. Weblate's "application" component is
 # configured to match.
+#
+# --add-location=file: emit "#: src/amuleDlg.cpp" instead of
+# "#: src/amuleDlg.cpp:1234". A line number shifts whenever anything above a
+# string is edited, so with full locations every catalog rewrote its entire
+# reference block on every regen -- the overwhelming bulk of a catalog diff
+# was renumbering rather than content, and any two PRs in flight conflicted
+# on it. File names rarely move, so translators keep the "where is this
+# string used" context Weblate shows while the churn goes away. msgmerge
+# below needs the same flag, otherwise it re-expands locations to full
+# file:line when merging the pot into each .po.
 xgettext \
 	--no-wrap \
+	--add-location=file \
 	--keyword=_ \
 	--keyword=wxTRANSLATE \
 	--keyword=wxPLURAL:1,2 \
@@ -103,7 +114,7 @@ echo "Merging po/amule.pot into each .po file ..."
 # any .po that was previously committed in wrapped form.
 for PO_FILE in po/*.po; do
 	echo "  $PO_FILE"
-	msgmerge --no-wrap "$PO_FILE" po/amule.pot --output-file="$PO_FILE.tmp"
+	msgmerge --no-wrap --add-location=file "$PO_FILE" po/amule.pot --output-file="$PO_FILE.tmp"
 	die 31 "msgmerge failed for $PO_FILE"
 	mv "$PO_FILE.tmp" "$PO_FILE"
 	die 31 "failed to install merged $PO_FILE"


### PR DESCRIPTION
## Why

Every catalog entry carries a `#: src/foo.cpp:1234` reference. A line number shifts whenever anything above a string is edited, so on each regen all 41 catalogs rewrite their entire reference block.

Measured on #663: the `po/` diff was **~27,000 lines, of which 25,174 were `#:` renumbering** — against **4 msgids** of genuine content change (three tooltips from the removed toolbar button, plus `"Disconnect Kad"`). It also means any two PRs in flight conflict in `po/` regardless of what they actually touch — #642, #643, #662, #663 and #664 all hit it.

## What

- `scripts/update-po.sh`: `--add-location=file` on **both** `xgettext` and `msgmerge`. The flag is needed on `msgmerge` too — without it, merging the pot back into each `.po` re-expands references to full `file:line`.
- `scripts/update-manpages-po.sh`: the po4a counterpart, `--porefs file`.

References become `#: src/amuleDlg.cpp`. Translators keep the "where is this string used" context Weblate shows (and repo-browser links still resolve, at file granularity); the renumbering churn goes away.

## Scope

**Scripts only** — no catalogs in this PR. They still hold `file:line` references and will pick up the new format the next time they are regenerated, so this does not collide with anything in flight.

## Verification

- Ran both scripts locally: locations collapse to file names, **zero** `file:line` references remain, and the msgid set is **byte-identical** to master (locations only, no content change).
- Simulated the "App catalogs in sync with source" gate with the catalogs reverted: it **passes**, since the check strips `#: ` lines on both sides before diffing.

## Before this merges

Weblate writes `.po` files back when translators submit, so its component output setting must match (as it already does for `--no-wrap`) — otherwise it re-adds line numbers and we oscillate. Holding as a draft until that is configured.
